### PR TITLE
feat(ci): add release workflow and git-flow model

### DIFF
--- a/.github/GIT-FLOW.md
+++ b/.github/GIT-FLOW.md
@@ -1,0 +1,137 @@
+# Git-Flow Branching Model
+
+This repository follows the **git-flow** branching model for firmware releases.
+
+## Branch Types
+
+| Branch | Purpose | Created from | Merges to |
+|--------|---------|-------------|-----------|
+| `master` | Production releases only. Every commit is tagged. | — | — |
+| `develop` | Integration branch. All features merge here first. | — | — |
+| `feature/*` | New features and improvements | `develop` | `develop` |
+| `release/*` | Release preparation (version bump, final fixes) | `develop` | `master` + `develop` |
+| `hotfix/*` | Critical production fixes | `master` | `master` + `develop` |
+| `fix/*` | Non-critical bug fixes | `develop` | `develop` |
+
+## Workflows
+
+### Feature Development
+
+```bash
+# Start feature
+git checkout develop
+git pull origin develop
+git checkout -b feature/solana-support
+
+# Work, commit, push
+git push -u origin feature/solana-support
+
+# Create PR → develop (CI runs automatically)
+gh pr create --repo BitHighlander/keepkey-firmware --base develop
+```
+
+### Cutting a Release
+
+```bash
+# 1. Branch from develop
+git checkout develop
+git pull origin develop
+git checkout -b release/v7.11.0
+
+# 2. Bump version in CMakeLists.txt
+#    VERSION 7.11.0
+
+# 3. Final fixes only (no new features!)
+git commit -m "chore: bump version to v7.11.0"
+git push -u origin release/v7.11.0
+
+# 4. CI runs on release/* branch — must pass
+
+# 5. When ready: merge to master
+gh pr create --repo BitHighlander/keepkey-firmware --base master \
+  --title "Release v7.11.0"
+
+# 6. After merge to master: tag it
+git checkout master
+git pull origin master
+git tag v7.11.0
+git push origin v7.11.0
+# → Release workflow triggers → builds firmware → creates draft GitHub Release
+
+# 7. Merge release branch back to develop
+git checkout develop
+git merge release/v7.11.0
+git push origin develop
+
+# 8. Delete release branch
+git branch -d release/v7.11.0
+git push origin --delete release/v7.11.0
+```
+
+### Hotfix (Critical Production Fix)
+
+```bash
+# 1. Branch from master
+git checkout master
+git pull origin master
+git checkout -b hotfix/v7.11.1
+
+# 2. Fix + bump patch version
+git commit -m "fix: critical signing bug"
+git commit -m "chore: bump version to v7.11.1"
+
+# 3. PR to master
+gh pr create --repo BitHighlander/keepkey-firmware --base master \
+  --title "Hotfix v7.11.1"
+
+# 4. After merge: tag + merge to develop
+git checkout master && git pull origin master
+git tag v7.11.1
+git push origin v7.11.1
+
+git checkout develop
+git merge hotfix/v7.11.1
+git push origin develop
+```
+
+## CI/CD Pipeline
+
+### On Every Push (ci.yml)
+- **Gate**: lint, secret scan, submodule check
+- **Build**: emulator + ARM firmware (full + BTC-only)
+- **Test**: unit tests + python integration
+
+### On Tag Push `v*` (release.yml)
+- **Validate**: tag matches CMakeLists.txt version
+- **Build**: full + BTC-only firmware with hash manifests
+- **Test**: emulator unit tests
+- **Release**: draft GitHub Release with all artifacts
+
+### After Draft Release
+1. Build on multiple machines, compare hashes
+2. Sign on air-gapped machine (3/5 signers)
+3. Upload signed `.bin` replacing unsigned
+4. Publish release (remove draft status)
+
+## Version Numbering
+
+```
+v7.MINOR.PATCH
+
+MINOR = feature releases (new chain support, protocol changes)
+PATCH = bug fixes, security patches
+```
+
+- `release/*` bumps MINOR (e.g., v7.10.0 → v7.11.0)
+- `hotfix/*` bumps PATCH (e.g., v7.11.0 → v7.11.1)
+
+## Branch Protection (Recommended)
+
+### `master`
+- Require PR reviews (1+)
+- Require CI status checks to pass
+- No direct pushes (except tags)
+
+### `develop`
+- Require CI status checks to pass
+- Allow direct pushes for maintainers (merge commits)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ name: CI
 
 on:
   push:
-    branches: [master, develop, 'feature/**', 'fix/**']
+    branches: [master, develop, 'feature/**', 'fix/**', 'release/**', 'hotfix/**']
   pull_request:
     branches: [master, develop]
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,362 @@
+# KeepKey Firmware Release Pipeline
+#
+# Triggered by version tags (v*) on master.
+# Builds full + BTC-only firmware, computes reproducible hashes,
+# and creates a draft GitHub Release with all artifacts.
+#
+# Git-flow: tag master after merging a release/* or hotfix/* branch.
+#
+# Usage:
+#   git tag v7.11.0
+#   git push origin v7.11.0
+
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  BASE_IMAGE: kktech/firmware:v15
+
+permissions:
+  contents: write
+
+jobs:
+  # ═══════════════════════════════════════════════════════════
+  # VALIDATE — sanity checks before building release artifacts
+  # ═══════════════════════════════════════════════════════════
+
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    outputs:
+      fw_version: ${{ steps.version.outputs.fw_version }}
+      tag_version: ${{ steps.version.outputs.tag_version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Extract and verify version
+        id: version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          FW_VERSION=$(sed -n '/^project/,/)/p' CMakeLists.txt | grep -oP '\d+\.\d+\.\d+')
+          echo "tag_version=${TAG_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "fw_version=${FW_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Tag: v${TAG_VERSION} | CMakeLists: ${FW_VERSION}"
+          if [ "$TAG_VERSION" != "$FW_VERSION" ]; then
+            echo "::error::Tag version (${TAG_VERSION}) does not match CMakeLists.txt (${FW_VERSION})"
+            exit 1
+          fi
+
+      - name: Verify submodules
+        run: |
+          REQUIRED=(
+            "deps/crypto/trezor-firmware"
+            "deps/device-protocol"
+            "deps/python-keepkey"
+            "deps/googletest"
+            "deps/qrenc/QR-Code-generator"
+            "deps/sca-hardening/SecAESSTM32"
+          )
+          for sub in "${REQUIRED[@]}"; do
+            if [ ! -f "$sub/CMakeLists.txt" ] && [ ! -f "$sub/Makefile" ] && [ ! -f "$sub/setup.py" ]; then
+              echo "::error::Submodule not initialized: $sub"
+              exit 1
+            fi
+            echo "  ok $sub"
+          done
+
+  # ═══════════════════════════════════════════════════════════
+  # BUILD — full firmware + BTC-only, both with hash manifests
+  # ═══════════════════════════════════════════════════════════
+
+  build-full:
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Cache base image
+        id: cache-base
+        uses: actions/cache@v4
+        with:
+          path: /tmp/base-image.tar
+          key: base-image-${{ env.BASE_IMAGE }}
+
+      - name: Pull and cache base image
+        if: steps.cache-base.outputs.cache-hit != 'true'
+        run: |
+          docker pull ${{ env.BASE_IMAGE }}
+          docker save ${{ env.BASE_IMAGE }} -o /tmp/base-image.tar
+
+      - name: Load base image from cache
+        if: steps.cache-base.outputs.cache-hit == 'true'
+        run: docker load -i /tmp/base-image.tar
+
+      - name: Cross-compile firmware
+        run: |
+          docker run --rm \
+            -v ${{ github.workspace }}:/root/keepkey-firmware:z \
+            ${{ env.BASE_IMAGE }} /bin/sh -c "\
+              mkdir /root/build && cd /root/build && \
+              cmake -C /root/keepkey-firmware/cmake/caches/device.cmake /root/keepkey-firmware \
+                -DCMAKE_BUILD_TYPE=MinSizeRel \
+                -DCMAKE_COLOR_MAKEFILE=ON && \
+              make && \
+              mkdir -p /root/keepkey-firmware/release && \
+              cp bin/firmware.keepkey.bin /root/keepkey-firmware/release/ && \
+              cp bin/firmware.keepkey.elf /root/keepkey-firmware/release/ && \
+              cp bin/bootloader.bin /root/keepkey-firmware/release/ 2>/dev/null || true && \
+              chmod -R a+rw /root/keepkey-firmware/release"
+
+      - name: Compute hashes
+        working-directory: release
+        run: |
+          echo "# KeepKey Firmware v${{ needs.validate.outputs.fw_version }} — Hash Manifest" > HASHES.txt
+          echo "# Full firmware build" >> HASHES.txt
+          echo "" >> HASHES.txt
+
+          for f in *.bin; do
+            [ -f "$f" ] || continue
+
+            # Full file hash
+            FULL_HASH=$(sha256sum "$f" | awk '{print $1}')
+            echo "sha256 (full)    $f  $FULL_HASH" >> HASHES.txt
+
+            # Payload hash (skip 256-byte KPKY header) — this is what the
+            # device reports and what the manifest uses for verification
+            FILE_SIZE=$(stat -c%s "$f")
+            if [ "$FILE_SIZE" -gt 256 ]; then
+              PAYLOAD_HASH=$(tail -c +257 "$f" | sha256sum | awk '{print $1}')
+              echo "sha256 (payload) $f  $PAYLOAD_HASH" >> HASHES.txt
+            fi
+            echo "" >> HASHES.txt
+          done
+
+          cat HASHES.txt
+
+      - name: Rename artifacts
+        working-directory: release
+        run: |
+          VER="${{ needs.validate.outputs.fw_version }}"
+          [ -f firmware.keepkey.bin ] && mv firmware.keepkey.bin "firmware.keepkey.v${VER}.bin"
+          [ -f firmware.keepkey.elf ] && mv firmware.keepkey.elf "firmware.keepkey.v${VER}.elf"
+          [ -f bootloader.bin ] && mv bootloader.bin "bootloader.v${VER}.bin"
+          ls -lh
+
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-full
+          path: release/*
+          retention-days: 90
+
+  build-btconly:
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Cache base image
+        id: cache-base
+        uses: actions/cache@v4
+        with:
+          path: /tmp/base-image.tar
+          key: base-image-${{ env.BASE_IMAGE }}
+
+      - name: Pull and cache base image
+        if: steps.cache-base.outputs.cache-hit != 'true'
+        run: |
+          docker pull ${{ env.BASE_IMAGE }}
+          docker save ${{ env.BASE_IMAGE }} -o /tmp/base-image.tar
+
+      - name: Load base image from cache
+        if: steps.cache-base.outputs.cache-hit == 'true'
+        run: docker load -i /tmp/base-image.tar
+
+      - name: Cross-compile BTC-only firmware
+        run: |
+          docker run --rm \
+            -v ${{ github.workspace }}:/root/keepkey-firmware:z \
+            ${{ env.BASE_IMAGE }} /bin/sh -c "\
+              mkdir /root/build && cd /root/build && \
+              cmake -C /root/keepkey-firmware/cmake/caches/device.cmake /root/keepkey-firmware \
+                -DCMAKE_BUILD_TYPE=MinSizeRel \
+                -DKK_BITCOIN_ONLY=ON && \
+              make && \
+              mkdir -p /root/keepkey-firmware/release-btconly && \
+              cp bin/firmware.keepkey.bin /root/keepkey-firmware/release-btconly/ && \
+              cp bin/firmware.keepkey.elf /root/keepkey-firmware/release-btconly/ && \
+              chmod -R a+rw /root/keepkey-firmware/release-btconly"
+
+      - name: Compute hashes
+        working-directory: release-btconly
+        run: |
+          echo "# KeepKey Firmware v${{ needs.validate.outputs.fw_version }} — BTC-Only Hash Manifest" > HASHES-btconly.txt
+          echo "" >> HASHES-btconly.txt
+
+          for f in *.bin; do
+            [ -f "$f" ] || continue
+            FULL_HASH=$(sha256sum "$f" | awk '{print $1}')
+            echo "sha256 (full)    $f  $FULL_HASH" >> HASHES-btconly.txt
+            FILE_SIZE=$(stat -c%s "$f")
+            if [ "$FILE_SIZE" -gt 256 ]; then
+              PAYLOAD_HASH=$(tail -c +257 "$f" | sha256sum | awk '{print $1}')
+              echo "sha256 (payload) $f  $PAYLOAD_HASH" >> HASHES-btconly.txt
+            fi
+            echo "" >> HASHES-btconly.txt
+          done
+
+          cat HASHES-btconly.txt
+
+      - name: Rename artifacts
+        working-directory: release-btconly
+        run: |
+          VER="${{ needs.validate.outputs.fw_version }}"
+          [ -f firmware.keepkey.bin ] && mv firmware.keepkey.bin "firmware.keepkey.btconly.v${VER}.bin"
+          [ -f firmware.keepkey.elf ] && mv firmware.keepkey.elf "firmware.keepkey.btconly.v${VER}.elf"
+          ls -lh
+
+      - name: Upload BTC-only artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-btconly
+          path: release-btconly/*
+          retention-days: 90
+
+  # ═══════════════════════════════════════════════════════════
+  # TEST — emulator tests on the tagged commit
+  # ═══════════════════════════════════════════════════════════
+
+  test:
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Cache base image
+        id: cache-base
+        uses: actions/cache@v4
+        with:
+          path: /tmp/base-image.tar
+          key: base-image-${{ env.BASE_IMAGE }}
+
+      - name: Pull and cache base image
+        if: steps.cache-base.outputs.cache-hit != 'true'
+        run: |
+          docker pull ${{ env.BASE_IMAGE }}
+          docker save ${{ env.BASE_IMAGE }} -o /tmp/base-image.tar
+
+      - name: Load base image from cache
+        if: steps.cache-base.outputs.cache-hit == 'true'
+        run: docker load -i /tmp/base-image.tar
+
+      - name: Build emulator
+        run: |
+          docker build \
+            -t kkemu-release \
+            -f scripts/emulator/Dockerfile \
+            .
+
+      - name: Run unit tests
+        run: |
+          docker run --rm \
+            --entrypoint /bin/sh \
+            kkemu-release \
+            -c "make xunit; RC=\$?; exit \$RC"
+
+  # ═══════════════════════════════════════════════════════════
+  # RELEASE — create draft GitHub Release with all artifacts
+  # ═══════════════════════════════════════════════════════════
+
+  create-release:
+    needs: [validate, build-full, build-btconly, test]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download full firmware
+        uses: actions/download-artifact@v4
+        with:
+          name: release-full
+          path: artifacts/full
+
+      - name: Download BTC-only firmware
+        uses: actions/download-artifact@v4
+        with:
+          name: release-btconly
+          path: artifacts/btconly
+
+      - name: Prepare release assets
+        run: |
+          mkdir -p release-assets
+          cp artifacts/full/*.bin artifacts/full/*.elf artifacts/full/HASHES.txt release-assets/
+          cp artifacts/btconly/*.bin artifacts/btconly/*.elf artifacts/btconly/HASHES-btconly.txt release-assets/
+          ls -lh release-assets/
+
+      - name: Generate release body
+        id: body
+        run: |
+          VER="${{ needs.validate.outputs.fw_version }}"
+          cat > release-body.md << 'RELEASE_EOF'
+          ## KeepKey Firmware v${{ needs.validate.outputs.fw_version }}
+
+          ### Artifacts
+
+          | File | Description |
+          |------|-------------|
+          | `firmware.keepkey.v$VER.bin` | Full firmware (all chains) |
+          | `firmware.keepkey.btconly.v$VER.bin` | Bitcoin-only firmware |
+          | `HASHES.txt` | SHA-256 hashes (full + payload) |
+          | `HASHES-btconly.txt` | SHA-256 hashes for BTC-only build |
+
+          ### Reproducible Build Verification
+
+          ```bash
+          # Build in Docker (same as CI)
+          ./scripts/build/docker/device/release.sh
+
+          # Compare payload hash (skip 256-byte KPKY header)
+          tail -c +257 bin/firmware.keepkey.bin | shasum -a 256
+          ```
+
+          > **Note:** This is a DRAFT release. Firmware must be signed by 3/5 key holders
+          > on an air-gapped machine before publishing. Replace the unsigned `.bin` with
+          > the signed version after the signing ceremony.
+
+          ### Signing Checklist
+
+          - [ ] Built on multiple machines, hashes match
+          - [ ] Signed on air-gapped machine (3/5 signers)
+          - [ ] Storage upgrade tested on production device
+          - [ ] Signed `.bin` uploaded, replacing unsigned
+          - [ ] Release notes finalized
+          RELEASE_EOF
+
+      - name: Create draft release
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          name: "Firmware v${{ needs.validate.outputs.fw_version }}"
+          body_path: release-body.md
+          files: release-assets/*
+          fail_on_unmatched_files: true


### PR DESCRIPTION
## Summary
- Add `release.yml` workflow: triggered on `v*` tags, builds full + BTC-only firmware, computes SHA-256 hashes (full file + payload without KPKY header), creates draft GitHub Release with all artifacts
- Update `ci.yml`: add `release/*` and `hotfix/*` branch patterns so CI runs on git-flow branches
- Add `GIT-FLOW.md`: documents the branching model (feature → develop → release → master → tag)

## What this enables
1. Push a `v*` tag to master → CI builds firmware → draft release appears with `.bin` + hashes
2. Signing ceremony adds signed `.bin` → publish release
3. All git-flow branches (`feature/*`, `release/*`, `hotfix/*`, `fix/*`) get full CI

## Test plan
- [ ] Push to `feature/*` branch triggers CI (this PR proves it)
- [ ] Verify release.yml syntax with `act` or manual workflow_dispatch
- [ ] End-to-end: tag a test version on a fork, confirm draft release appears