### PR TITLE
fix: backport nanopb oneof memory leak fix

### DIFF
--- a/lib/transport/pb_decode.c
+++ b/lib/transport/pb_decode.c
@@ -452,14 +452,18 @@ static bool checkreturn decode_static_field(pb_istream_t *stream,
       }
 
     case PB_HTYPE_ONEOF:
-      *(pb_size_t *)iter->pSize = iter->pos->tag;
-      if (PB_LTYPE(type) == PB_LTYPE_SUBMESSAGE) {
+      if (PB_LTYPE(type) == PB_LTYPE_SUBMESSAGE &&
+                *(pb_size_t*)iter->pSize != iter->pos->tag)
+      {
         /* We memset to zero so that any callbacks are set to NULL.
-         * Then set any default values. */
+         * This is because the callbacks might otherwise have values
+         * from some other union field. */
         memset(iter->pData, 0, iter->pos->data_size);
         pb_message_set_to_defaults((const pb_field_t *)iter->pos->ptr,
                                    iter->pData);
       }
+      *(pb_size_t*)iter->pSize = iter->pos->tag;
+
       return func(stream, iter->pos, iter->pData);
 
     default:


### PR DESCRIPTION
## Summary

Backports upstream nanopb commit `4fe23595732b6f1254cfc11a9b8d6da900b55b0c` to fix a memory leak in `pb_decode.c` when decoding `oneof` fields with `PB_ENABLE_MALLOC`.

Sourced from upstream PR: https://github.com/keepkey/keepkey-firmware/pull/361

## What changed

In `decode_static_field()`, the `PB_HTYPE_ONEOF` case:

- **Before**: `which_field` tag was set *before* the conditional memset, causing previously allocated memory to be orphaned when the same oneof variant appeared twice in a protobuf stream
- **After**: Tag assignment moved *after* the memset, and memset only fires when the variant *changes* — preventing the leak and avoiding unnecessary re-initialization

## Impact on KeepKey

`PB_ENABLE_MALLOC` is currently **commented out** in `include/pb.h`, so the malloc-specific leak path is not reachable in production firmware. However:

1. The ordering fix in the non-malloc path is a correctness improvement (avoids unnecessary re-init of same-variant oneofs)
2. Defense in depth if `PB_ENABLE_MALLOC` is ever enabled
3. Keeps our nanopb closer to upstream, reducing future merge friction

## Risk

- 1 file, 4 lines of logic change
- Zero new dependencies
- Matches verified upstream commit exactly

## Test Plan

- [ ] ARM cross-compilation succeeds (`docker build`)
- [ ] Emulator build + unit tests pass
- [ ] Device boots and operates normally