### PR TITLE
fix(ci): add multi-chain firmware build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,7 +249,16 @@ jobs:
   build-arm-firmware:
     needs: [check-submodules, secret-scan]
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
+    strategy:
+      matrix:
+        include:
+          - variant: btc
+            coin_support: "-DCOIN_SUPPORT=BTC"
+            label: "BTC-only"
+          - variant: multichain
+            coin_support: ""
+            label: "Multi-chain"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -289,14 +298,14 @@ jobs:
           echo "git_short=${GIT_SHORT}" >> "$GITHUB_OUTPUT"
           echo "Firmware version: ${FW_VERSION} (${GIT_SHORT})"
 
-      - name: Cross-compile firmware for ARM (BTC-only)
+      - name: Cross-compile firmware for ARM (${{ matrix.label }})
         run: |
           docker run --rm \
             -v ${{ github.workspace }}:/root/keepkey-firmware:z \
             ${{ env.BASE_IMAGE }} /bin/sh -c "\
               mkdir /root/build && cd /root/build && \
               cmake -C /root/keepkey-firmware/cmake/caches/device.cmake /root/keepkey-firmware \
-                -DCOIN_SUPPORT=BTC \
+                ${{ matrix.coin_support }} \
                 -DVARIANTS=NoObsoleteVariants \
                 -DCMAKE_BUILD_TYPE=MinSizeRel \
                 -DCMAKE_COLOR_MAKEFILE=ON && \
@@ -311,19 +320,19 @@ jobs:
           cd bin
           for f in *.bin; do
             [ -f "$f" ] || continue
-            mv "$f" "firmware.keepkey.v${{ steps.version.outputs.fw_version }}-${{ steps.version.outputs.git_short }}-${f}"
+            mv "$f" "${{ matrix.variant }}-${f}"
           done
           for f in *.elf; do
             [ -f "$f" ] || continue
-            mv "$f" "firmware.keepkey.v${{ steps.version.outputs.fw_version }}-${{ steps.version.outputs.git_short }}-${f}"
+            mv "$f" "${{ matrix.variant }}-${f}"
           done
           ls -lh
-          echo "::notice::Firmware v${{ steps.version.outputs.fw_version }} built successfully"
+          echo "::notice::Firmware v${{ steps.version.outputs.fw_version }} (${{ matrix.label }}) built successfully"
 
       - name: Upload firmware artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: firmware-v${{ steps.version.outputs.fw_version }}-${{ steps.version.outputs.git_short }}
+          name: firmware-${{ matrix.variant }}-v${{ steps.version.outputs.fw_version }}-${{ steps.version.outputs.git_short }}
           path: |
             bin/*.bin
             bin/*.elf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,6 +251,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
+      fail-fast: false
       matrix:
         include:
           - variant: btc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,15 @@
 # KeepKey Firmware Release Pipeline
 #
 # Triggered by version tags (v*) on master.
-# Builds firmware, computes reproducible hashes,
-# and creates a draft GitHub Release with all artifacts.
+# Builds both BTC-only and multi-chain firmware,
+# computes reproducible hashes, and creates a draft
+# GitHub Release with all artifacts.
 #
 # Git-flow: tag master after merging a release/* or hotfix/* branch.
 #
 # Usage:
-#   git tag v7.11.0
-#   git push origin v7.11.0
+#   git tag v7.14.0
+#   git push origin v7.14.0
 
 name: Release
 
@@ -49,6 +50,15 @@ jobs:
     needs: validate
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    strategy:
+      matrix:
+        include:
+          - variant: btc
+            coin_support: "-DCOIN_SUPPORT=BTC"
+            label: "BTC-only"
+          - variant: multichain
+            coin_support: ""
+            label: "Multi-chain"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -71,28 +81,28 @@ jobs:
         if: steps.cache-base.outputs.cache-hit == 'true'
         run: docker load -i /tmp/base-image.tar
 
-      - name: Cross-compile firmware (BTC-only)
+      - name: Cross-compile firmware (${{ matrix.label }})
         run: |
           docker run --rm \
             -v ${{ github.workspace }}:/root/keepkey-firmware:z \
             ${{ env.BASE_IMAGE }} /bin/sh -c "\
               mkdir /root/build && cd /root/build && \
               cmake -C /root/keepkey-firmware/cmake/caches/device.cmake /root/keepkey-firmware \
-                -DCOIN_SUPPORT=BTC \
+                ${{ matrix.coin_support }} \
                 -DVARIANTS=NoObsoleteVariants \
                 -DCMAKE_BUILD_TYPE=MinSizeRel \
                 -DCMAKE_COLOR_MAKEFILE=ON && \
               make && \
               mkdir -p /root/keepkey-firmware/release && \
-              cp bin/firmware.keepkey.bin /root/keepkey-firmware/release/ && \
-              cp bin/firmware.keepkey.elf /root/keepkey-firmware/release/ && \
-              cp bin/bootloader.bin /root/keepkey-firmware/release/ 2>/dev/null || true && \
+              cp bin/*.bin /root/keepkey-firmware/release/ && \
+              cp bin/*.elf /root/keepkey-firmware/release/ && \
               chmod -R a+rw /root/keepkey-firmware/release"
 
       - name: Compute hashes
         working-directory: release
         run: |
-          echo "# KeepKey Firmware v${{ needs.validate.outputs.fw_version }} — Hash Manifest" > HASHES.txt
+          VER="${{ needs.validate.outputs.fw_version }}"
+          echo "# KeepKey Firmware v${VER} (${{ matrix.label }}) — Hash Manifest" > HASHES.txt
           echo "" >> HASHES.txt
           for f in *.bin; do
             [ -f "$f" ] || continue
@@ -111,15 +121,22 @@ jobs:
         working-directory: release
         run: |
           VER="${{ needs.validate.outputs.fw_version }}"
-          [ -f firmware.keepkey.bin ] && mv firmware.keepkey.bin "firmware.keepkey.v${VER}.bin"
-          [ -f firmware.keepkey.elf ] && mv firmware.keepkey.elf "firmware.keepkey.v${VER}.elf"
-          [ -f bootloader.bin ] && mv bootloader.bin "bootloader.v${VER}.bin"
+          VARIANT="${{ matrix.variant }}"
+          for f in *.bin; do
+            [ -f "$f" ] || continue
+            mv "$f" "${VARIANT}-${f%.bin}.v${VER}.bin"
+          done
+          for f in *.elf; do
+            [ -f "$f" ] || continue
+            mv "$f" "${VARIANT}-${f%.elf}.v${VER}.elf"
+          done
+          mv HASHES.txt "HASHES-${VARIANT}.txt"
           ls -lh
 
       - name: Upload release artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: release-firmware
+          name: release-firmware-${{ matrix.variant }}
           path: release/*
           retention-days: 90
 
@@ -164,16 +181,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download firmware artifacts
+      - name: Download BTC firmware artifacts
         uses: actions/download-artifact@v4
         with:
-          name: release-firmware
-          path: artifacts
+          name: release-firmware-btc
+          path: artifacts/btc
+
+      - name: Download multi-chain firmware artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: release-firmware-multichain
+          path: artifacts/multichain
 
       - name: Prepare release assets
         run: |
           mkdir -p release-assets
-          cp artifacts/*.bin artifacts/*.elf artifacts/HASHES.txt release-assets/
+          cp artifacts/btc/* artifacts/multichain/* release-assets/
           ls -lh release-assets/
 
       - name: Generate release body
@@ -182,9 +205,18 @@ jobs:
           cat > release-body.md <<EOF
           ## KeepKey Firmware v${VER}
 
-          ### Reproducible Build Verification (BTC-only)
+          ### Firmware Variants
+          - **BTC-only** (\`btc-*\`): Bitcoin-only firmware (~350K)
+          - **Multi-chain** (\`multichain-*\`): Full multi-chain support (~700K)
+
+          ### Reproducible Build Verification
           \`\`\`bash
+          # BTC-only
           ./scripts/build/docker/device/btcrelease.sh
+          tail -c +257 bin/firmware.keepkeybtc.bin | shasum -a 256
+
+          # Multi-chain (no -DCOIN_SUPPORT flag)
+          ./scripts/build/docker/device/release.sh
           tail -c +257 bin/firmware.keepkey.bin | shasum -a 256
           \`\`\`
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
+      fail-fast: false
       matrix:
         include:
           - variant: btc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,25 +98,6 @@ jobs:
               cp bin/*.elf /root/keepkey-firmware/release/ && \
               chmod -R a+rw /root/keepkey-firmware/release"
 
-      - name: Compute hashes
-        working-directory: release
-        run: |
-          VER="${{ needs.validate.outputs.fw_version }}"
-          echo "# KeepKey Firmware v${VER} (${{ matrix.label }}) — Hash Manifest" > HASHES.txt
-          echo "" >> HASHES.txt
-          for f in *.bin; do
-            [ -f "$f" ] || continue
-            FULL_HASH=$(sha256sum "$f" | awk '{print $1}')
-            echo "sha256 (full)    $f  $FULL_HASH" >> HASHES.txt
-            FILE_SIZE=$(stat -c%s "$f")
-            if [ "$FILE_SIZE" -gt 256 ]; then
-              PAYLOAD_HASH=$(tail -c +257 "$f" | sha256sum | awk '{print $1}')
-              echo "sha256 (payload) $f  $PAYLOAD_HASH" >> HASHES.txt
-            fi
-            echo "" >> HASHES.txt
-          done
-          cat HASHES.txt
-
       - name: Rename artifacts
         working-directory: release
         run: |
@@ -130,8 +111,27 @@ jobs:
             [ -f "$f" ] || continue
             mv "$f" "${VARIANT}-${f%.elf}.v${VER}.elf"
           done
-          mv HASHES.txt "HASHES-${VARIANT}.txt"
           ls -lh
+
+      - name: Compute hashes
+        working-directory: release
+        run: |
+          VER="${{ needs.validate.outputs.fw_version }}"
+          VARIANT="${{ matrix.variant }}"
+          echo "# KeepKey Firmware v${VER} (${{ matrix.label }}) — Hash Manifest" > "HASHES-${VARIANT}.txt"
+          echo "" >> "HASHES-${VARIANT}.txt"
+          for f in *.bin; do
+            [ -f "$f" ] || continue
+            FULL_HASH=$(sha256sum "$f" | awk '{print $1}')
+            echo "sha256 (full)    $f  $FULL_HASH" >> "HASHES-${VARIANT}.txt"
+            FILE_SIZE=$(stat -c%s "$f")
+            if [ "$FILE_SIZE" -gt 256 ]; then
+              PAYLOAD_HASH=$(tail -c +257 "$f" | sha256sum | awk '{print $1}')
+              echo "sha256 (payload) $f  $PAYLOAD_HASH" >> "HASHES-${VARIANT}.txt"
+            fi
+            echo "" >> "HASHES-${VARIANT}.txt"
+          done
+          cat "HASHES-${VARIANT}.txt"
 
       - name: Upload release artifacts
         uses: actions/upload-artifact@v4

--- a/lib/firmware/CMakeLists.txt
+++ b/lib/firmware/CMakeLists.txt
@@ -58,6 +58,7 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/scm_revision.h.in"
 include_directories(
   ${CMAKE_BINARY_DIR}/include
   ${CMAKE_SOURCE_DIR}/deps/crypto/trezor-firmware/crypto
+  ${CMAKE_SOURCE_DIR}/deps/crypto
   ${CMAKE_SOURCE_DIR}/lib/firmware
   ${CMAKE_CURRENT_BINARY_DIR})
 

--- a/lib/firmware/tron.c
+++ b/lib/firmware/tron.c
@@ -97,7 +97,7 @@ bool tron_signTx(const HDNode *node, const TronSignTx *msg,
   // Get the curve for secp256k1
   const curve_info *curve = get_curve_by_name(SECP256K1_NAME);
   if (!curve) {
-    return;
+    return false;
   }
 
   // Hash the transaction with SHA256


### PR DESCRIPTION
## Summary
- CI and release workflows were only building BTC-only firmware (`-DCOIN_SUPPORT=BTC`)
- Added matrix strategy to build **both** BTC-only and multi-chain variants in parallel
- Artifacts are clearly labeled `btc-*` and `multichain-*`
- Release workflow now uploads both variants to GitHub releases

## Test plan
- [ ] CI runs produce two artifact sets: `firmware-btc-*` and `firmware-multichain-*`
- [ ] Multi-chain firmware binary is ~500-800K (not 256K like the bootloader payload)
- [ ] Release tag produces draft with both variants and hash manifests