### PR TITLE
fix(zcash): byte-level field reduction and parity checks

### DIFF
--- a/deps/crypto/redpallas.c
+++ b/deps/crypto/redpallas.c
@@ -189,14 +189,37 @@ static void pallas_scalar_mult(const bignum256 *k, const curve_point *G,
  * Format: little-endian x-coordinate, sign of y in bit 255.
  */
 static void pallas_point_serialize(const curve_point *P, uint8_t out[32]) {
-  bignum256 x_copy;
-  bn_copy(&P->x, &x_copy);
-  bn_mod(&x_copy, &pallas_prime);
-  bn_write_le(&x_copy, out);
-  if (bn_is_odd(&P->y)) {
+  /* Pallas prime p in LE bytes — hardcoded to avoid bn_write_le roundtrip
+   * issues where the bignum internal representation produces values >= p. */
+  static const uint8_t pallas_p_le[32] = {
+    0x01,0x00,0x00,0x00,0xed,0x30,0x2d,0x99,
+    0x1b,0xf9,0x4c,0x09,0xfc,0x98,0x46,0x22,
+    0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+    0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x40,
+  };
+
+  /* Serialize x-coord to LE bytes and reduce mod p */
+  bignum256 tmp;
+  bn_copy(&P->x, &tmp);
+  bn_write_le(&tmp, out);
+  { int c=0; for(int i=31;i>=0;i--){if(out[i]>pallas_p_le[i]){c=1;break;}if(out[i]<pallas_p_le[i]){c=-1;break;}}
+    while(c>=0){uint16_t b=0;for(int i=0;i<32;i++){uint16_t d=(uint16_t)out[i]-(uint16_t)pallas_p_le[i]-b;out[i]=(uint8_t)(d&0xFF);b=(d>>15)&1;}
+    c=0;for(int i=31;i>=0;i--){if(out[i]>pallas_p_le[i]){c=1;break;}if(out[i]<pallas_p_le[i]){c=-1;break;}}} }
+
+  /* Check y parity using serialized bytes (bn_is_odd is unreliable for
+   * Pallas-sized bignums — the internal limb representation may not be
+   * fully reduced, causing bn_is_odd to return wrong results). */
+  uint8_t y_bytes[32];
+  bn_copy(&P->y, &tmp);
+  bn_write_le(&tmp, y_bytes);
+  { int c=0; for(int i=31;i>=0;i--){if(y_bytes[i]>pallas_p_le[i]){c=1;break;}if(y_bytes[i]<pallas_p_le[i]){c=-1;break;}}
+    while(c>=0){uint16_t b=0;for(int i=0;i<32;i++){uint16_t d=(uint16_t)y_bytes[i]-(uint16_t)pallas_p_le[i]-b;y_bytes[i]=(uint8_t)(d&0xFF);b=(d>>15)&1;}
+    c=0;for(int i=31;i>=0;i--){if(y_bytes[i]>pallas_p_le[i]){c=1;break;}if(y_bytes[i]<pallas_p_le[i]){c=-1;break;}}} }
+  if (y_bytes[0] & 1) {
     out[31] |= 0x80;
   }
-  memzero(&x_copy, sizeof(x_copy));
+  memzero(&tmp, sizeof(tmp));
+  memzero(y_bytes, sizeof(y_bytes));
 }
 
 /*

--- a/include/keepkey/firmware/zcash.h
+++ b/include/keepkey/firmware/zcash.h
@@ -27,6 +27,7 @@
 typedef struct {
   uint8_t sk[32];    /* Spending key (master secret at this level) */
   uint8_t ask[32];   /* Spend authorizing key (scalar) */
+  uint8_t ak[32];    /* Authorizing key (serialized Pallas point with sign bit) */
   uint8_t nk[32];    /* Nullifier deriving key */
   uint8_t rivk[32];  /* Commitment randomness key */
 } ZcashOrchardKeys;

--- a/lib/firmware/fsm_msg_zcash.h
+++ b/lib/firmware/fsm_msg_zcash.h
@@ -264,25 +264,13 @@ void fsm_msgZcashGetOrchardFVK(const ZcashGetOrchardFVK *msg) {
   }
   memzero(seed_proxy, sizeof(seed_proxy));
 
-  /* Compute ak = [ask]G_spendauth on Pallas curve (SpendAuth basepoint) */
-  bignum256 ask_scalar;
-  bn_read_le(keys.ask, &ask_scalar);
-  curve_point ak_point;
-  redpallas_scalar_mult_spendauth_G(&ask_scalar, &ak_point);
-
-  /* Serialize ak as Pallas point (LE x-coord, sign bit in high byte) */
-  uint8_t ak_bytes[32];
-  bignum256 x_copy;
-  bn_copy(&ak_point.x, &x_copy);
-  bn_write_le(&x_copy, ak_bytes);
-  if (bn_is_odd(&ak_point.y)) {
-    ak_bytes[31] |= 0x80;
-  }
+  /* ak is pre-computed during zcash_derive_orchard_keys() with correct
+   * byte-level parity check and reduction. Use it directly. */
 
   /* Build response */
   resp->has_ak = true;
   resp->ak.size = 32;
-  memcpy(resp->ak.bytes, ak_bytes, 32);
+  memcpy(resp->ak.bytes, keys.ak, 32);
 
   resp->has_nk = true;
   resp->nk.size = 32;
@@ -293,7 +281,6 @@ void fsm_msgZcashGetOrchardFVK(const ZcashGetOrchardFVK *msg) {
   memcpy(resp->rivk.bytes, keys.rivk, 32);
 
   /* Clean up sensitive data */
-  memzero(&ask_scalar, sizeof(ask_scalar));
   memzero(&keys, sizeof(keys));
 
   msg_write(MessageType_MessageType_ZcashOrchardFVK, resp);

--- a/lib/firmware/zcash.c
+++ b/lib/firmware/zcash.c
@@ -108,6 +108,44 @@ static const uint8_t two_256_mod_p[32] = {
  *   result = (lo + hi * 2^256) mod q
  * where lo = input[0..31], hi = input[32..63] (little-endian).
  */
+/* Force-reduce a bignum256 so serialized LE bytes are < modulus.
+ * trezor-crypto's bn_mod may leave internal representation > modulus.
+ * Serializes to bytes, compares against prime bytes, subtracts in loop. */
+static void force_reduce_bytes(uint8_t val[32], const uint8_t prime[32]) {
+  int cmp = 0;
+  for (int i = 31; i >= 0; i--) {
+    if (val[i] > prime[i]) { cmp = 1; break; }
+    if (val[i] < prime[i]) { cmp = -1; break; }
+  }
+  while (cmp >= 0) {
+    uint16_t borrow = 0;
+    for (int i = 0; i < 32; i++) {
+      uint16_t diff = (uint16_t)val[i] - (uint16_t)prime[i] - borrow;
+      val[i] = (uint8_t)(diff & 0xFF);
+      borrow = (diff >> 15) & 1;
+    }
+    cmp = 0;
+    for (int i = 31; i >= 0; i--) {
+      if (val[i] > prime[i]) { cmp = 1; break; }
+      if (val[i] < prime[i]) { cmp = -1; break; }
+    }
+  }
+}
+
+/* Pallas prime p and scalar order q in LE bytes (avoids bignum roundtrip) */
+static const uint8_t PALLAS_P_LE[32] = {
+  0x01,0x00,0x00,0x00,0xed,0x30,0x2d,0x99,
+  0x1b,0xf9,0x4c,0x09,0xfc,0x98,0x46,0x22,
+  0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+  0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x40,
+};
+static const uint8_t PALLAS_Q_LE[32] = {
+  0x01,0x00,0x00,0x00,0x21,0xeb,0x46,0x8c,
+  0xdd,0xa8,0x94,0x09,0xfc,0x98,0x46,0x22,
+  0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+  0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x40,
+};
+
 static void to_scalar(const uint8_t input[64], uint8_t output[32]) {
   bignum256 lo, hi, t256, result;
 
@@ -127,6 +165,7 @@ static void to_scalar(const uint8_t input[64], uint8_t output[32]) {
   pallas_add_mod_q(&result, &lo);
 
   bn_write_le(&result, output);
+  force_reduce_bytes(output, PALLAS_Q_LE);
 
   memzero(&lo, sizeof(lo));
   memzero(&hi, sizeof(hi));
@@ -162,6 +201,7 @@ static void to_base(const uint8_t input[64], uint8_t output[32]) {
   memzero(&sum, sizeof(sum));
 
   bn_write_le(&result, output);
+  force_reduce_bytes(output, PALLAS_P_LE);
 
   memzero(&lo, sizeof(lo));
   memzero(&hi, sizeof(hi));
@@ -221,41 +261,35 @@ bool zcash_derive_orchard_keys(const uint8_t *seed, uint32_t seed_len,
   to_scalar(expanded, keys->ask);
 
   /*
-   * Zcash spec (§ 4.2.3): If [ask]*G_spendauth has odd y (ỹ = 1),
-   * negate ask so that the resulting ak always has ỹ = 0.
-   * This matches the orchard crate's SpendAuthorizingKey::from() behavior.
+   * Zcash spec (§ 4.2.3): Compute ak = [ask]*G_spendauth.
+   * If y is odd, negate ask so ak has even y (sign bit = 0).
+   * Use pallas_point_serialize (now fixed with byte-level parity)
+   * to serialize and check, then store in keys->ak.
    */
   {
-    bignum256 ask_test;
-    bn_read_le(keys->ask, &ask_test);
-    curve_point ak_test;
-    redpallas_scalar_mult_spendauth_G(&ask_test, &ak_test);
-    if (bn_is_odd(&ak_test.y)) {
-      /* ask = order - ask (negate mod q) */
-      bignum256 neg_ask;
-      bn_copy(&pallas_order, &neg_ask);
-      bignum256 ask_val;
-      bn_read_le(keys->ask, &ask_val);
-      bn_normalize(&ask_val);
-      bn_normalize(&neg_ask);
-      /* neg_ask = order - ask */
-      int32_t borrow = 0;
-      for (int i = 0; i < 9; i++) {
-        int32_t diff = (int32_t)neg_ask.val[i] - (int32_t)ask_val.val[i] + borrow;
-        if (diff < 0) {
-          diff += (1 << 29);
-          borrow = -1;
-        } else {
-          borrow = 0;
-        }
-        neg_ask.val[i] = (uint32_t)diff;
+    bignum256 ask_scalar;
+    curve_point ak_point;
+
+    bn_read_le(keys->ask, &ask_scalar);
+    redpallas_scalar_mult_spendauth_G(&ask_scalar, &ak_point);
+    pallas_point_serialize(&ak_point, keys->ak);
+
+    if (keys->ak[31] & 0x80) {
+      /* y is odd — negate ask: ask = order - ask (byte-level) */
+      uint16_t borrow = 0;
+      for (int i = 0; i < 32; i++) {
+        uint16_t diff = (uint16_t)PALLAS_Q_LE[i] - (uint16_t)keys->ask[i] - borrow;
+        keys->ask[i] = (uint8_t)(diff & 0xFF);
+        borrow = (diff >> 15) & 1;
       }
-      bn_write_le(&neg_ask, keys->ask);
-      memzero(&neg_ask, sizeof(neg_ask));
-      memzero(&ask_val, sizeof(ask_val));
+      /* Recompute ak with negated ask */
+      bn_read_le(keys->ask, &ask_scalar);
+      redpallas_scalar_mult_spendauth_G(&ask_scalar, &ak_point);
+      pallas_point_serialize(&ak_point, keys->ak);
     }
-    memzero(&ask_test, sizeof(ask_test));
-    memzero(&ak_test, sizeof(ak_test));
+
+    memzero(&ask_scalar, sizeof(ask_scalar));
+    memzero(&ak_point, sizeof(ak_point));
   }
 
   /* nk = ToBase(PRF^expand(sk, [0x07])) */


### PR DESCRIPTION
## Summary
Fix trezor-crypto bignum incompatibility with Pallas curve (~254-bit field).

`bn_mod`/`bn_is_odd` are unreliable for Pallas-sized values — the internal limb representation may not be fully reduced, causing:
1. `ask`/`nk`/`rivk` values exceeding field modulus (invalid FVK)
2. Wrong y parity in point serialization (wrong sign bits → signature failures)
3. Broken `ask` negation (negating unreduced value gives wrong key)

## Changes (4 files, pure bugfix)
- **`redpallas.c`**: Replace `bn_is_odd` with byte-level y parity in `pallas_point_serialize()`. Hardcoded Pallas prime for x/y reduction.
- **`zcash.c`**: Add `force_reduce_bytes()`. Apply after `to_scalar()`/`to_base()`. Replace `bn_is_odd` ak negation with `pallas_point_serialize()` check. Pre-compute `ak` during derivation.
- **`fsm_msg_zcash.h`**: Use pre-computed `keys.ak` in FVK export.
- **`zcash.h`**: Add `ak[32]` to `ZcashOrchardKeys` struct.

## Test plan
- [ ] Build multichain firmware
- [ ] Emulator unit tests pass
- [ ] FVK export: `ak` sign bit = 0, `nk < p`, `rivk < q`
- [ ] FVK accepted by orchard Rust crate (`FullViewingKey::from_bytes`)
- [ ] RedPallas signatures verify on sidecar
- [ ] Shielded send end-to-end