### PR TITLE
fix(ton): v4r2 StateInit address + code review fixes

### DIFF
--- a/include/keepkey/firmware/ton.h
+++ b/include/keepkey/firmware/ton.h
@@ -63,6 +63,6 @@ void ton_formatAmount(char *buf, size_t len, uint64_t amount);
  * @param msg TonSignTx request message
  * @param resp TonSignedTx response message (will be filled with signature)
  */
-void ton_signTx(const HDNode *node, const TonSignTx *msg, TonSignedTx *resp);
+bool ton_signTx(const HDNode *node, const TonSignTx *msg, TonSignedTx *resp);
 
 #endif

--- a/include/keepkey/firmware/tron.h
+++ b/include/keepkey/firmware/tron.h
@@ -54,7 +54,7 @@ void tron_formatAmount(char *buf, size_t len, uint64_t amount);
  * @param msg TronSignTx request message
  * @param resp TronSignedTx response message (will be filled with signature)
  */
-void tron_signTx(const HDNode *node, const TronSignTx *msg,
+bool tron_signTx(const HDNode *node, const TronSignTx *msg,
                  TronSignedTx *resp);
 
 #endif

--- a/lib/firmware/fsm_msg_ton.h
+++ b/lib/firmware/fsm_msg_ton.h
@@ -24,10 +24,12 @@ void fsm_msgTonGetAddress(const TonGetAddress *msg) {
 
   CHECK_PIN
 
-  // Validate path: m/44'/607'/x'/x'/x'/x' (all hardened for TON)
-  if (msg->address_n_count < 6) {
+  // Validate path: m/44'/607'/... (all hardened for TON)
+  if (msg->address_n_count < 2 ||
+      msg->address_n[0] != (0x80000000 | 44) ||
+      msg->address_n[1] != (0x80000000 | 607)) {
     fsm_sendFailure(FailureType_Failure_Other,
-                    _("Invalid path for TON address"));
+                    _("Invalid TON path (expected m/44'/607'/...)"));
     layoutHome();
     return;
   }
@@ -89,6 +91,16 @@ void fsm_msgTonSignTx(TonSignTx *msg) {
 
   CHECK_PIN
 
+  // Validate path: m/44'/607'/...
+  if (msg->address_n_count < 2 ||
+      msg->address_n[0] != (0x80000000 | 44) ||
+      msg->address_n[1] != (0x80000000 | 607)) {
+    fsm_sendFailure(FailureType_Failure_Other,
+                    _("Invalid TON path (expected m/44'/607'/...)"));
+    layoutHome();
+    return;
+  }
+
   // Derive node using Ed25519 curve
   HDNode *node = fsm_getDerivedNode(ED25519_NAME, msg->address_n,
                                     msg->address_n_count, NULL);
@@ -129,7 +141,12 @@ void fsm_msgTonSignTx(TonSignTx *msg) {
   }
 
   // Sign the transaction with Ed25519
-  ton_signTx(node, msg, resp);
+  if (!ton_signTx(node, msg, resp)) {
+    memzero(node, sizeof(*node));
+    fsm_sendFailure(FailureType_Failure_Other, _("TON signing failed"));
+    layoutHome();
+    return;
+  }
 
   memzero(node, sizeof(*node));
   msg_write(MessageType_MessageType_TonSignedTx, resp);

--- a/lib/firmware/fsm_msg_tron.h
+++ b/lib/firmware/fsm_msg_tron.h
@@ -24,10 +24,12 @@ void fsm_msgTronGetAddress(const TronGetAddress *msg) {
 
   CHECK_PIN
 
-  // Validate path: m/44'/195'/x'/0/0
-  if (msg->address_n_count < 3) {
+  // Validate path: m/44'/195'/...
+  if (msg->address_n_count < 3 ||
+      msg->address_n[0] != (0x80000000 | 44) ||
+      msg->address_n[1] != (0x80000000 | 195)) {
     fsm_sendFailure(FailureType_Failure_Other,
-                    _("Invalid path for TRON address"));
+                    _("Invalid TRON path (expected m/44'/195'/...)"));
     layoutHome();
     return;
   }
@@ -79,6 +81,16 @@ void fsm_msgTronSignTx(TronSignTx *msg) {
 
   CHECK_PIN
 
+  // Validate path: m/44'/195'/...
+  if (msg->address_n_count < 3 ||
+      msg->address_n[0] != (0x80000000 | 44) ||
+      msg->address_n[1] != (0x80000000 | 195)) {
+    fsm_sendFailure(FailureType_Failure_Other,
+                    _("Invalid TRON path (expected m/44'/195'/...)"));
+    layoutHome();
+    return;
+  }
+
   // Derive node using secp256k1 curve
   HDNode *node = fsm_getDerivedNode(SECP256K1_NAME, msg->address_n,
                                     msg->address_n_count, NULL);
@@ -119,7 +131,12 @@ void fsm_msgTronSignTx(TronSignTx *msg) {
   }
 
   // Sign the transaction with secp256k1
-  tron_signTx(node, msg, resp);
+  if (!tron_signTx(node, msg, resp)) {
+    memzero(node, sizeof(*node));
+    fsm_sendFailure(FailureType_Failure_Other, _("TRON signing failed"));
+    layoutHome();
+    return;
+  }
 
   memzero(node, sizeof(*node));
   msg_write(MessageType_MessageType_TronSignedTx, resp);

--- a/lib/firmware/ton.c
+++ b/lib/firmware/ton.c
@@ -103,8 +103,7 @@ bool ton_get_address(const ed25519_public_key public_key, bool bounceable,
 
   // Construct address data: [tag][workchain][hash][crc16]
   uint8_t addr_data[36];
-  uint8_t tag = 0x11;  // Base tag
-  if (bounceable) tag |= 0x11;
+  uint8_t tag = bounceable ? 0x11 : 0x51;
   if (testnet) tag |= 0x80;
 
   addr_data[0] = tag;
@@ -150,14 +149,14 @@ void ton_formatAmount(char *buf, size_t len, uint64_t amount) {
 /**
  * Sign a TON transaction with Ed25519
  */
-void ton_signTx(const HDNode *node, const TonSignTx *msg, TonSignedTx *resp) {
+bool ton_signTx(const HDNode *node, const TonSignTx *msg, TonSignedTx *resp) {
   if (!node || !msg || !resp) {
-    return;
+    return false;
   }
 
   // Verify we have raw transaction data
   if (!msg->has_raw_tx || msg->raw_tx.size == 0) {
-    return;
+    return false;
   }
 
   // Ed25519 sign the transaction
@@ -172,4 +171,6 @@ void ton_signTx(const HDNode *node, const TonSignTx *msg, TonSignedTx *resp) {
 
   // Zero out the signature buffer for security
   memzero(signature, sizeof(signature));
+
+  return true;
 }

--- a/lib/firmware/ton.c
+++ b/lib/firmware/ton.c
@@ -83,10 +83,88 @@ static uint16_t ton_crc16(const uint8_t *data, size_t len) {
   return crc;
 }
 
+// Well-known v4r2 wallet contract code cell hash (constant)
+// Source: https://github.com/ton-blockchain/wallet-contract (WalletV4R2)
+static const uint8_t V4R2_CODE_HASH[32] = {
+    0xfe, 0xb5, 0xff, 0x68, 0x20, 0xe2, 0xff, 0x0d,
+    0x94, 0x83, 0xe7, 0xe0, 0xd6, 0x2c, 0x81, 0x7d,
+    0x84, 0x67, 0x89, 0xfb, 0x4a, 0xe5, 0x80, 0xc8,
+    0x78, 0x86, 0x6d, 0x95, 0x9d, 0xab, 0xd5, 0xc0};
+// Code cell depth in the cell tree
+#define V4R2_CODE_DEPTH 7
+// Standard v4r2 wallet_id for mainnet workchain 0
+#define V4R2_WALLET_ID 698983191u  // 0x29A9A317
+
 /**
- * Generate TON address from Ed25519 public key
- * TON uses a specific format with workchain, bounceable/testnet flags, and
- * CRC16
+ * Compute the v4r2 data cell representation hash.
+ * Data cell layout: seqno(32b=0) + wallet_id(32b) + pubkey(256b) + plugins(1b=0)
+ * Total: 321 bits, d1=0x00 (no refs), d2=0x51 (floor(321/8)+ceil(321/8)=40+41=81)
+ * Augmented data: 40 full bytes + 0x40 (plugin=0, completion=1, pad=000000)
+ */
+static void ton_data_cell_hash(const uint8_t *public_key, uint8_t *out) {
+  // repr = d1(1) + d2(1) + augmented_data(41) = 43 bytes
+  uint8_t repr[43];
+  repr[0] = 0x00;  // d1: no refs
+  repr[1] = 0x51;  // d2: 81 decimal
+
+  // seqno = 0 (4 bytes)
+  memset(repr + 2, 0, 4);
+
+  // wallet_id = 698983191 = 0x29A9A317 (4 bytes big-endian)
+  repr[6]  = (V4R2_WALLET_ID >> 24) & 0xFF;
+  repr[7]  = (V4R2_WALLET_ID >> 16) & 0xFF;
+  repr[8]  = (V4R2_WALLET_ID >> 8)  & 0xFF;
+  repr[9]  = (V4R2_WALLET_ID)       & 0xFF;
+
+  // public key (32 bytes)
+  memcpy(repr + 10, public_key, 32);
+
+  // plugins = 0 (1 bit) + completion tag (1 bit) + padding (6 bits) = 0x40
+  repr[42] = 0x40;
+
+  sha256_Raw(repr, 43, out);
+}
+
+/**
+ * Compute the v4r2 StateInit representation hash.
+ * StateInit: split_depth(0) + special(0) + code(1,ref) + data(1,ref) + library(0)
+ * Total: 5 bits, d1=0x02 (2 refs), d2=0x01
+ * Augmented: 00110 + 100 = 0x34
+ * repr = d1 + d2 + data + depth(code) + depth(data) + hash(code) + hash(data)
+ */
+static void ton_stateinit_hash(const uint8_t *public_key, uint8_t *out) {
+  uint8_t data_hash[32];
+  ton_data_cell_hash(public_key, data_hash);
+
+  // repr = d1(1) + d2(1) + augmented(1) + code_depth(2) + data_depth(2) +
+  //        code_hash(32) + data_hash(32) = 71 bytes
+  uint8_t repr[71];
+  repr[0] = 0x02;  // d1: 2 refs
+  repr[1] = 0x01;  // d2: 1
+  repr[2] = 0x34;  // augmented: 00110100
+
+  // code cell depth = 7 (2 bytes big-endian)
+  repr[3] = 0x00;
+  repr[4] = V4R2_CODE_DEPTH;
+
+  // data cell depth = 0 (no refs)
+  repr[5] = 0x00;
+  repr[6] = 0x00;
+
+  // code cell hash (32 bytes)
+  memcpy(repr + 7, V4R2_CODE_HASH, 32);
+
+  // data cell hash (32 bytes)
+  memcpy(repr + 39, data_hash, 32);
+
+  sha256_Raw(repr, 71, out);
+  memzero(data_hash, sizeof(data_hash));
+}
+
+/**
+ * Generate TON v4r2 wallet address from Ed25519 public key.
+ * Address = base64url(tag || workchain || sha256(StateInit) || crc16)
+ * where StateInit = code_cell(v4r2) + data_cell(seqno=0, walletId, pubkey)
  */
 bool ton_get_address(const ed25519_public_key public_key, bool bounceable,
                      bool testnet, int32_t workchain, char *address,
@@ -97,9 +175,9 @@ bool ton_get_address(const ed25519_public_key public_key, bool bounceable,
     return false;
   }
 
-  // Hash the public key with SHA256
+  // Compute the v4r2 StateInit representation hash — this IS the address hash
   uint8_t hash[32];
-  sha256_Raw(public_key, 32, hash);
+  ton_stateinit_hash(public_key, hash);
 
   // Construct address data: [tag][workchain][hash][crc16]
   uint8_t addr_data[36];

--- a/lib/firmware/tron.c
+++ b/lib/firmware/tron.c
@@ -46,7 +46,9 @@ bool tron_getAddress(const uint8_t public_key[33], char *address,
   uint8_t addr_bytes[21];
 
   // Uncompress the public key
-  ecdsa_uncompress_pubkey(&secp256k1, public_key, uncompressed_pubkey);
+  if (!ecdsa_uncompress_pubkey(&secp256k1, public_key, uncompressed_pubkey)) {
+    return false;
+  }
 
   // Keccak256 hash of uncompressed public key (skip first 0x04 byte)
   keccak_256(uncompressed_pubkey + 1, 64, hash);
@@ -81,15 +83,15 @@ void tron_formatAmount(char *buf, size_t len, uint64_t amount) {
 /**
  * Sign a TRON transaction with secp256k1
  */
-void tron_signTx(const HDNode *node, const TronSignTx *msg,
+bool tron_signTx(const HDNode *node, const TronSignTx *msg,
                  TronSignedTx *resp) {
   if (!node || !msg || !resp) {
-    return;
+    return false;
   }
 
   // Verify we have raw transaction data
   if (!msg->has_raw_data || msg->raw_data.size == 0) {
-    return;
+    return false;
   }
 
   // Get the curve for secp256k1
@@ -110,7 +112,7 @@ void tron_signTx(const HDNode *node, const TronSignTx *msg,
   if (ecdsa_sign_digest(&secp256k1, node->private_key, hash, sig, &pby,
                         NULL) != 0) {
     memzero(hash, sizeof(hash));
-    return;
+    return false;
   }
 
   // Convert to recoverable signature format (r + s + recovery_id)
@@ -125,4 +127,6 @@ void tron_signTx(const HDNode *node, const TronSignTx *msg,
   // Clean up sensitive data
   memzero(hash, sizeof(hash));
   memzero(sig, sizeof(sig));
+
+  return true;
 }

--- a/lib/firmware/tron.c
+++ b/lib/firmware/tron.c
@@ -97,7 +97,7 @@ bool tron_signTx(const HDNode *node, const TronSignTx *msg,
   // Get the curve for secp256k1
   const curve_info *curve = get_curve_by_name(SECP256K1_NAME);
   if (!curve) {
-    return;
+    return false;
   }
 
   // Hash the transaction with SHA256


### PR DESCRIPTION
## Summary
- Fix TON address derivation: `sha256(StateInit(v4r2))` instead of `sha256(pubkey)`
- Fix bounceable flag: was `0x11 | 0x11` (no-op), now `bounceable ? 0x11 : 0x51`
- Add BIP-44 path validation (`44'/607'`) in both GetAddress and SignTx
- Change `ton_signTx` to return bool for proper error propagation
- Add Tron code review fixes (path validation, error handling)

## Test plan
- [ ] CI green (build + unit tests + python integration)
- [ ] Verify TON address matches vault-side `tonV4R2Address()` computation