### PR TITLE
fix: Solana + BIP-85 code review fixes

### DIFF
--- a/include/keepkey/firmware/fsm.h
+++ b/include/keepkey/firmware/fsm.h
@@ -129,8 +129,6 @@ void fsm_msgTonGetAddress(const TonGetAddress *msg);
 void fsm_msgTonSignTx(TonSignTx *msg);
 #endif // BITCOIN_ONLY
 
-#endif  // BITCOIN_ONLY
-
 #if DEBUG_LINK
 // void fsm_msgDebugLinkDecision(DebugLinkDecision *msg);
 void fsm_msgDebugLinkGetState(DebugLinkGetState *msg);

--- a/include/keepkey/firmware/fsm.h
+++ b/include/keepkey/firmware/fsm.h
@@ -129,6 +129,8 @@ void fsm_msgTonGetAddress(const TonGetAddress *msg);
 void fsm_msgTonSignTx(TonSignTx *msg);
 #endif // BITCOIN_ONLY
 
+#endif  // BITCOIN_ONLY
+
 #if DEBUG_LINK
 // void fsm_msgDebugLinkDecision(DebugLinkDecision *msg);
 void fsm_msgDebugLinkGetState(DebugLinkGetState *msg);

--- a/lib/firmware/bip85.c
+++ b/lib/firmware/bip85.c
@@ -26,6 +26,11 @@ static const uint8_t BIP85_HMAC_KEY[] = "bip-entropy-from-k";
 
 bool bip85_derive_mnemonic(uint32_t word_count, uint32_t index,
                            char *mnemonic, size_t mnemonic_len) {
+  /* Reject index >= 0x80000000 to avoid hardened-bit collision */
+  if (index & 0x80000000) {
+    return false;
+  }
+
   /* Validate word count and compute entropy length */
   int entropy_bytes;
   switch (word_count) {

--- a/lib/firmware/fsm_msg_bip85.h
+++ b/lib/firmware/fsm_msg_bip85.h
@@ -1,15 +1,7 @@
 void fsm_msgGetBip85Mnemonic(const GetBip85Mnemonic *msg) {
   CHECK_INITIALIZED
 
-  /* Validate required fields are present */
-  if (!msg->has_word_count || !msg->has_index) {
-    fsm_sendFailure(FailureType_Failure_SyntaxError,
-                    "word_count and index are required");
-    layoutHome();
-    return;
-  }
-
-  /* Validate word count */
+  /* Validate word count (required field, always present in nanopb) */
   if (msg->word_count != 12 && msg->word_count != 18 && msg->word_count != 24) {
     fsm_sendFailure(FailureType_Failure_SyntaxError,
                     "word_count must be 12, 18, or 24");

--- a/lib/firmware/fsm_msg_bip85.h
+++ b/lib/firmware/fsm_msg_bip85.h
@@ -1,6 +1,14 @@
 void fsm_msgGetBip85Mnemonic(const GetBip85Mnemonic *msg) {
   CHECK_INITIALIZED
 
+  /* Validate required fields are present */
+  if (!msg->has_word_count || !msg->has_index) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    "word_count and index are required");
+    layoutHome();
+    return;
+  }
+
   /* Validate word count */
   if (msg->word_count != 12 && msg->word_count != 18 && msg->word_count != 24) {
     fsm_sendFailure(FailureType_Failure_SyntaxError,
@@ -9,16 +17,24 @@ void fsm_msgGetBip85Mnemonic(const GetBip85Mnemonic *msg) {
     return;
   }
 
+  /* Reject index >= 0x80000000 (hardened-bit collision) */
+  if (msg->index & 0x80000000) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    "index must be less than 2147483648");
+    layoutHome();
+    return;
+  }
+
   CHECK_PIN
 
-  /* User confirmation on device display */
+  /* User confirmation — make clear a secret is being exported */
   char desc[80];
   snprintf(desc, sizeof(desc),
-           "Derive %lu-word child seed at index %lu?",
+           "Export %lu-word child seed at index %lu to host?",
            (unsigned long)msg->word_count, (unsigned long)msg->index);
 
   if (!confirm(ButtonRequestType_ButtonRequest_Other,
-               "BIP-85 Derive Seed", "%s", desc)) {
+               "BIP-85 Export Seed", "%s", desc)) {
     fsm_sendFailure(FailureType_Failure_ActionCancelled,
                     "BIP-85 derivation cancelled");
     layoutHome();
@@ -34,6 +50,17 @@ void fsm_msgGetBip85Mnemonic(const GetBip85Mnemonic *msg) {
     memzero(mnemonic_buf, sizeof(mnemonic_buf));
     fsm_sendFailure(FailureType_Failure_Other,
                     "BIP-85 derivation failed");
+    layoutHome();
+    return;
+  }
+
+  /* Second confirmation before sending secret to host */
+  if (!confirm(ButtonRequestType_ButtonRequest_Other,
+               "Send to Computer?",
+               "The child seed will be sent to the connected computer. Continue?")) {
+    memzero(mnemonic_buf, sizeof(mnemonic_buf));
+    fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                    "BIP-85 export cancelled");
     layoutHome();
     return;
   }

--- a/lib/firmware/fsm_msg_solana.h
+++ b/lib/firmware/fsm_msg_solana.h
@@ -26,6 +26,16 @@ void fsm_msgSolanaGetAddress(const SolanaGetAddress *msg) {
 
   CHECK_PIN
 
+  // Validate BIP44 path: m/44'/501'/...
+  if (msg->address_n_count < 2 ||
+      msg->address_n[0] != (0x80000000 | 44) ||
+      msg->address_n[1] != (0x80000000 | 501)) {
+    fsm_sendFailure(FailureType_Failure_Other,
+                    _("Invalid Solana derivation path (expected m/44'/501'/...)"));
+    layoutHome();
+    return;
+  }
+
   // Derive Ed25519 key for Solana (uses Ed25519 curve, not secp256k1)
   HDNode *node = fsm_getDerivedNode("ed25519", msg->address_n,
                                     msg->address_n_count, NULL);
@@ -51,21 +61,17 @@ void fsm_msgSolanaGetAddress(const SolanaGetAddress *msg) {
 
   // Show address on display if requested
   if (msg->has_show_display && msg->show_display) {
-    const CoinType *coin = fsm_getCoin(true, "Solana");
     char node_str[NODE_STRING_LENGTH];
 
-    // Try to format the BIP32 path in a user-friendly way
-    if (!(bip32_node_to_string(node_str, sizeof(node_str), coin, msg->address_n,
-                               msg->address_n_count,
-                               /*whole_account=*/false,
-                               /*show_addridx=*/false)) &&
-        !bip32_path_to_string(node_str, sizeof(node_str), msg->address_n,
+    // Format BIP32 path as string (no coin table entry needed)
+    if (!bip32_path_to_string(node_str, sizeof(node_str), msg->address_n,
                               msg->address_n_count)) {
       memset(node_str, 0, sizeof(node_str));
     }
 
     // Confirm address display with user
     if (!confirm_ethereum_address(node_str, address)) {
+      memzero(public_key, sizeof(public_key));
       memzero(node, sizeof(*node));
       fsm_sendFailure(FailureType_Failure_ActionCancelled,
                       _("Show address cancelled"));
@@ -75,6 +81,7 @@ void fsm_msgSolanaGetAddress(const SolanaGetAddress *msg) {
   }
 
   // Clean up and send response
+  memzero(public_key, sizeof(public_key));
   memzero(node, sizeof(*node));
   msg_write(MessageType_MessageType_SolanaAddress, resp);
   layoutHome();
@@ -86,6 +93,16 @@ void fsm_msgSolanaSignTx(const SolanaSignTx *msg) {
   CHECK_INITIALIZED
 
   CHECK_PIN
+
+  // Validate BIP44 path: m/44'/501'/...
+  if (msg->address_n_count < 2 ||
+      msg->address_n[0] != (0x80000000 | 44) ||
+      msg->address_n[1] != (0x80000000 | 501)) {
+    fsm_sendFailure(FailureType_Failure_Other,
+                    _("Invalid Solana derivation path (expected m/44'/501'/...)"));
+    layoutHome();
+    return;
+  }
 
   // Validate transaction data
   if (!msg->has_raw_tx || msg->raw_tx.size == 0) {
@@ -107,6 +124,7 @@ void fsm_msgSolanaSignTx(const SolanaSignTx *msg) {
   // Parse transaction to display details to user
   SolanaParsedTransaction parsed_tx;
   if (!solana_parseTransaction(msg->raw_tx.bytes, msg->raw_tx.size, &parsed_tx)) {
+    memzero(public_key, sizeof(public_key));
     memzero(node, sizeof(*node));
     fsm_sendFailure(FailureType_Failure_SyntaxError,
                     _("Failed to parse transaction"));
@@ -116,6 +134,7 @@ void fsm_msgSolanaSignTx(const SolanaSignTx *msg) {
 
   // Confirm transaction with user (shows parsed details)
   if (!solana_confirmTransaction(&parsed_tx, public_key)) {
+    memzero(public_key, sizeof(public_key));
     memzero(node, sizeof(*node));
     fsm_sendFailure(FailureType_Failure_ActionCancelled, "Signing cancelled");
     layoutHome();
@@ -124,6 +143,7 @@ void fsm_msgSolanaSignTx(const SolanaSignTx *msg) {
 
   // Sign the transaction
   if (!solana_signTx(node, msg, resp)) {
+    memzero(public_key, sizeof(public_key));
     memzero(node, sizeof(*node));
     fsm_sendFailure(FailureType_Failure_Other,
                     _("Failed to sign transaction"));
@@ -132,6 +152,7 @@ void fsm_msgSolanaSignTx(const SolanaSignTx *msg) {
   }
 
   // Clean up and send response
+  memzero(public_key, sizeof(public_key));
   memzero(node, sizeof(*node));
   msg_write(MessageType_MessageType_SolanaSignedTx, resp);
   layoutHome();
@@ -143,6 +164,16 @@ void fsm_msgSolanaSignMessage(const SolanaSignMessage *msg) {
   CHECK_INITIALIZED
 
   CHECK_PIN
+
+  // Validate BIP44 path: m/44'/501'/...
+  if (msg->address_n_count < 2 ||
+      msg->address_n[0] != (0x80000000 | 44) ||
+      msg->address_n[1] != (0x80000000 | 501)) {
+    fsm_sendFailure(FailureType_Failure_Other,
+                    _("Invalid Solana derivation path (expected m/44'/501'/...)"));
+    layoutHome();
+    return;
+  }
 
   // Validate message data
   if (!msg->has_message || msg->message.size == 0) {
@@ -188,6 +219,7 @@ void fsm_msgSolanaSignMessage(const SolanaSignMessage *msg) {
 
   // Clean up sensitive data
   memzero(signature, sizeof(signature));
+  memzero(public_key, sizeof(public_key));
   memzero(node, sizeof(*node));
 
   msg_write(MessageType_MessageType_SolanaMessageSignature, resp);


### PR DESCRIPTION
## Summary
Code review fixes that were on the old release branch but missed in the develop rebuild:

- **Solana**: address review findings C1,C3,C4,H1,H3,H4,L1,L4,L5,M6 (bounds checks, validation)
- **Solana**: additional review fixes in fsm_msg_solana.h
- **BIP-85**: review fixes in bip85.c and fsm_msg_bip85.h
- **BIP-85**: remove has_ checks on required nanopb fields

## Test plan
- [ ] CI green