### PR TITLE
upstream #361: fix nanopb memory leak with oneofs + PB_ENABLE_MALLOC

### DIFF
--- a/lib/transport/pb_decode.c
+++ b/lib/transport/pb_decode.c
@@ -452,14 +452,18 @@ static bool checkreturn decode_static_field(pb_istream_t *stream,
       }
 
     case PB_HTYPE_ONEOF:
-      *(pb_size_t *)iter->pSize = iter->pos->tag;
-      if (PB_LTYPE(type) == PB_LTYPE_SUBMESSAGE) {
+      if (PB_LTYPE(type) == PB_LTYPE_SUBMESSAGE &&
+                *(pb_size_t*)iter->pSize != iter->pos->tag) 
+      {
         /* We memset to zero so that any callbacks are set to NULL.
-         * Then set any default values. */
+         * This is because the callbacks might otherwise have values
+         * from some other union field. */
         memset(iter->pData, 0, iter->pos->data_size);
         pb_message_set_to_defaults((const pb_field_t *)iter->pos->ptr,
                                    iter->pData);
       }
+      *(pb_size_t*)iter->pSize = iter->pos->tag;
+      
       return func(stream, iter->pos, iter->pData);
 
     default:


### PR DESCRIPTION
## Summary
Cherry-pick of upstream keepkey/keepkey-firmware#361 (external contributor: Mifacopy)

Fixes memory leak in nanopb when using oneofs with PB_ENABLE_MALLOC.

## Test plan
- [ ] CI green