### PR TITLE
feat(policy): add blind signing policies, default disabled

### DIFF
--- a/include/keepkey/firmware/policy.h
+++ b/include/keepkey/firmware/policy.h
@@ -33,7 +33,7 @@ static const PolicyType policies[] = {
     {true, "Experimental", true, false},
     {true, "AdvancedMode", true, false},
     {true, "SolBlindSign", true, false},
-    {true, "EthBlindSign", true, true},
+    {true, "EthBlindSign", true, false},
 };
 
 int run_policy_compile_output(const CoinType *coin, const HDNode *root,


### PR DESCRIPTION
## Summary
- Add `EthBlindSign` and `SolBlindSign` policies to the policy table, both defaulting to **disabled**
- Add hard gate in `ethereum.c` — arbitrary contract data signing is blocked unless `EthBlindSign` is enabled on-device
- Users must explicitly enable via `ApplyPolicies` which requires on-device button confirmation + PIN

## Test plan
- [ ] Flash firmware, verify blind signing ETH contract data is rejected by default
- [ ] Enable `EthBlindSign` via ApplyPolicies, confirm device prompts for button + PIN
- [ ] After enabling, verify ETH contract data signing works
- [ ] Verify `SolBlindSign` policy is present and defaults to disabled