### PR TITLE
feat(bip85): display-only mode — never send seed over USB

### DIFF
--- a/lib/firmware/fsm_msg_bip85.h
+++ b/lib/firmware/fsm_msg_bip85.h
@@ -80,6 +80,8 @@ void fsm_msgGetBip85Mnemonic(const GetBip85Mnemonic *msg) {
       if (MAX_PAGES <= page_count) {
         memzero(tokened_mnemonic, sizeof(tokened_mnemonic));
         memzero(formatted_mnemonic, sizeof(formatted_mnemonic));
+        memzero(mnemonic_display, sizeof(mnemonic_display));
+        memzero(formatted_word, sizeof(formatted_word));
         fsm_sendFailure(FailureType_Failure_Other,
                         "Too many pages of mnemonic words");
         layoutHome();
@@ -118,6 +120,8 @@ void fsm_msgGetBip85Mnemonic(const GetBip85Mnemonic *msg) {
             formatted_mnemonic[current_page])) {
       memzero(tokened_mnemonic, sizeof(tokened_mnemonic));
       memzero(formatted_mnemonic, sizeof(formatted_mnemonic));
+      memzero(mnemonic_display, sizeof(mnemonic_display));
+      memzero(formatted_word, sizeof(formatted_word));
       display_constant_power(false);
       fsm_sendFailure(FailureType_Failure_ActionCancelled,
                       "BIP-85 display cancelled");

--- a/lib/firmware/fsm_msg_bip85.h
+++ b/lib/firmware/fsm_msg_bip85.h
@@ -19,14 +19,14 @@ void fsm_msgGetBip85Mnemonic(const GetBip85Mnemonic *msg) {
 
   CHECK_PIN
 
-  /* User confirmation — make clear a secret is being exported */
+  /* User confirmation */
   char desc[80];
   snprintf(desc, sizeof(desc),
-           "Export %lu-word child seed at index %lu to host?",
+           "Derive %lu-word child seed at index %lu?",
            (unsigned long)msg->word_count, (unsigned long)msg->index);
 
   if (!confirm(ButtonRequestType_ButtonRequest_Other,
-               "BIP-85 Export Seed", "%s", desc)) {
+               "BIP-85 Derive Seed", "%s", desc)) {
     fsm_sendFailure(FailureType_Failure_ActionCancelled,
                     "BIP-85 derivation cancelled");
     layoutHome();
@@ -46,22 +46,95 @@ void fsm_msgGetBip85Mnemonic(const GetBip85Mnemonic *msg) {
     return;
   }
 
-  /* Second confirmation before sending secret to host */
-  if (!confirm(ButtonRequestType_ButtonRequest_Other,
-               "Send to Computer?",
-               "The child seed will be sent to the connected computer. Continue?")) {
-    memzero(mnemonic_buf, sizeof(mnemonic_buf));
-    fsm_sendFailure(FailureType_Failure_ActionCancelled,
-                    "BIP-85 export cancelled");
-    layoutHome();
-    return;
-  }
+  /*
+   * Display mnemonic on device screen only — never send over USB.
+   * Uses the same paginated display as the backup flow in reset.c.
+   */
+  uint32_t word_count = 0, page_count = 0;
+  static char CONFIDENTIAL tokened_mnemonic[TOKENED_MNEMONIC_BUF];
+  static char CONFIDENTIAL formatted_mnemonic[MAX_PAGES][FORMATTED_MNEMONIC_BUF];
+  static char CONFIDENTIAL mnemonic_display[FORMATTED_MNEMONIC_BUF];
+  static char CONFIDENTIAL formatted_word[MAX_WORD_LEN + ADDITIONAL_WORD_PAD];
 
-  /* Send response */
-  RESP_INIT(Bip85Mnemonic);
-  strlcpy(resp->mnemonic, mnemonic_buf, sizeof(resp->mnemonic));
+  strlcpy(tokened_mnemonic, mnemonic_buf, TOKENED_MNEMONIC_BUF);
   memzero(mnemonic_buf, sizeof(mnemonic_buf));
 
-  msg_write(MessageType_MessageType_Bip85Mnemonic, resp);
+  /* Clear formatting buffers */
+  memzero(formatted_mnemonic, sizeof(formatted_mnemonic));
+  memzero(mnemonic_display, sizeof(mnemonic_display));
+
+  char *tok = strtok(tokened_mnemonic, " ");
+
+  while (tok) {
+    snprintf(formatted_word, MAX_WORD_LEN + ADDITIONAL_WORD_PAD,
+             (word_count & 1) ? "%lu.%s\n" : "%lu.%s",
+             (unsigned long)(word_count + 1), tok);
+
+    /* Check that we have enough room on display to show word */
+    snprintf(mnemonic_display, FORMATTED_MNEMONIC_BUF, "%s   %s",
+             formatted_mnemonic[page_count], formatted_word);
+
+    if (calc_str_line(get_body_font(), mnemonic_display, BODY_WIDTH) > 3) {
+      page_count++;
+
+      if (MAX_PAGES <= page_count) {
+        memzero(tokened_mnemonic, sizeof(tokened_mnemonic));
+        memzero(formatted_mnemonic, sizeof(formatted_mnemonic));
+        fsm_sendFailure(FailureType_Failure_Other,
+                        "Too many pages of mnemonic words");
+        layoutHome();
+        return;
+      }
+
+      snprintf(mnemonic_display, FORMATTED_MNEMONIC_BUF, "%s   %s",
+               formatted_mnemonic[page_count], formatted_word);
+    }
+
+    strlcpy(formatted_mnemonic[page_count], mnemonic_display,
+            FORMATTED_MNEMONIC_BUF);
+
+    tok = strtok(NULL, " ");
+    word_count++;
+  }
+
+  /* Switch from 0-indexing to 1-indexing */
+  page_count++;
+
+  display_constant_power(true);
+
+  /* Show each page of the mnemonic on screen */
+  for (uint32_t current_page = 0; current_page < page_count; current_page++) {
+    char title[MEDIUM_STR_BUF];
+
+    if (page_count > 1) {
+      snprintf(title, MEDIUM_STR_BUF, "BIP-85 Seed %" PRIu32 "/%" PRIu32,
+               current_page + 1, page_count);
+    } else {
+      snprintf(title, MEDIUM_STR_BUF, "BIP-85 Seed");
+    }
+
+    if (!confirm_constant_power(
+            ButtonRequestType_ButtonRequest_ConfirmWord, title, "%s",
+            formatted_mnemonic[current_page])) {
+      memzero(tokened_mnemonic, sizeof(tokened_mnemonic));
+      memzero(formatted_mnemonic, sizeof(formatted_mnemonic));
+      display_constant_power(false);
+      fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                      "BIP-85 display cancelled");
+      layoutHome();
+      return;
+    }
+  }
+
+  display_constant_power(false);
+
+  /* Wipe all sensitive buffers */
+  memzero(tokened_mnemonic, sizeof(tokened_mnemonic));
+  memzero(formatted_mnemonic, sizeof(formatted_mnemonic));
+  memzero(mnemonic_display, sizeof(mnemonic_display));
+  memzero(formatted_word, sizeof(formatted_word));
+
+  /* Send success — mnemonic is NOT sent over the wire */
+  fsm_sendSuccess("BIP-85 seed displayed on device");
   layoutHome();
 }


### PR DESCRIPTION
## Summary
- BIP-85 derived mnemonics are now displayed on the KeepKey OLED screen using the same paginated layout as the backup/recovery flow
- The mnemonic is **never transmitted over USB** to the host computer
- Device returns `Success` instead of `Bip85Mnemonic` response after user confirms all pages on screen
- All sensitive buffers (`CONFIDENTIAL`) are zeroed after use

## What changed
- `lib/firmware/fsm_msg_bip85.h`: Replaced USB mnemonic export with on-device paginated display
  - Reuses `reset.h` formatting constants (`TOKENED_MNEMONIC_BUF`, `MAX_PAGES`, `FORMATTED_MNEMONIC_BUF`, etc.)
  - Uses `confirm_constant_power()` for each page (same as backup flow in `reset.c`)
  - Words are numbered and paginated to fit the 256x64 OLED (max 3 lines per page)

## Security improvement
Previously, the BIP-85 flow sent the derived child seed over USB to the host. Even with two on-device confirmations, the seed was exposed to any malware on the host machine. Now the seed never leaves the device — it's shown on screen for the user to write down manually, identical to how the primary seed backup works.

## Test plan
- [ ] Trigger `GetBip85Mnemonic` with 12, 18, and 24 word counts
- [ ] Verify words display correctly on device screen (paginated)
- [ ] Verify host receives `Success` (not `Bip85Mnemonic` with seed)
- [ ] Verify cancelling on any page sends `Failure` and clears buffers
- [ ] Verify PIN is required before derivation