### PR TITLE
fix: unify blind-sign gating under AdvancedMode

### DIFF
--- a/build-evm-clear-signing/lib/transport/messages-ton.options
+++ b/build-evm-clear-signing/lib/transport/messages-ton.options
@@ -1,0 +1,13 @@
+TonGetAddress.address_n max_count:8
+TonGetAddress.coin_name max_size:21
+
+TonAddress.address max_size:50
+TonAddress.raw_address max_size:70
+
+TonSignTx.address_n max_count:8
+TonSignTx.coin_name max_size:21
+TonSignTx.raw_tx max_size:1024
+TonSignTx.to_address max_size:50
+
+TonSignTx.memo max_size:121
+TonSignedTx.signature max_size:64

--- a/build-evm-clear-signing/lib/transport/messages-ton.proto
+++ b/build-evm-clear-signing/lib/transport/messages-ton.proto
@@ -1,0 +1,62 @@
+/*
+ * Messages (TON specific) for KeepKey Communication
+ *
+ */
+
+syntax = "proto2";
+
+// Sugar for easier handling in Java
+option java_package = "com.keepkey.deviceprotocol";
+option java_outer_classname = "KeepKeyMessageTon";
+
+/**
+ * Request: Ask device for TON address corresponding to address_n path
+ * @next PassphraseRequest
+ * @next TonAddress
+ * @next Failure
+ */
+message TonGetAddress {
+    repeated uint32 address_n = 1;                // BIP-32 path to derive the key from master node
+    optional string coin_name = 2 [default='Ton'];
+    optional bool show_display = 3;               // optionally show on display before sending the result
+    optional bool bounceable = 4 [default=true];  // bounceable flag for address encoding
+    optional bool testnet = 5 [default=false];    // testnet flag for address encoding
+    optional sint32 workchain = 6 [default=0];    // workchain ID (-1 or 0)
+}
+
+/**
+ * Response: Contains a TON address derived from device private seed
+ * @prev TonGetAddress
+ */
+message TonAddress {
+    optional string address = 1;                  // TON address in user-friendly Base64 encoding
+    optional string raw_address = 2;              // TON address in raw format (workchain:hash)
+}
+
+/**
+ * Request: ask device to sign TON transaction
+ * @start
+ * @next TonSignedTx
+ */
+message TonSignTx {
+    repeated uint32 address_n = 1;                // BIP-32 path to derive the key from master node
+    optional string coin_name = 2 [default='Ton'];
+    optional bytes raw_tx = 3;                    // Raw transaction data (serialized by client)
+    optional uint32 expire_at = 4;                // Transaction expiration timestamp
+    optional uint32 seqno = 5;                    // Wallet sequence number
+    optional sint32 workchain = 6 [default=0];    // Workchain ID (-1 or 0)
+    optional string to_address = 7;               // Destination address (for display)
+    optional uint64 amount = 8;                   // Transfer amount in nanoTON (for display)
+    // Clear-signing fields
+    optional bool bounce = 9;                     // Message bounce flag
+    optional string memo = 10;                    // Optional text memo/comment
+    optional bool is_deploy = 11;                 // True if wallet needs StateInit (first tx)
+}
+
+/**
+ * Response: signature for transaction
+ * @end
+ */
+message TonSignedTx {
+    optional bytes signature = 1;                 // Ed25519 signature (64 bytes)
+}

--- a/include/keepkey/firmware/policy.h
+++ b/include/keepkey/firmware/policy.h
@@ -32,8 +32,6 @@ static const PolicyType policies[] = {
     {true, "Pin Caching", true, true},
     {true, "Experimental", true, false},
     {true, "AdvancedMode", true, false},
-    {true, "SolBlindSign", true, false},
-    {true, "EthBlindSign", true, true},
 };
 
 int run_policy_compile_output(const CoinType *coin, const HDNode *root,

--- a/include/keepkey/firmware/ton.h
+++ b/include/keepkey/firmware/ton.h
@@ -73,4 +73,31 @@ void ton_formatAmount(char *buf, size_t len, uint64_t amount);
  */
 bool ton_signTx(const HDNode *node, const TonSignTx *msg, TonSignedTx *resp);
 
+/**
+ * Validate a TON user-friendly address (Base64 URL-safe with CRC16).
+ * @param address  Base64 URL-safe encoded TON address (48 chars)
+ * @return true if address is valid
+ */
+bool ton_validateAddress(const char *address);
+
+/**
+ * Verify a v4r2 transfer body hash by reconstructing it from structured fields.
+ * Returns true if the computed hash matches expected_hash (32 bytes).
+ *
+ * @param to_address   User-friendly base64 TON address (48 chars)
+ * @param amount       Transfer amount in nanoTON
+ * @param seqno        Wallet sequence number
+ * @param expire_at    Expiration timestamp
+ * @param bounce       Message bounce flag
+ * @param memo         Optional text memo (NULL or "" for none)
+ * @param memo_len     Length of memo string
+ * @param expected_hash  32-byte hash to verify against
+ * @return true if computed hash matches expected_hash
+ */
+bool ton_verify_transfer_hash(
+    const char *to_address, uint64_t amount,
+    uint32_t seqno, uint32_t expire_at, bool bounce,
+    const char *memo, size_t memo_len,
+    const uint8_t *expected_hash);
+
 #endif

--- a/lib/firmware/ethereum.c
+++ b/lib/firmware/ethereum.c
@@ -755,24 +755,15 @@ void ethereum_signing_init(EthereumSignTx *msg, const HDNode *node,
 
   memset(confirm_body_message, 0, sizeof(confirm_body_message));
   if (token == NULL && data_total > 0 && data_needs_confirm) {
-    // EthBlindSign policy: hard gate when disabled
-    if (!storage_isPolicyEnabled("EthBlindSign")) {
+    // AdvancedMode policy: hard gate for blind-signing arbitrary contract data
+    if (!storage_isPolicyEnabled("AdvancedMode")) {
       (void)review(ButtonRequestType_ButtonRequest_Other, "Blocked",
-                   "Blind signing is disabled. Enable "
-                   "'EthBlindSign' policy to allow.");
+                   "Blind signing requires AdvancedMode. "
+                   "Enable in device settings.");
       fsm_sendFailure(FailureType_Failure_ActionCancelled,
                       "Blind signing disabled by policy");
       ethereum_signing_abort();
       return;
-    }
-
-    // KeepKey custom: warn the user that they're trying to do something
-    // that is potentially dangerous.
-    if (!storage_isPolicyEnabled("AdvancedMode")) {
-      (void)review(
-          ButtonRequestType_ButtonRequest_Other, "Warning",
-          "Signing of arbitrary ETH contract data is recommended only for "
-          "experienced users. Enable 'AdvancedMode' policy to dismiss.");
     }
 
     layoutEthereumData(msg->data_initial_chunk.bytes,

--- a/lib/firmware/fsm_msg_solana.h
+++ b/lib/firmware/fsm_msg_solana.h
@@ -412,10 +412,10 @@ void fsm_msgSolanaSignTx(const SolanaSignTx *msg) {
         }
     } else if (review == SOL_TX_REVIEW_OPAQUE) {
         /* Unsupported or opaque message: allow explicit blind-sign only. */
-        if (!storage_isPolicyEnabled("SolBlindSign")) {
+        if (!storage_isPolicyEnabled("AdvancedMode")) {
             memzero(node, sizeof(*node));
             fsm_sendFailure(FailureType_Failure_Other,
-                            _("Solana blind signing is disabled"));
+                            _("Enable AdvancedMode to blind-sign"));
             layoutHome();
             return;
         }

--- a/lib/firmware/fsm_msg_ton.h
+++ b/lib/firmware/fsm_msg_ton.h
@@ -145,8 +145,12 @@ void fsm_msgTonSignTx(TonSignTx *msg) {
   }
 
   // Determine clear-sign vs blind-sign mode
+  // Deploy txs (is_deploy=true) include StateInit which changes the cell tree;
+  // firmware cannot reconstruct that, so deploy always uses blind-sign.
+  bool is_deploy = msg->has_is_deploy && msg->is_deploy;
   bool clear_sign = false;
-  if (msg->has_to_address && msg->has_amount &&
+  if (!is_deploy &&
+      msg->has_to_address && msg->has_amount &&
       msg->has_seqno && msg->has_expire_at &&
       msg->raw_tx.size == 32) {
     // All clear-sign fields present and raw_tx is a 32-byte hash — attempt verification
@@ -204,9 +208,11 @@ void fsm_msgTonSignTx(TonSignTx *msg) {
       }
     }
 
+    const char *blind_msg = is_deploy
+        ? "Wallet deployment TX\ncannot be verified on\ndevice. Sign only if you\ntrust the sending app."
+        : "TON TX details cannot be\nverified on device.\nSign only if you trust\nthe sending app.";
     if (!confirm(ButtonRequestType_ButtonRequest_SignTx, "Blind Signature",
-                 "TON TX details cannot be\nverified on device.\n"
-                 "Sign only if you trust\nthe sending app.")) {
+                 "%s", blind_msg)) {
       memzero(node, sizeof(*node));
       fsm_sendFailure(FailureType_Failure_ActionCancelled,
                       _("Signing cancelled"));

--- a/lib/firmware/fsm_msg_ton.h
+++ b/lib/firmware/fsm_msg_ton.h
@@ -110,7 +110,6 @@ void fsm_msgTonSignTx(TonSignTx *msg) {
     return;
   }
 
-
   // Derive node using Ed25519 curve
   HDNode *node = fsm_getDerivedNode(ED25519_NAME, msg->address_n,
                                     msg->address_n_count, NULL);
@@ -134,10 +133,7 @@ void fsm_msgTonSignTx(TonSignTx *msg) {
     return;
   }
 
-  // TON uses Cell/BoC encoding which cannot be parsed on-device.
-  // Display host-supplied fields with explicit blind-sign warning.
-
-  // Validate destination address if provided (independent of amount)
+  // Validate destination address if provided
   if (msg->has_to_address) {
     if (!ton_validateAddress(msg->to_address)) {
       memzero(node, sizeof(*node));
@@ -148,8 +144,25 @@ void fsm_msgTonSignTx(TonSignTx *msg) {
     }
   }
 
-  // Show transfer details if both destination and amount are provided
-  if (msg->has_to_address && msg->has_amount) {
+  // Determine clear-sign vs blind-sign mode
+  bool clear_sign = false;
+  if (msg->has_to_address && msg->has_amount &&
+      msg->has_seqno && msg->has_expire_at &&
+      msg->raw_tx.size == 32) {
+    // All clear-sign fields present and raw_tx is a 32-byte hash — attempt verification
+    bool bounce = msg->has_bounce ? msg->bounce : true;
+    const char *memo = (msg->has_memo && msg->memo[0] != '\0') ? msg->memo : NULL;
+    size_t memo_len = memo ? strlen(memo) : 0;
+
+    clear_sign = ton_verify_transfer_hash(
+        msg->to_address, msg->amount,
+        msg->seqno, msg->expire_at, bounce,
+        memo, memo_len,
+        msg->raw_tx.bytes);
+  }
+
+  if (clear_sign) {
+    // ── Clear-sign: verified fields match raw_tx hash ──────────────
     char amount_str[32];
     ton_formatAmount(amount_str, sizeof(amount_str), msg->amount);
 
@@ -162,18 +175,44 @@ void fsm_msgTonSignTx(TonSignTx *msg) {
       layoutHome();
       return;
     }
-  }
 
-  // Always require explicit blind-sign acknowledgment — TON Cell/BoC
-  // encoding cannot be verified on-device
-  if (!confirm(ButtonRequestType_ButtonRequest_SignTx, "Blind Signature",
-               "TON TX details cannot be\nverified on device.\n"
-               "Sign only if you trust\nthe sending app.")) {
-    memzero(node, sizeof(*node));
-    fsm_sendFailure(FailureType_Failure_ActionCancelled,
-                    _("Signing cancelled"));
-    layoutHome();
-    return;
+    // Show memo if present
+    if (msg->has_memo && msg->memo[0] != '\0') {
+      if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
+                   "Memo", "%s", msg->memo)) {
+        memzero(node, sizeof(*node));
+        fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                        _("Signing cancelled"));
+        layoutHome();
+        return;
+      }
+    }
+  } else {
+    // ── Blind-sign: show fields if available + explicit warning ─────
+    if (msg->has_to_address && msg->has_amount) {
+      char amount_str[32];
+      ton_formatAmount(amount_str, sizeof(amount_str), msg->amount);
+
+      if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
+                   "TON Transfer", "Send %s to\n%s?",
+                   amount_str, msg->to_address)) {
+        memzero(node, sizeof(*node));
+        fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                        _("Signing cancelled"));
+        layoutHome();
+        return;
+      }
+    }
+
+    if (!confirm(ButtonRequestType_ButtonRequest_SignTx, "Blind Signature",
+                 "TON TX details cannot be\nverified on device.\n"
+                 "Sign only if you trust\nthe sending app.")) {
+      memzero(node, sizeof(*node));
+      fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                      _("Signing cancelled"));
+      layoutHome();
+      return;
+    }
   }
 
   // Sign the transaction with Ed25519

--- a/lib/firmware/ton.c
+++ b/lib/firmware/ton.c
@@ -282,6 +282,253 @@ void ton_formatAmount(char *buf, size_t len, uint64_t amount) {
   bn_format(&val, NULL, " TON", TON_DECIMALS, 0, false, buf, len);
 }
 
+// ── Bit-level writer for cell construction ──────────────────────────
+
+typedef struct {
+  uint8_t buf[256]; // max 2048 bits
+  uint16_t len;     // bits written
+} BitWriter;
+
+static void bw_init(BitWriter *w) {
+  memset(w->buf, 0, sizeof(w->buf));
+  w->len = 0;
+}
+
+static void bw_write_bit(BitWriter *w, bool v) {
+  if (v) w->buf[w->len >> 3] |= (0x80 >> (w->len & 7));
+  w->len++;
+}
+
+static void bw_write_uint(BitWriter *w, uint64_t value, int bits) {
+  for (int i = bits - 1; i >= 0; i--) {
+    bw_write_bit(w, (value >> i) & 1);
+  }
+}
+
+static void bw_write_bytes(BitWriter *w, const uint8_t *data, size_t len) {
+  for (size_t i = 0; i < len; i++) bw_write_uint(w, data[i], 8);
+}
+
+static void bw_write_coins(BitWriter *w, uint64_t amount) {
+  if (amount == 0) { bw_write_uint(w, 0, 4); return; }
+  int byte_len = 0;
+  uint64_t v = amount;
+  while (v > 0) { byte_len++; v >>= 8; }
+  bw_write_uint(w, byte_len, 4);
+  for (int i = byte_len - 1; i >= 0; i--) {
+    bw_write_uint(w, (amount >> (i * 8)) & 0xFF, 8);
+  }
+}
+
+/** Get augmented byte length and apply completion tag */
+static size_t bw_augmented(BitWriter *w, uint8_t *out, size_t out_len) {
+  size_t byte_len = (w->len + 7) / 8;
+  if (byte_len > out_len) return 0;
+  memcpy(out, w->buf, byte_len);
+  if (w->len % 8 != 0) {
+    out[byte_len - 1] |= (0x80 >> (w->len & 7));
+  }
+  return byte_len;
+}
+
+/** Compute cell representation hash: SHA256(d1 || d2 || data [|| ref_depths || ref_hashes]) */
+static void cell_hash(const BitWriter *bits, const uint8_t ref_hashes[][32],
+                       const uint16_t *ref_depths, int ref_count, uint8_t *out) {
+  uint8_t d1 = (uint8_t)ref_count;
+  uint8_t d2 = (uint8_t)((bits->len + 7) / 8 + bits->len / 8);
+
+  uint8_t aug_data[256];
+  size_t aug_len = (bits->len + 7) / 8;
+  memcpy(aug_data, bits->buf, aug_len);
+  if (bits->len % 8 != 0) {
+    aug_data[aug_len - 1] |= (0x80 >> (bits->len & 7));
+  }
+
+  SHA256_CTX ctx;
+  sha256_Init(&ctx);
+  sha256_Update(&ctx, &d1, 1);
+  sha256_Update(&ctx, &d2, 1);
+  sha256_Update(&ctx, aug_data, aug_len);
+
+  for (int i = 0; i < ref_count; i++) {
+    uint8_t depth_be[2] = { (ref_depths[i] >> 8) & 0xFF, ref_depths[i] & 0xFF };
+    sha256_Update(&ctx, depth_be, 2);
+  }
+  for (int i = 0; i < ref_count; i++) {
+    sha256_Update(&ctx, ref_hashes[i], 32);
+  }
+  sha256_Final(&ctx, out);
+}
+
+// ── Base64 URL-safe decode ──────────────────────────────────────────
+
+static int b64url_decode_char(char c) {
+  if (c >= 'A' && c <= 'Z') return c - 'A';
+  if (c >= 'a' && c <= 'z') return c - 'a' + 26;
+  if (c >= '0' && c <= '9') return c - '0' + 52;
+  if (c == '-' || c == '+') return 62;
+  if (c == '_' || c == '/') return 63;
+  return -1;
+}
+
+static bool base64_url_decode(const char *in, size_t in_len, uint8_t *out, size_t *out_len) {
+  size_t max_out = *out_len;
+  size_t j = 0;
+
+  // Process groups of 4 characters
+  for (size_t i = 0; i < in_len; ) {
+    int vals[4] = {0, 0, 0, 0};
+    int count = 0;
+    for (int k = 0; k < 4 && i < in_len; k++, i++) {
+      if (in[i] == '=') continue;
+      vals[k] = b64url_decode_char(in[i]);
+      if (vals[k] < 0) return false;
+      count = k + 1;
+    }
+    if (count >= 2 && j < max_out) out[j++] = (vals[0] << 2) | (vals[1] >> 4);
+    if (count >= 3 && j < max_out) out[j++] = ((vals[1] & 0xF) << 4) | (vals[2] >> 2);
+    if (count >= 4 && j < max_out) out[j++] = ((vals[2] & 0x3) << 6) | vals[3];
+  }
+  *out_len = j;
+  return true;
+}
+
+/**
+ * Validate a TON user-friendly address (Base64 URL-safe, 48 chars → 36 bytes)
+ */
+bool ton_validateAddress(const char *address) {
+  size_t addr_len = strlen(address);
+  if (addr_len < 46 || addr_len > 48) return false;
+
+  uint8_t raw[36];
+  size_t raw_len = sizeof(raw);
+  if (!base64_url_decode(address, addr_len, raw, &raw_len)) return false;
+  if (raw_len != 36) return false;
+
+  uint16_t expected_crc = (raw[34] << 8) | raw[35];
+  uint16_t actual_crc = ton_crc16(raw, 34);
+  return expected_crc == actual_crc;
+}
+
+/**
+ * Parse a TON user-friendly address → workchain + 32-byte hash
+ */
+static bool ton_parse_address(const char *address, int8_t *workchain, uint8_t *hash) {
+  size_t addr_len = strlen(address);
+  uint8_t raw[36];
+  size_t raw_len = sizeof(raw);
+  if (!base64_url_decode(address, addr_len, raw, &raw_len)) return false;
+  if (raw_len != 36) return false;
+
+  uint16_t expected_crc = (raw[34] << 8) | raw[35];
+  uint16_t actual_crc = ton_crc16(raw, 34);
+  if (expected_crc != actual_crc) return false;
+
+  *workchain = (int8_t)raw[1];
+  memcpy(hash, raw + 2, 32);
+  return true;
+}
+
+/**
+ * Verify a v4r2 transfer body hash by reconstructing it from structured fields.
+ * Reproduces the exact same cell tree as the host-side buildUnsignedBody().
+ */
+bool ton_verify_transfer_hash(
+    const char *to_address, uint64_t amount,
+    uint32_t seqno, uint32_t expire_at, bool bounce,
+    const char *memo, size_t memo_len,
+    const uint8_t *expected_hash) {
+
+  // Parse destination address
+  int8_t dest_wc;
+  uint8_t dest_hash[32];
+  if (!ton_parse_address(to_address, &dest_wc, dest_hash)) return false;
+
+  // ── Build memo body cell (if present) ────────────────────────────
+  uint8_t memo_cell_hash[32];
+  uint16_t memo_cell_depth = 0;
+  bool has_memo = (memo != NULL && memo_len > 0);
+
+  if (has_memo) {
+    BitWriter memo_bits;
+    bw_init(&memo_bits);
+    bw_write_uint(&memo_bits, 0, 32); // op = 0 (text comment)
+    bw_write_bytes(&memo_bits, (const uint8_t *)memo, memo_len);
+    cell_hash(&memo_bits, NULL, NULL, 0, memo_cell_hash);
+  }
+
+  // ── Build internal message cell ──────────────────────────────────
+  BitWriter im_bits;
+  bw_init(&im_bits);
+
+  bw_write_bit(&im_bits, false);  // int_msg_info tag = 0
+  bw_write_bit(&im_bits, true);   // ihr_disabled
+  bw_write_bit(&im_bits, bounce); // bounce
+  bw_write_bit(&im_bits, false);  // bounced
+  bw_write_uint(&im_bits, 0, 2);  // src = addr_none
+
+  // dest = addr_std$10 + no anycast + workchain(8) + hash(256)
+  bw_write_uint(&im_bits, 2, 2);  // addr_std tag
+  bw_write_bit(&im_bits, false);  // no anycast
+  bw_write_uint(&im_bits, (uint8_t)dest_wc, 8);
+  bw_write_bytes(&im_bits, dest_hash, 32);
+
+  bw_write_coins(&im_bits, amount);
+  bw_write_bit(&im_bits, false);  // no extra_currencies
+  bw_write_coins(&im_bits, 0);    // ihr_fee = 0
+  bw_write_coins(&im_bits, 0);    // fwd_fee = 0
+  bw_write_uint(&im_bits, 0, 64); // created_lt = 0
+  bw_write_uint(&im_bits, 0, 32); // created_at = 0
+  bw_write_bit(&im_bits, false);  // no StateInit
+
+  if (has_memo) {
+    bw_write_bit(&im_bits, true); // body is ref
+  } else {
+    bw_write_bit(&im_bits, false); // no body
+  }
+
+  uint8_t im_hash[32];
+  uint16_t im_depth;
+
+  if (has_memo) {
+    uint8_t ref_hashes[1][32];
+    memcpy(ref_hashes[0], memo_cell_hash, 32);
+    uint16_t ref_depths[1] = { memo_cell_depth };
+    cell_hash(&im_bits, ref_hashes, ref_depths, 1, im_hash);
+    im_depth = 1 + memo_cell_depth;
+  } else {
+    cell_hash(&im_bits, NULL, NULL, 0, im_hash);
+    im_depth = 0;
+  }
+
+  // ── Build unsigned body cell ─────────────────────────────────────
+  BitWriter ub_bits;
+  bw_init(&ub_bits);
+
+  bw_write_uint(&ub_bits, V4R2_WALLET_ID, 32); // wallet_id
+  bw_write_uint(&ub_bits, expire_at, 32);       // valid_until
+  bw_write_uint(&ub_bits, seqno, 32);           // seqno
+  bw_write_uint(&ub_bits, 0, 8);                // op = 0 (simple send)
+  bw_write_uint(&ub_bits, 3, 8);                // send_mode = 3
+
+  uint8_t ub_hash[32];
+  {
+    uint8_t ref_hashes[1][32];
+    memcpy(ref_hashes[0], im_hash, 32);
+    uint16_t ref_depths[1] = { im_depth };
+    cell_hash(&ub_bits, ref_hashes, ref_depths, 1, ub_hash);
+  }
+
+  // ── Compare with expected hash ───────────────────────────────────
+  bool match = (memcmp(ub_hash, expected_hash, 32) == 0);
+
+  // Clean up
+  memzero(&im_bits, sizeof(im_bits));
+  memzero(&ub_bits, sizeof(ub_bits));
+
+  return match;
+}
+
 /**
  * Sign a TON transaction with Ed25519
  */


### PR DESCRIPTION
## Summary
- Remove redundant `EthBlindSign` and `SolBlindSign` policies
- All blind-sign gates now use existing `AdvancedMode` — one toggle for all chains
- No storage migration needed (firmware not shipped with separate policies)

## Changes
- `ethereum.c`: EthBlindSign hard gate → AdvancedMode hard gate
- `fsm_msg_solana.h`: SolBlindSign → AdvancedMode
- `policy.h`: remove SolBlindSign + EthBlindSign entries

## Why
Three policies doing the same thing is confusing. AdvancedMode already exists and is the established pattern for "I know what I'm doing" operations. The per-chain policies were added in the EVM clear-signing branch but never shipped.

## Test plan
- [ ] ETH tx with calldata + AdvancedMode OFF → blocked
- [ ] ETH tx with calldata + AdvancedMode ON → shows data, proceeds
- [ ] SOL opaque tx + AdvancedMode OFF → blocked
- [ ] SOL opaque tx + AdvancedMode ON → blind-sign flow
- [ ] Existing python tests pass (tests already use AdvancedMode)