### PR TITLE
fix: unify blind-sign gating under AdvancedMode

### DIFF
--- a/include/keepkey/firmware/policy.h
+++ b/include/keepkey/firmware/policy.h
@@ -32,6 +32,8 @@ static const PolicyType policies[] = {
     {true, "Pin Caching", true, true},
     {true, "Experimental", true, false},
     {true, "AdvancedMode", true, false},
+    {true, "SolBlindSign", true, false},    // unused — AdvancedMode gates all blind-sign
+    {true, "EthBlindSign", true, false},    // unused — AdvancedMode gates all blind-sign
 };
 
 int run_policy_compile_output(const CoinType *coin, const HDNode *root,

--- a/include/keepkey/firmware/policy.h
+++ b/include/keepkey/firmware/policy.h
@@ -32,8 +32,6 @@ static const PolicyType policies[] = {
     {true, "Pin Caching", true, true},
     {true, "Experimental", true, false},
     {true, "AdvancedMode", true, false},
-    {true, "SolBlindSign", true, false},
-    {true, "EthBlindSign", true, false},
 };
 
 int run_policy_compile_output(const CoinType *coin, const HDNode *root,

--- a/lib/firmware/ethereum.c
+++ b/lib/firmware/ethereum.c
@@ -755,24 +755,15 @@ void ethereum_signing_init(EthereumSignTx *msg, const HDNode *node,
 
   memset(confirm_body_message, 0, sizeof(confirm_body_message));
   if (token == NULL && data_total > 0 && data_needs_confirm) {
-    // EthBlindSign policy: hard gate when disabled
-    if (!storage_isPolicyEnabled("EthBlindSign")) {
+    // AdvancedMode policy: hard gate for blind-signing arbitrary contract data
+    if (!storage_isPolicyEnabled("AdvancedMode")) {
       (void)review(ButtonRequestType_ButtonRequest_Other, "Blocked",
-                   "Blind signing is disabled. Enable "
-                   "'EthBlindSign' policy to allow.");
+                   "Blind signing requires AdvancedMode. "
+                   "Enable in device settings.");
       fsm_sendFailure(FailureType_Failure_ActionCancelled,
                       "Blind signing disabled by policy");
       ethereum_signing_abort();
       return;
-    }
-
-    // KeepKey custom: warn the user that they're trying to do something
-    // that is potentially dangerous.
-    if (!storage_isPolicyEnabled("AdvancedMode")) {
-      (void)review(
-          ButtonRequestType_ButtonRequest_Other, "Warning",
-          "Signing of arbitrary ETH contract data is recommended only for "
-          "experienced users. Enable 'AdvancedMode' policy to dismiss.");
     }
 
     layoutEthereumData(msg->data_initial_chunk.bytes,

--- a/lib/firmware/fsm_msg_solana.h
+++ b/lib/firmware/fsm_msg_solana.h
@@ -412,10 +412,10 @@ void fsm_msgSolanaSignTx(const SolanaSignTx *msg) {
         }
     } else if (review == SOL_TX_REVIEW_OPAQUE) {
         /* Unsupported or opaque message: allow explicit blind-sign only. */
-        if (!storage_isPolicyEnabled("SolBlindSign")) {
+        if (!storage_isPolicyEnabled("AdvancedMode")) {
             memzero(node, sizeof(*node));
             fsm_sendFailure(FailureType_Failure_Other,
-                            _("Solana blind signing is disabled"));
+                            _("Enable AdvancedMode to blind-sign"));
             layoutHome();
             return;
         }


### PR DESCRIPTION
## Summary
- Remove `EthBlindSign` and `SolBlindSign` policies — use `AdvancedMode` for all blind-sign gates
- 3 files, net -11 lines

## Changes
- `policy.h`: remove 2 entries
- `ethereum.c`: replace double-gate (EthBlindSign hard + AdvancedMode soft) with single AdvancedMode hard gate
- `fsm_msg_solana.h`: replace SolBlindSign with AdvancedMode

## Test plan
- [ ] ETH calldata + AdvancedMode OFF → "Blocked" + rejected
- [ ] ETH calldata + AdvancedMode ON → data shown, signing proceeds
- [ ] SOL opaque + AdvancedMode OFF → rejected
- [ ] SOL opaque + AdvancedMode ON → blind-sign proceeds
- [ ] All 342 passing python tests still pass (they already set AdvancedMode)