### PR TITLE
feat: show previous word number during recovery cipher

### DIFF
--- a/include/keepkey/firmware/app_layout.h
+++ b/include/keepkey/firmware/app_layout.h
@@ -119,7 +119,8 @@ void layout_ethereum_address_notification(const char *desc, const char *address,
 void layout_nano_address_notification(const char *desc, const char *address,
                                       NotificationType type);
 void layout_pin(const char *prompt, char *pin);
-void layout_cipher(const char *current_word, const char *cipher);
+void layout_cipher(const char *current_word, const char *cipher,
+                    const char *prev_word_info);
 void layout_address(const char *address, QRSize qr_size);
 void set_leaving_handler(leaving_handler_t leaving_func);
 

--- a/lib/firmware/app_layout.c
+++ b/lib/firmware/app_layout.c
@@ -704,12 +704,13 @@ void layout_cipher(const char *current_word, const char *cipher,
   call_leaving_handler();
   layout_clear();
 
-  /* Draw previous word info (small, top-right corner) */
+  /* Draw previous word info (small, top-left — must be x < 76 to avoid
+   * being wiped by cipher animation which clears x >= CIPHER_START_X) */
   if (prev_word_info && prev_word_info[0]) {
     sp.y = 2;
-    sp.x = 200;
+    sp.x = 4;
     sp.color = CIPHER_FONT_COLOR;  /* gray — less prominent than current word */
-    draw_string(canvas, title_font, prev_word_info, &sp, 56,
+    draw_string(canvas, title_font, prev_word_info, &sp, 68,
                 font_height(title_font));
   }
 

--- a/lib/firmware/app_layout.c
+++ b/lib/firmware/app_layout.c
@@ -695,13 +695,23 @@ void layout_pin(const char *str, char pin[]) {
  * OUTPUT
  *     none
  */
-void layout_cipher(const char *current_word, const char *cipher) {
+void layout_cipher(const char *current_word, const char *cipher,
+                    const char *prev_word_info) {
   DrawableParams sp;
   const Font *title_font = get_body_font();
   Canvas *canvas = layout_get_canvas();
 
   call_leaving_handler();
   layout_clear();
+
+  /* Draw previous word info (small, top-right corner) */
+  if (prev_word_info && prev_word_info[0]) {
+    sp.y = 2;
+    sp.x = 200;
+    sp.color = CIPHER_FONT_COLOR;  /* gray — less prominent than current word */
+    draw_string(canvas, title_font, prev_word_info, &sp, 56,
+                font_height(title_font));
+  }
 
   /* Draw prompt */
   sp.y = 11;

--- a/lib/firmware/recovery_cipher.c
+++ b/lib/firmware/recovery_cipher.c
@@ -376,8 +376,16 @@ void next_character(void) {
   format_current_word(word_pos, current_word, auto_completed, &formatted_word);
   memzero(current_word, sizeof(current_word));
 
+  /* Format previous word indicator (e.g. "prev:3" when entering word 4) */
+  static char prev_info[16];
+  if (word_pos > 0) {
+    snprintf(prev_info, sizeof(prev_info), "prev:%" PRIu32, word_pos);
+  } else {
+    prev_info[0] = '\0';
+  }
+
   /* Show cipher and partial word */
-  layout_cipher(formatted_word, cipher);
+  layout_cipher(formatted_word, cipher, prev_info);
   memzero(formatted_word, sizeof(formatted_word));
 }
 


### PR DESCRIPTION
## Summary

During cipher recovery, the device screen now shows "prev:N" in the top-right corner (gray text) indicating which word was last entered.

## Changes

- layout_cipher() takes new prev_word_info parameter
- Draws gray text at x=200, y=2
- recovery_cipher.c formats "prev:N" from word_pos
- Both main firmware and clear-signing submodule updated

## Test plan

- [ ] Recovery with 12/24-word seed
- [ ] Word 1 — no "prev:" shown
- [ ] Zoo test for new screen layout