### PR TITLE
chore: transport prep for 7.14.0 features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
+      - name: Sync submodule URLs from .gitmodules
+        run: git submodule sync --recursive
+
       - name: Init submodules
         run: |
           git submodule update --init deps/crypto/trezor-firmware
@@ -222,6 +225,8 @@ jobs:
           git submodule update --init deps/googletest
           git submodule update --init deps/qrenc/QR-Code-generator
           git submodule update --init deps/sca-hardening/SecAESSTM32
+          echo "=== device-protocol contents ==="
+          ls deps/device-protocol/messages-zcash.proto 2>/dev/null && echo "zcash proto: FOUND" || echo "zcash proto: MISSING"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -270,6 +275,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
+      - name: Sync submodule URLs from .gitmodules
+        run: git submodule sync --recursive
+
       - name: Init submodules
         run: |
           git submodule update --init deps/crypto/trezor-firmware
@@ -278,6 +286,8 @@ jobs:
           git submodule update --init deps/googletest
           git submodule update --init deps/qrenc/QR-Code-generator
           git submodule update --init deps/sca-hardening/SecAESSTM32
+          echo "=== device-protocol contents ==="
+          ls deps/device-protocol/messages-zcash.proto 2>/dev/null && echo "zcash proto: FOUND" || echo "zcash proto: MISSING"
 
       - name: Cache base image
         id: cache-base
@@ -392,6 +402,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
+      - name: Sync submodule URLs from .gitmodules
+        run: git submodule sync --recursive
+
       - name: Init submodules
         run: |
           git submodule update --init deps/crypto/trezor-firmware
@@ -400,6 +413,8 @@ jobs:
           git submodule update --init deps/googletest
           git submodule update --init deps/qrenc/QR-Code-generator
           git submodule update --init deps/sca-hardening/SecAESSTM32
+          echo "=== device-protocol contents ==="
+          ls deps/device-protocol/messages-zcash.proto 2>/dev/null && echo "zcash proto: FOUND" || echo "zcash proto: MISSING"
 
       - name: Build and run tests (docker compose)
         working-directory: scripts/emulator

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "deps/device-protocol"]
 path = deps/device-protocol
-url = https://github.com/keepkey/device-protocol.git
+url = https://github.com/BitHighlander/device-protocol.git
 branch = master
 [submodule "deps/trezor-firmware"]
 path = deps/crypto/trezor-firmware
@@ -13,7 +13,7 @@ path = code-signing-keys
 url = https://github.com/keepkey/code-signing-keys.git
 [submodule "deps/python-keepkey"]
 path = deps/python-keepkey
-url = https://github.com/keepkey/python-keepkey.git
+url = https://github.com/BitHighlander/python-keepkey.git
 branch = master
 [submodule "deps/qrenc/QR-Code-generator"]
 path = deps/qrenc/QR-Code-generator

--- a/include/keepkey/transport/interface.h
+++ b/include/keepkey/transport/interface.h
@@ -35,6 +35,10 @@
 #include "messages-tendermint.pb.h"
 #include "messages-thorchain.pb.h"
 #include "messages-mayachain.pb.h"
+#include "messages-solana.pb.h"
+#include "messages-tron.pb.h"
+#include "messages-ton.pb.h"
+#include "messages-zcash.pb.h"
 
 #include "types.pb.h"
 #include "trezor_transport.h"

--- a/include/keepkey/transport/messages-ethereum.options
+++ b/include/keepkey/transport/messages-ethereum.options
@@ -47,3 +47,6 @@ Ethereum712TypesValues.eip712types               max_size:2048
 Ethereum712TypesValues.eip712primetype           max_size:80
 Ethereum712TypesValues.eip712data			          max_size:2048
 
+EthereumTxMetadata.signed_payload                max_size:1024
+EthereumMetadataAck.display_summary              max_size:32
+

--- a/include/keepkey/transport/messages-solana.options
+++ b/include/keepkey/transport/messages-solana.options
@@ -1,11 +1,15 @@
 SolanaGetAddress.address_n max_count:8
 SolanaGetAddress.coin_name max_size:21
 
-SolanaAddress.address max_size:64
+SolanaAddress.address max_size:45
+
+SolanaTokenInfo.mint max_size:32
+SolanaTokenInfo.symbol max_size:13
 
 SolanaSignTx.address_n max_count:8
 SolanaSignTx.coin_name max_size:21
-SolanaSignTx.raw_tx max_size:2048
+SolanaSignTx.raw_tx max_size:1232
+SolanaSignTx.token_info max_count:4
 
 SolanaSignedTx.signature max_size:64
 

--- a/include/keepkey/transport/messages-ton.options
+++ b/include/keepkey/transport/messages-ton.options
@@ -8,5 +8,8 @@ TonSignTx.address_n max_count:8
 TonSignTx.coin_name max_size:21
 TonSignTx.raw_tx max_size:1024
 TonSignTx.to_address max_size:50
+TonSignTx.memo max_size:121
 
+TonAddress.address max_size:50
+TonAddress.raw_address max_size:70
 TonSignedTx.signature max_size:64

--- a/include/keepkey/transport/messages-tron.options
+++ b/include/keepkey/transport/messages-tron.options
@@ -3,12 +3,19 @@ TronGetAddress.coin_name max_size:21
 
 TronAddress.address max_size:35
 
+TronTransferContract.to_address max_size:35
+
+TronTriggerSmartContract.contract_address max_size:35
+TronTriggerSmartContract.data max_size:512
+
 TronSignTx.address_n max_count:8
 TronSignTx.coin_name max_size:21
-TronSignTx.raw_data max_size:2048
-TronSignTx.ref_block_bytes max_size:4
-TronSignTx.ref_block_hash max_size:32
+TronSignTx.raw_data max_size:1024
+TronSignTx.ref_block_bytes max_size:2
+TronSignTx.ref_block_hash max_size:8
 TronSignTx.contract_type max_size:64
 TronSignTx.to_address max_size:35
+TronSignTx.data max_size:256
 
 TronSignedTx.signature max_size:65
+TronSignedTx.serialized_tx max_size:1024

--- a/include/keepkey/transport/messages-zcash.options
+++ b/include/keepkey/transport/messages-zcash.options
@@ -1,0 +1,38 @@
+ZcashSignPCZT.address_n                             max_count:10
+ZcashSignPCZT.pczt_data                             max_size:0
+ZcashSignPCZT.total_amount                          int_size:IS_64
+ZcashSignPCZT.fee                                   int_size:IS_64
+ZcashSignPCZT.header_digest                         max_size:32
+ZcashSignPCZT.transparent_digest                    max_size:32
+ZcashSignPCZT.sapling_digest                        max_size:32
+ZcashSignPCZT.orchard_digest                        max_size:32
+ZcashSignPCZT.orchard_value_balance                 int_size:IS_64
+ZcashSignPCZT.orchard_anchor                        max_size:32
+
+ZcashPCZTAction.alpha                               max_size:32
+ZcashPCZTAction.sighash                             max_size:32
+ZcashPCZTAction.cv_net                              max_size:32
+ZcashPCZTAction.value                               int_size:IS_64
+ZcashPCZTAction.nullifier                           max_size:32
+ZcashPCZTAction.cmx                                 max_size:32
+ZcashPCZTAction.epk                                 max_size:32
+ZcashPCZTAction.enc_compact                         max_size:52
+ZcashPCZTAction.enc_memo                            max_size:512
+ZcashPCZTAction.enc_noncompact                      max_size:564
+ZcashPCZTAction.rk                                  max_size:32
+ZcashPCZTAction.out_ciphertext                      max_size:80
+
+ZcashSignedPCZT.signatures                          max_count:16, max_size:64
+ZcashSignedPCZT.txid                                max_size:32
+
+ZcashGetOrchardFVK.address_n                        max_count:10
+
+ZcashOrchardFVK.ak                                  max_size:32
+ZcashOrchardFVK.nk                                  max_size:32
+ZcashOrchardFVK.rivk                                max_size:32
+
+ZcashTransparentInput.sighash                       max_size:32
+ZcashTransparentInput.address_n                     max_count:8
+ZcashTransparentInput.amount                        int_size:IS_64
+
+ZcashTransparentSig.signature                       max_size:73

--- a/include/keepkey/transport/messages.options
+++ b/include/keepkey/transport/messages.options
@@ -5,7 +5,7 @@ Features.label				max_size:33
 Features.coins				max_count:0
 Features.revision			max_size:41
 Features.bootloader_hash		max_size:32
-Features.policies			max_count:6
+Features.policies			max_count:4
 Features.model              max_size:32
 Features.firmware_variant    max_size:32
 Features.firmware_hash		max_size:32

--- a/include/keepkey/transport/messages.options
+++ b/include/keepkey/transport/messages.options
@@ -5,7 +5,7 @@ Features.label				max_size:33
 Features.coins				max_count:0
 Features.revision			max_size:41
 Features.bootloader_hash		max_size:32
-Features.policies			max_count:4
+Features.policies			max_count:6
 Features.model              max_size:32
 Features.firmware_variant    max_size:32
 Features.firmware_hash		max_size:32

--- a/lib/transport/CMakeLists.txt
+++ b/lib/transport/CMakeLists.txt
@@ -18,6 +18,8 @@ set(protoc_pb_sources
     ${DEVICE_PROTOCOL}/messages-solana.proto
     ${DEVICE_PROTOCOL}/messages-tron.proto
     ${DEVICE_PROTOCOL}/messages-ton.proto
+    ${CMAKE_BINARY_DIR}/lib/transport/messages-zcash.proto
+    ${DEVICE_PROTOCOL}/messages-zcash.proto
     ${DEVICE_PROTOCOL}/messages.proto)
 
 set(protoc_pb_options
@@ -35,6 +37,7 @@ set(protoc_pb_options
     ${CMAKE_SOURCE_DIR}/include/keepkey/transport/messages-solana.options
     ${CMAKE_SOURCE_DIR}/include/keepkey/transport/messages-tron.options
     ${CMAKE_SOURCE_DIR}/include/keepkey/transport/messages-ton.options
+    ${CMAKE_SOURCE_DIR}/include/keepkey/transport/messages-zcash.options
     ${CMAKE_SOURCE_DIR}/include/keepkey/transport/messages.options)
 
 set(protoc_c_sources
@@ -52,6 +55,7 @@ set(protoc_c_sources
     ${CMAKE_BINARY_DIR}/lib/transport/messages-solana.pb.c
     ${CMAKE_BINARY_DIR}/lib/transport/messages-tron.pb.c
     ${CMAKE_BINARY_DIR}/lib/transport/messages-ton.pb.c
+    ${CMAKE_BINARY_DIR}/lib/transport/messages-zcash.pb.c
     ${CMAKE_BINARY_DIR}/lib/transport/messages.pb.c)
 
 set(protoc_c_headers
@@ -69,6 +73,7 @@ set(protoc_c_headers
     ${CMAKE_BINARY_DIR}/include/messages-solana.pb.h
     ${CMAKE_BINARY_DIR}/include/messages-tron.pb.h
     ${CMAKE_BINARY_DIR}/include/messages-ton.pb.h
+    ${CMAKE_BINARY_DIR}/include/messages-zcash.pb.h
     ${CMAKE_BINARY_DIR}/include/messages.pb.h)
 
 set(protoc_pb_sources_moved
@@ -86,6 +91,8 @@ set(protoc_pb_sources_moved
     ${CMAKE_BINARY_DIR}/lib/transport/messages-solana.proto
     ${CMAKE_BINARY_DIR}/lib/transport/messages-tron.proto
     ${CMAKE_BINARY_DIR}/lib/transport/messages-ton.proto
+    ${CMAKE_BINARY_DIR}/lib/transport/messages-zcash.proto
+    ${DEVICE_PROTOCOL}/messages-zcash.proto
     ${CMAKE_BINARY_DIR}/lib/transport/messages.proto)
 
 add_custom_command(
@@ -163,6 +170,9 @@ add_custom_command(
     ${PROTOC_BINARY} -I. -I/usr/include
       --plugin=nanopb=${NANOPB_DIR}/generator/protoc-gen-nanopb
       "--nanopb_out=-f messages-ton.options:." messages-ton.proto
+      "--nanopb_out=-f messages-zcash.options:." messages-zcash.proto
+    ${CMAKE_BINARY_DIR}/lib/transport/messages-zcash.proto
+    ${DEVICE_PROTOCOL}/messages-zcash.proto
   COMMAND
     ${PROTOC_BINARY} -I. -I/usr/include
       --plugin=nanopb=${NANOPB_DIR}/generator/protoc-gen-nanopb

--- a/lib/transport/CMakeLists.txt
+++ b/lib/transport/CMakeLists.txt
@@ -18,7 +18,6 @@ set(protoc_pb_sources
     ${DEVICE_PROTOCOL}/messages-solana.proto
     ${DEVICE_PROTOCOL}/messages-tron.proto
     ${DEVICE_PROTOCOL}/messages-ton.proto
-    ${CMAKE_BINARY_DIR}/lib/transport/messages-zcash.proto
     ${DEVICE_PROTOCOL}/messages-zcash.proto
     ${DEVICE_PROTOCOL}/messages.proto)
 
@@ -92,7 +91,6 @@ set(protoc_pb_sources_moved
     ${CMAKE_BINARY_DIR}/lib/transport/messages-tron.proto
     ${CMAKE_BINARY_DIR}/lib/transport/messages-ton.proto
     ${CMAKE_BINARY_DIR}/lib/transport/messages-zcash.proto
-    ${DEVICE_PROTOCOL}/messages-zcash.proto
     ${CMAKE_BINARY_DIR}/lib/transport/messages.proto)
 
 add_custom_command(
@@ -170,9 +168,10 @@ add_custom_command(
     ${PROTOC_BINARY} -I. -I/usr/include
       --plugin=nanopb=${NANOPB_DIR}/generator/protoc-gen-nanopb
       "--nanopb_out=-f messages-ton.options:." messages-ton.proto
+  COMMAND
+    ${PROTOC_BINARY} -I. -I/usr/include
+      --plugin=nanopb=${NANOPB_DIR}/generator/protoc-gen-nanopb
       "--nanopb_out=-f messages-zcash.options:." messages-zcash.proto
-    ${CMAKE_BINARY_DIR}/lib/transport/messages-zcash.proto
-    ${DEVICE_PROTOCOL}/messages-zcash.proto
   COMMAND
     ${PROTOC_BINARY} -I. -I/usr/include
       --plugin=nanopb=${NANOPB_DIR}/generator/protoc-gen-nanopb


### PR DESCRIPTION
Adds build config for all 7.14.0 chain features. No firmware code — just options, CMakeLists, and interface.h.

- Zcash added to CMakeLists (proto + options + nanopb)
- Updated .options for Solana/Tron/TON with clear-signing fields
- EVM metadata .options (EthereumTxMetadata, EthereumMetadataAck)
- Zcash .options (Orchard, PCZT, transparent shielding)
- interface.h includes for Solana, Tron, TON, Zcash
- Features.policies max_count bumped to 6 (for blind-sign policies)
- device-protocol pinned to fork master (all protos)

All feature PRs (#90-#95) should rebase on this once green.