### PR TITLE
fix: backport nanopb oneof memory leak fix

### DIFF
--- a/lib/transport/pb_decode.c
+++ b/lib/transport/pb_decode.c
@@ -452,14 +452,18 @@ static bool checkreturn decode_static_field(pb_istream_t *stream,
       }
 
     case PB_HTYPE_ONEOF:
-      *(pb_size_t *)iter->pSize = iter->pos->tag;
-      if (PB_LTYPE(type) == PB_LTYPE_SUBMESSAGE) {
+      if (PB_LTYPE(type) == PB_LTYPE_SUBMESSAGE &&
+                *(pb_size_t*)iter->pSize != iter->pos->tag)
+      {
         /* We memset to zero so that any callbacks are set to NULL.
-         * Then set any default values. */
+         * This is because the callbacks might otherwise have values
+         * from some other union field. */
         memset(iter->pData, 0, iter->pos->data_size);
         pb_message_set_to_defaults((const pb_field_t *)iter->pos->ptr,
                                    iter->pData);
       }
+      *(pb_size_t*)iter->pSize = iter->pos->tag;
+
       return func(stream, iter->pos, iter->pData);
 
     default:


### PR DESCRIPTION
Backport of upstream nanopb fix 4fe23595. Single function change in pb_decode.c. +7/-3, 1 file.