### PR TITLE
feat: show previous completed word during recovery cipher

### DIFF
--- a/lib/firmware/app_layout.c
+++ b/lib/firmware/app_layout.c
@@ -703,8 +703,18 @@ void layout_cipher(const char *current_word, const char *cipher) {
   call_leaving_handler();
   layout_clear();
 
-  /* Draw prompt */
-  sp.y = 11;
+  /* Draw previous word info at top-left — must be x < 76 to avoid
+   * being wiped by cipher animation which clears x >= CIPHER_START_X */
+  if (prev_word_info && prev_word_info[0]) {
+    sp.y = 2;
+    sp.x = 4;
+    sp.color = CIPHER_FONT_COLOR;  /* gray — less prominent than current word */
+    draw_string(canvas, title_font, prev_word_info, &sp, 68,
+                font_height(title_font));
+  }
+
+  /* Draw prompt — push down when prev word is shown */
+  sp.y = (prev_word_info && prev_word_info[0]) ? 14 : 11;
   sp.x = 4;
   sp.color = BODY_COLOR;
   draw_string(canvas, title_font, "Recovery Cipher:", &sp, 58,

--- a/lib/firmware/recovery_cipher.c
+++ b/lib/firmware/recovery_cipher.c
@@ -371,10 +371,26 @@ void next_character(void) {
   }
 #endif
 
+  /* Save word so we can show it as "prev" on next word.
+   * When auto-complete fires, current_word holds the full expanded word
+   * (e.g. "alcohol" not "alc"). Otherwise save the typed prefix. */
+  static char CONFIDENTIAL last_completed_word[12];
+  if (strlen(current_word) > 0) {
+    strlcpy(last_completed_word, current_word, sizeof(last_completed_word));
+  }
+
   /* Format current word and display it along with cipher */
   static char CONFIDENTIAL formatted_word[CURRENT_WORD_BUF + 10];
   format_current_word(word_pos, current_word, auto_completed, &formatted_word);
   memzero(current_word, sizeof(current_word));
+
+  /* Format previous word indicator (e.g. "(1.alcohol)" when entering word 2) */
+  static char prev_info[16];
+  prev_info[0] = '\0';
+  if (word_pos > 0 && last_completed_word[0]) {
+    snprintf(prev_info, sizeof(prev_info), "(%" PRIu32 ".%s)",
+             word_pos, last_completed_word);
+  }
 
   /* Show cipher and partial word */
   layout_cipher(formatted_word, cipher);


### PR DESCRIPTION
## Summary
- Display the full auto-completed previous word as `(N.word)` in the top-left of the OLED during cipher recovery
- Saves the expanded word from `attempt_auto_complete()` into a static buffer — the raw mnemonic only contains the typed prefix, so we capture the full BIP39 word before it is zeroed
- Recovery Cipher label shifts down 3px when prev word is present to avoid overlap
- Word 1 keeps the original tight layout (no prev word to show)

## Changed files
- `lib/firmware/recovery_cipher.c` — save auto-completed word, format as `(N.word)`
- `lib/firmware/app_layout.c` — draw prev word at y=2, shift prompt when present

## Test plan
- [x] Emulator build + 12-word recovery with real screenshots
- [x] All 12 words auto-complete and display correctly
- [x] Full word text shown (not truncated prefix)
- [x] No overlap with cipher animation (x < 76)