### PR TITLE
feat(zcash): display unified address on device with FVK verification

### DIFF
--- a/include/keepkey/firmware/app_confirm.h
+++ b/include/keepkey/firmware/app_confirm.h
@@ -50,6 +50,7 @@ bool confirm_cosmos_address(const char *desc, const char *address);
 bool confirm_osmosis_address(const char *desc, const char *address);
 bool confirm_ethereum_address(const char *desc, const char *address);
 bool confirm_nano_address(const char *desc, const char *address);
+bool confirm_zcash_address(const char *desc, const char *address);
 bool confirm_omni(ButtonRequestType button_request, const char *title,
                   const uint8_t *data, uint32_t size);
 bool confirm_data(ButtonRequestType button_request, const char *title,

--- a/include/keepkey/firmware/app_layout.h
+++ b/include/keepkey/firmware/app_layout.h
@@ -118,6 +118,8 @@ void layout_ethereum_address_notification(const char *desc, const char *address,
                                           NotificationType type);
 void layout_nano_address_notification(const char *desc, const char *address,
                                       NotificationType type);
+void layout_zcash_address_notification(const char *desc, const char *address,
+                                       NotificationType type);
 void layout_pin(const char *prompt, char *pin);
 void layout_cipher(const char *current_word, const char *cipher,
                     const char *prev_word_info);

--- a/include/keepkey/firmware/fsm.h
+++ b/include/keepkey/firmware/fsm.h
@@ -132,6 +132,7 @@ void fsm_msgTonSignTx(TonSignTx *msg);
 void fsm_msgZcashSignPCZT(const ZcashSignPCZT *msg);
 void fsm_msgZcashPCZTAction(const ZcashPCZTAction *msg);
 void fsm_msgZcashGetOrchardFVK(const ZcashGetOrchardFVK *msg);
+void fsm_msgZcashDisplayAddress(const ZcashDisplayAddress *msg);
 #endif // BITCOIN_ONLY
 
 #if DEBUG_LINK
@@ -150,6 +151,7 @@ void fsm_msgZcashSignPCZT(const ZcashSignPCZT *msg);
 void fsm_msgZcashPCZTAction(const ZcashPCZTAction *msg);
 void fsm_msgZcashGetOrchardFVK(const ZcashGetOrchardFVK *msg);
 void fsm_msgZcashTransparentInput(const ZcashTransparentInput *msg);
+void fsm_msgZcashDisplayAddress(const ZcashDisplayAddress *msg);
 void fsm_msgTonGetAddress(const TonGetAddress *msg);
 void fsm_msgTonSignTx(TonSignTx *msg);
 void fsm_msgTronGetAddress(const TronGetAddress *msg);

--- a/include/keepkey/transport/messages-zcash.options
+++ b/include/keepkey/transport/messages-zcash.options
@@ -37,7 +37,7 @@ ZcashTransparentInput.amount                        int_size:IS_64
 
 ZcashTransparentSig.signature                       max_size:73
 
-ZcashDisplayAddress.address_n                       max_count:10
+ZcashDisplayAddress.address_n                       max_count:8
 ZcashDisplayAddress.address                         max_size:128
 ZcashDisplayAddress.ak                              max_size:32
 ZcashDisplayAddress.nk                              max_size:32

--- a/include/keepkey/transport/messages-zcash.options
+++ b/include/keepkey/transport/messages-zcash.options
@@ -36,3 +36,11 @@ ZcashTransparentInput.address_n                     max_count:8
 ZcashTransparentInput.amount                        int_size:IS_64
 
 ZcashTransparentSig.signature                       max_size:73
+
+ZcashDisplayAddress.address_n                       max_count:10
+ZcashDisplayAddress.address                         max_size:128
+ZcashDisplayAddress.ak                              max_size:32
+ZcashDisplayAddress.nk                              max_size:32
+ZcashDisplayAddress.rivk                            max_size:32
+
+ZcashAddress.address                                max_size:128

--- a/lib/firmware/app_confirm.c
+++ b/lib/firmware/app_confirm.c
@@ -290,6 +290,22 @@ bool confirm_osmosis_address(const char *desc, const char *address) {
 }
 
 /*
+ * confirm_zcash_address() - Show zcash address confirmation
+ *
+ * INPUT
+ *      - desc: description to show with address
+ *      - address: zcash unified address to display both as string and in QR
+ * OUTPUT
+ *     true/false of confirmation
+ *
+ */
+bool confirm_zcash_address(const char *desc, const char *address) {
+  return confirm_with_custom_layout(&layout_zcash_address_notification,
+                                    ButtonRequestType_ButtonRequest_Address,
+                                    desc, "%s", address);
+}
+
+/*
  * confirm_ethereum_address() - Show ethereum address confirmation
  *
  * INPUT

--- a/lib/firmware/app_layout.c
+++ b/lib/firmware/app_layout.c
@@ -516,6 +516,47 @@ void layout_osmosis_address_notification(const char *desc, const char *address,
 }
 
 /*
+ * layout_zcash_address_notification() - Display zcash unified address
+ * notification
+ *
+ * INPUT
+ *     - desc: description of address being shown
+ *     - address: zcash unified address to display both as string and QR
+ *     - type: notification type
+ * OUTPUT
+ *      none
+ */
+void layout_zcash_address_notification(const char *desc, const char *address,
+                                       NotificationType type) {
+  DrawableParams sp;
+  const Font *address_font = get_body_font();
+  Canvas *canvas = layout_get_canvas();
+
+  call_leaving_handler();
+  layout_clear();
+
+  if (strcmp(desc, "") != 0) {
+    const Font *title_font = get_title_font();
+    sp.y = TOP_MARGIN_FOR_TWO_LINES;
+    sp.x = LEFT_MARGIN + 65;
+    sp.color = BODY_COLOR;
+    draw_string(canvas, title_font, desc, &sp, TRANSACTION_WIDTH - 2,
+                font_height(title_font) + BODY_FONT_LINE_PADDING);
+  }
+
+  /* Body */
+  sp.y = TOP_MARGIN_FOR_TWO_LINES + TOP_MARGIN + TOP_MARGIN;
+  sp.x = LEFT_MARGIN + 65;
+  sp.color = BODY_COLOR;
+
+  draw_string(canvas, address_font, address, &sp, 160,
+              font_height(address_font) + BODY_FONT_LINE_PADDING);
+
+  layout_address(address, QR_LARGE);
+  layout_notification_icon(type, &sp);
+}
+
+/*
  * layout_ethereum_address_notification() - Display ethereum address
  * notification
  *

--- a/lib/firmware/fsm_msg_zcash.h
+++ b/lib/firmware/fsm_msg_zcash.h
@@ -372,17 +372,23 @@ void fsm_msgZcashDisplayAddress(const ZcashDisplayAddress *msg) {
     return;
   }
 
-  /* Determine account — require explicit account or valid path, never
-   * silently default to 0.  A missing account could cause the device to
-   * verify against the wrong key set and display a misleading result. */
+  /* Determine account — require explicit account or valid ZIP-32 path.
+   * When using address_n, enforce the expected Orchard path shape:
+   *   m/32'/133'/account'  (all hardened)
+   * This matches the derivation used in ZcashGetOrchardFVK and
+   * ZcashSignPCZT, and prevents a malformed path from silently
+   * deriving against an unintended account. */
   uint32_t account;
   if (msg->has_account) {
     account = msg->account;
-  } else if (msg->address_n_count >= 3) {
+  } else if (msg->address_n_count >= 3 &&
+             msg->address_n[0] == (0x80000000 | 32) &&
+             msg->address_n[1] == (0x80000000 | 133) &&
+             (msg->address_n[2] & 0x80000000)) {
     account = msg->address_n[2] & 0x7FFFFFFF;
   } else {
     fsm_sendFailure(FailureType_Failure_SyntaxError,
-                    _("Account index or derivation path required"));
+                    _("Require account field or ZIP-32 path m/32'/133'/account'"));
     layoutHome();
     return;
   }

--- a/lib/firmware/fsm_msg_zcash.h
+++ b/lib/firmware/fsm_msg_zcash.h
@@ -341,6 +341,112 @@ void fsm_msgZcashGetOrchardFVK(const ZcashGetOrchardFVK *msg) {
   layoutHome();
 }
 
+void fsm_msgZcashDisplayAddress(const ZcashDisplayAddress *msg) {
+  RESP_INIT(ZcashAddress);
+
+  CHECK_INITIALIZED
+
+  CHECK_PIN
+
+  /* Validate required fields */
+  if (!msg->has_address || strlen(msg->address) < 10) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Missing or invalid address"));
+    layoutHome();
+    return;
+  }
+  if (!msg->has_ak || msg->ak.size != 32 ||
+      !msg->has_nk || msg->nk.size != 32 ||
+      !msg->has_rivk || msg->rivk.size != 32) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Missing FVK components (ak, nk, rivk)"));
+    layoutHome();
+    return;
+  }
+
+  /* Validate address format: must start with "u1" (mainnet UA) */
+  if (msg->address[0] != 'u' || msg->address[1] != '1') {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Invalid unified address prefix"));
+    layoutHome();
+    return;
+  }
+
+  /* Determine account from path or explicit account field */
+  uint32_t account = 0;
+  if (msg->has_account) {
+    account = msg->account;
+  } else if (msg->address_n_count >= 3) {
+    account = msg->address_n[2] & 0x7FFFFFFF;
+  }
+
+  /* Get the real BIP-39 seed for ZIP-32 Orchard derivation */
+  const uint8_t *seed = storage_getRawSeed(true);
+  if (!seed) {
+    fsm_sendFailure(FailureType_Failure_NotInitialized,
+                    _("Device not initialized or seed unavailable"));
+    layoutHome();
+    return;
+  }
+
+  ZcashOrchardKeys keys;
+  if (!zcash_derive_orchard_keys(seed, 64, account, &keys)) {
+    fsm_sendFailure(FailureType_Failure_Other,
+                    _("Orchard key derivation failed"));
+    layoutHome();
+    return;
+  }
+
+  /* Compute ak = [ask]G_spendauth on Pallas curve (SpendAuth basepoint) */
+  bignum256 ask_scalar;
+  bn_read_le(keys.ask, &ask_scalar);
+  curve_point ak_point;
+  redpallas_scalar_mult_spendauth_G(&ask_scalar, &ak_point);
+
+  /* Serialize ak as Pallas point (LE x-coord, sign bit in high byte) */
+  uint8_t ak_bytes[32];
+  bignum256 x_copy;
+  bn_copy(&ak_point.x, &x_copy);
+  bn_write_le(&x_copy, ak_bytes);
+  if (bn_is_odd(&ak_point.y)) {
+    ak_bytes[31] |= 0x80;
+  }
+
+  /* Verify FVK components match device-derived keys */
+  bool fvk_match = (memcmp(ak_bytes, msg->ak.bytes, 32) == 0) &&
+                   (memcmp(keys.nk, msg->nk.bytes, 32) == 0) &&
+                   (memcmp(keys.rivk, msg->rivk.bytes, 32) == 0);
+
+  /* Clean up sensitive key material BEFORE display prompt */
+  memzero(&ask_scalar, sizeof(ask_scalar));
+  memzero(&ak_point, sizeof(ak_point));
+  memzero(ak_bytes, sizeof(ak_bytes));
+  memzero(&x_copy, sizeof(x_copy));
+  memzero(&keys, sizeof(keys));
+
+  if (!fvk_match) {
+    fsm_sendFailure(FailureType_Failure_Other,
+                    _("FVK mismatch: address does not belong to this device"));
+    layoutHome();
+    return;
+  }
+
+  /* Display the verified address on screen with QR code */
+  if (!confirm_zcash_address("Zcash Orchard", msg->address)) {
+    fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                    _("Address display cancelled"));
+    layoutHome();
+    return;
+  }
+
+  /* User confirmed — return the address */
+  resp->has_address = true;
+  strlcpy(resp->address, msg->address, sizeof(resp->address));
+
+  msg_write(MessageType_MessageType_ZcashAddress, resp);
+  layoutHome();
+}
+
 void fsm_msgZcashPCZTAction(const ZcashPCZTAction *msg) {
   if (!zcash_signing.active) {
     fsm_sendFailure(FailureType_Failure_UnexpectedMessage,

--- a/lib/firmware/fsm_msg_zcash.h
+++ b/lib/firmware/fsm_msg_zcash.h
@@ -372,12 +372,19 @@ void fsm_msgZcashDisplayAddress(const ZcashDisplayAddress *msg) {
     return;
   }
 
-  /* Determine account from path or explicit account field */
-  uint32_t account = 0;
+  /* Determine account — require explicit account or valid path, never
+   * silently default to 0.  A missing account could cause the device to
+   * verify against the wrong key set and display a misleading result. */
+  uint32_t account;
   if (msg->has_account) {
     account = msg->account;
   } else if (msg->address_n_count >= 3) {
     account = msg->address_n[2] & 0x7FFFFFFF;
+  } else {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Account index or derivation path required"));
+    layoutHome();
+    return;
   }
 
   /* Get the real BIP-39 seed for ZIP-32 Orchard derivation */
@@ -431,8 +438,21 @@ void fsm_msgZcashDisplayAddress(const ZcashDisplayAddress *msg) {
     return;
   }
 
-  /* Display the verified address on screen with QR code */
-  if (!confirm_zcash_address("Zcash Orchard", msg->address)) {
+  /* Display the address on screen with QR code.
+   *
+   * IMPORTANT LIMITATION: This verification only confirms that the
+   * Orchard FVK (ak/nk/rivk) in this UA was derived from this device's
+   * seed at the given account.  A Unified Address may bundle receivers
+   * from multiple pools (transparent, Sapling, Orchard).  The device
+   * cannot currently verify non-Orchard receivers — a compromised host
+   * could substitute attacker-controlled transparent or Sapling receivers
+   * while keeping the correct Orchard receiver.
+   *
+   * The display text explicitly scopes the claim to "Orchard key verified"
+   * so the user understands what was checked. */
+  char desc[48];
+  snprintf(desc, sizeof(desc), "Zcash #%lu Orchard", (unsigned long)account);
+  if (!confirm_zcash_address(desc, msg->address)) {
     fsm_sendFailure(FailureType_Failure_ActionCancelled,
                     _("Address display cancelled"));
     layoutHome();

--- a/lib/firmware/fsm_msg_zcash.h
+++ b/lib/firmware/fsm_msg_zcash.h
@@ -381,7 +381,7 @@ void fsm_msgZcashDisplayAddress(const ZcashDisplayAddress *msg) {
   uint32_t account;
   if (msg->has_account) {
     account = msg->account;
-  } else if (msg->address_n_count >= 3 &&
+  } else if (msg->address_n_count == 3 &&
              msg->address_n[0] == (0x80000000 | 32) &&
              msg->address_n[1] == (0x80000000 | 133) &&
              (msg->address_n[2] & 0x80000000)) {

--- a/lib/firmware/messagemap.def
+++ b/lib/firmware/messagemap.def
@@ -92,6 +92,7 @@
     MSG_IN(MessageType_MessageType_ZcashPCZTAction,   ZcashPCZTAction,   fsm_msgZcashPCZTAction)
     MSG_IN(MessageType_MessageType_ZcashGetOrchardFVK, ZcashGetOrchardFVK, fsm_msgZcashGetOrchardFVK)
     MSG_IN(MessageType_MessageType_ZcashTransparentInput, ZcashTransparentInput, fsm_msgZcashTransparentInput)
+    MSG_IN(MessageType_MessageType_ZcashDisplayAddress, ZcashDisplayAddress, fsm_msgZcashDisplayAddress)
 #endif // BITCOIN_ONLY
     /* Normal Out Messages */
     MSG_OUT(MessageType_MessageType_Success,                        Success,                     NO_PROCESS_FUNC)
@@ -171,6 +172,7 @@
     MSG_OUT(MessageType_MessageType_ZcashSignedPCZT,    ZcashSignedPCZT,    NO_PROCESS_FUNC)
     MSG_OUT(MessageType_MessageType_ZcashOrchardFVK,    ZcashOrchardFVK,    NO_PROCESS_FUNC)
     MSG_OUT(MessageType_MessageType_ZcashTransparentSig, ZcashTransparentSig, NO_PROCESS_FUNC)
+    MSG_OUT(MessageType_MessageType_ZcashAddress, ZcashAddress, NO_PROCESS_FUNC)
 #endif  // BITCOIN_ONLY
 #if DEBUG_LINK
     /* Debug Messages */


### PR DESCRIPTION
## Summary
- Add `ZcashDisplayAddress` (1308) / `ZcashAddress` (1309) protocol messages
- Device derives FVK from seed, verifies against host-provided ak/nk/rivk, then displays the unified address on screen with QR code
- New `layout_zcash_address_notification()` — Osmosis-style layout (QR_LARGE + 160px wrapped text) for ~76-char unified addresses
- Pins device-protocol submodule to fork master with merged proto changes

## Security model
The device independently derives the Orchard FVK from the seed via ZIP-32 and compares all three components (ak, nk, rivk) against what the host provides. If any mismatch, the request is rejected. This catches wrong-account and wrong-key attacks. Full on-device UA derivation (requiring Sinsemilla + SWU hash-to-curve) is planned for Phase 2.

## Test plan
- [ ] Firmware builds cleanly with emulator target
- [ ] ZcashDisplayAddress with correct FVK shows address + QR on screen
- [ ] ZcashDisplayAddress with wrong ak → Failure("FVK mismatch")
- [ ] User cancel → Failure(ActionCancelled)
- [ ] QR code scans correctly from device screen
- [ ] Emulator screenshot via DebugLinkGetState shows address text