### PR TITLE
fix(maya): show 'Maya data' instead of 'Thorchain data' for Maya EVM txs

### DIFF
--- a/include/keepkey/firmware/ethereum_contracts/thortx.h
+++ b/include/keepkey/firmware/ethereum_contracts/thortx.h
@@ -26,12 +26,18 @@
 #define ETH_ADDRESS "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
 #define ETH_NATIVE  "\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee"
 
+/* THORChain ETH router (mainnet) */
 #define THOR_ROUTER "42a5ed456650a09dc10ebc6361a7480fdd61f27b"
+
+/* Maya Protocol ETH router (mainnet) */
+#define MAYA_ROUTER "d89dce570de35a6f42d3bca7dba50a6d89bfc2a2"
 
 typedef struct _EthereumSignTx EthereumSignTx;
 
 bool thor_isThorchainTx(const EthereumSignTx *msg);
+bool thor_isMayachainTx(const EthereumSignTx *msg);
 bool thor_confirmThorTx(uint32_t data_total, const EthereumSignTx *msg);
+bool thor_confirmMayaTx(uint32_t data_total, const EthereumSignTx *msg);
 
 
 #endif

--- a/lib/firmware/ethereum_contracts.c
+++ b/lib/firmware/ethereum_contracts.c
@@ -38,6 +38,7 @@ bool ethereum_contractHandled(uint32_t data_total, const EthereumSignTx *msg,
   if (zx_isZxLiquidTx(msg)) return true;
   if (zx_isZxApproveLiquid(msg)) return true;
 
+  if (thor_isMayachainTx(msg)) return true;
   if (thor_isThorchainTx(msg)) return true;
 
   if (makerdao_isMakerDAO(data_total, msg)) return true;
@@ -63,6 +64,9 @@ bool ethereum_contractConfirmed(uint32_t data_total, const EthereumSignTx *msg,
 
   if (zx_isZxApproveLiquid(msg))
     return zx_confirmApproveLiquidity(data_total, msg);
+
+  if (thor_isMayachainTx(msg))
+    return thor_confirmMayaTx(data_total, msg);
 
   if (thor_isThorchainTx(msg))
     return thor_confirmThorTx(data_total, msg);

--- a/lib/firmware/ethereum_contracts/thortx.c
+++ b/lib/firmware/ethereum_contracts/thortx.c
@@ -27,17 +27,40 @@
 #include "keepkey/firmware/thorchain.h"
 #include "trezor/crypto/address.h"
 
-bool thor_isThorchainTx(const EthereumSignTx *msg) {
-  if (msg->has_to && msg->to.size == 20 &&
-      memcmp(msg->data_initial_chunk.bytes,
-             "\x1f\xec\xe7\xb4\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00", 
-             16) == 0) {
-    return true;
+/* Helper: format msg->to as lowercase hex string (40 chars + NUL) */
+static void thor_format_to_addr(const EthereumSignTx *msg, char out[41]) {
+  for (uint32_t i = 0; i < 20; i++) {
+    snprintf(&out[i * 2], 3, "%02x", msg->to.bytes[i]);
   }
-  return false;
+  out[40] = '\0';
 }
 
-bool thor_confirmThorTx(uint32_t data_total, const EthereumSignTx *msg) {  
+/* depositWithExpiry() selector = 0x1fece7b4 */
+static bool thor_has_deposit_selector(const EthereumSignTx *msg) {
+  return msg->has_to && msg->to.size == 20 &&
+         msg->data_initial_chunk.size >= 16 &&
+         memcmp(msg->data_initial_chunk.bytes,
+                "\x1f\xec\xe7\xb4\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
+                16) == 0;
+}
+
+bool thor_isMayachainTx(const EthereumSignTx *msg) {
+  if (!thor_has_deposit_selector(msg)) return false;
+  char toStr[41];
+  thor_format_to_addr(msg, toStr);
+  return strncmp(toStr, MAYA_ROUTER, 40) == 0;
+}
+
+bool thor_isThorchainTx(const EthereumSignTx *msg) {
+  /* Matches any depositWithExpiry() call — Maya transactions are
+   * a subset; call thor_isMayachainTx() first to distinguish them. */
+  return thor_has_deposit_selector(msg);
+}
+
+/* Internal helper used by both thor_confirmThorTx and thor_confirmMayaTx */
+static bool thor_confirm_deposit_tx(uint32_t data_total, const EthereumSignTx *msg,
+                                    const char *protocol_label,
+                                    const char *router_label) {
     (void)data_total;
 
     char confStr[41], *conf;
@@ -51,61 +74,55 @@ bool thor_confirmThorTx(uint32_t data_total, const EthereumSignTx *msg) {
     bn_from_bytes(msg->data_initial_chunk.bytes + 4 + 2*32, 32, &Amount);
     thorchainData = (uint8_t *)(msg->data_initial_chunk.bytes + 4 + 5*32);
 
-    // Start confirmations    
-    for (ctr=0; ctr<20; ctr++) {
-        snprintf(&confStr[ctr*2], 3, "%02x", msg->to.bytes[ctr]);
-    }
-    if (strncmp(confStr, THOR_ROUTER, sizeof(THOR_ROUTER)) == 0) {
+    /* Show routing router */
+    thor_format_to_addr(msg, confStr);
+    if (strncmp(confStr, THOR_ROUTER, 40) == 0) {
         conf = "Thorchain router";
+    } else if (strncmp(confStr, MAYA_ROUTER, 40) == 0) {
+        conf = router_label;
     } else {
         conf = confStr;
     }
     if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
-             "Thorchain data", "Routing through %s", conf)) {
+             protocol_label, "Routing through %s", conf)) {
         return false;
     }
 
-    // just display token address and amount as string
+    /* Show Asgard vault address */
     for (ctr=0; ctr<20; ctr++) {
         snprintf(&confStr[ctr*2], 3, "%02x", vaultAddress[ctr]);
     }
     if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
-             "Thorchain data", "Using Asgard vault %s", confStr)) {
+             protocol_label, "Using Asgard vault %s", confStr)) {
         return false;
     }
 
     if (memcmp(contractAssetAddress, ETH_ADDRESS, sizeof(ETH_ADDRESS)) == 0) {
-        assetAddress = (uint8_t *)ETH_NATIVE;      // get eth native parameters if asset is not a token
+        assetAddress = (uint8_t *)ETH_NATIVE;
     } else {
         assetAddress = contractAssetAddress;
     }
-    
+
     assetToken = tokenByChainAddress(msg->chain_id, assetAddress);
 
     if (strncmp(assetToken->ticker, " UNKN", 5) == 0) {
- 
-        // just display token address and amount as string
         for (ctr=0; ctr<20; ctr++) {
             snprintf(&confStr[ctr*2], 3, "%02x", assetAddress[ctr]);
         }
         if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
-                 "Thorchain data", "from asset %s", confStr)) {
+                 protocol_label, "from asset %s", confStr)) {
             return false;
         }
-        // We don't know what the exponent should be so just confirm raw unformatted number
         bn_format(&Amount, NULL, " unformatted", 0, 0, false, confStr, sizeof(confStr));
-
         if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
-                 "Thorchain data", "amount %s", confStr)) {
+                 protocol_label, "amount %s", confStr)) {
             return false;
         }
-
     } else {
         ethereumFormatAmount(&Amount, assetToken, msg->chain_id, confStr,
                            sizeof(confStr));
-    
         if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
-                     "Thorchain data", "Confirm sending %s", confStr)) {
+                     protocol_label, "Confirm sending %s", confStr)) {
             return false;
         }
     }
@@ -114,6 +131,14 @@ bool thor_confirmThorTx(uint32_t data_total, const EthereumSignTx *msg) {
         return false;
 
     return true;
+}
+
+bool thor_confirmThorTx(uint32_t data_total, const EthereumSignTx *msg) {
+    return thor_confirm_deposit_tx(data_total, msg, "Thorchain data", "Thorchain router");
+}
+
+bool thor_confirmMayaTx(uint32_t data_total, const EthereumSignTx *msg) {
+    return thor_confirm_deposit_tx(data_total, msg, "Maya data", "Maya router");
 }
 
 


### PR DESCRIPTION
## Summary
- Maya Protocol EVM transactions now display "Maya data" and "Maya router" instead of "Thorchain data" and "Thorchain router"
- THORChain and Maya share the same `depositWithExpiry()` ABI; differentiator is the router contract address
- Adds `MAYA_ROUTER` constant, `thor_isMayachainTx()`, and `thor_confirmMayaTx()` functions
- Maya check is performed before THORChain check in ethereum_contracts.c

## Changes
- `include/keepkey/firmware/ethereum_contracts/thortx.h`: add MAYA_ROUTER, declare new functions
- `lib/firmware/ethereum_contracts/thortx.c`: add Maya detection + confirmation with correct labels
- `lib/firmware/ethereum_contracts.c`: check Maya before THORChain

## Bug
Bug #13 from zoo audit: "Maya swap test shows 'THORCHAIN DATA' not 'MAYA'"

🤖 Generated with Claude Code