### PR TITLE
fix(ci): always upload oled-screenshots artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -512,7 +512,7 @@ jobs:
 
       - name: Upload OLED screenshots
         uses: actions/upload-artifact@v4
-        if: always() && (steps.changes.outputs.firmware == 'true' || github.event_name == 'push')
+        if: always()
         with:
           name: oled-screenshots
           path: test-reports/screenshots/


### PR DESCRIPTION
## Summary
- Fixes zoo audit bug #20: CI never uploads oled-screenshots artifact
- The `if:` condition referenced `steps.changes.outputs.firmware` which doesn't exist in this workflow, making the condition always false
- Screenshots captured in Docker were never uploaded

## Changes
- `.github/workflows/ci.yml`: Changed `if: always() && (steps.changes.outputs.firmware == 'true' || github.event_name == 'push')` to `if: always()`

🤖 Generated with Claude Code