### PR TITLE
feat(ci): firmware test report with OLED screenshots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,6 +430,49 @@ jobs:
         working-directory: scripts/emulator
         run: docker compose down -v || true
 
+  # Parallel: generate test report with OLED screenshots (does not gate PR)
+  python-test-report:
+    needs: [check-submodules, secret-scan]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Init submodules
+        run: |
+          git submodule update --init deps/crypto/trezor-firmware
+          git submodule update --init deps/device-protocol
+          git submodule update --init --recursive deps/python-keepkey
+          git submodule update --init deps/googletest
+          git submodule update --init deps/qrenc/QR-Code-generator
+          git submodule update --init deps/sca-hardening/SecAESSTM32
+
+      - name: Build emulator and run tests with screenshots
+        working-directory: scripts/emulator
+        run: |
+          set +e
+          docker compose up --build python-keepkey-report
+          set -e
+          mkdir -p ${{ github.workspace }}/test-reports
+          docker cp "$(docker compose ps -a -q python-keepkey-report)":/kkemu/test-reports/. ${{ github.workspace }}/test-reports/ 2>/dev/null || true
+
+      - name: Upload firmware test report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: firmware-test-report
+          path: test-reports/python-keepkey/test-report.pdf
+          retention-days: 90
+
+      - name: Tear down
+        if: always()
+        working-directory: scripts/emulator
+        run: docker compose down -v || true
+
   # ═══════════════════════════════════════════════════════════
   # STAGE 4: PUBLISH — manual trigger only, all tests must pass
   # ═══════════════════════════════════════════════════════════

--- a/include/keepkey/transport/messages.options
+++ b/include/keepkey/transport/messages.options
@@ -109,7 +109,7 @@ ApplyPolicies.policy			max_count:16
 FirmwareUpload.payload_hash  max_size:32
 FirmwareUpload.payload			max_size:0
 
-DebugLinkState.layout			max_size:1024
+DebugLinkState.layout			max_size:2048
 DebugLinkState.pin			max_size:10
 DebugLinkState.matrix			max_size:10
 DebugLinkState.mnemonic			max_size:241

--- a/lib/firmware/fsm.c
+++ b/lib/firmware/fsm.c
@@ -32,6 +32,7 @@
 #include "keepkey/board/timer.h"
 #include "keepkey/board/util.h"
 #include "keepkey/board/variant.h"
+#include "keepkey/board/keepkey_display.h"
 #include "keepkey/firmware/app_confirm.h"
 #include "keepkey/firmware/app_layout.h"
 #include "keepkey/firmware/authenticator.h"

--- a/lib/firmware/fsm_msg_debug.h
+++ b/lib/firmware/fsm_msg_debug.h
@@ -46,6 +46,32 @@ void fsm_msgDebugLinkGetState(DebugLinkGetState *msg) {
   resp->storage_hash.size =
       memory_storage_hash(resp->storage_hash.bytes, storage_getLocation());
 
+  /* Force pending animations to render before reading the canvas.
+   * Without this, animated elements (cipher grid, PIN matrix) won't
+   * appear in DebugLink screenshots. */
+  force_animation_start();
+  animate();
+  display_refresh();
+
+  /* Pack 256x64 grayscale canvas into 1bpp layout for screenshot capture.
+   * Each byte in layout holds 8 vertical pixels (LSB = top).
+   * Total: 256 columns x (64/8) rows = 2048 bytes. */
+  {
+    Canvas *c = display_canvas();
+    if (c && c->buffer) {
+      resp->has_layout = true;
+      resp->layout.size = 2048;
+      memset(resp->layout.bytes, 0, 2048);
+      for (int x = 0; x < 256; x++) {
+        for (int y = 0; y < 64; y++) {
+          if (c->buffer[y * 256 + x] > 0) {
+            resp->layout.bytes[x + (y / 8) * 256] |= (1 << (y % 8));
+          }
+        }
+      }
+    }
+  }
+
   msg_debug_write(MessageType_MessageType_DebugLinkState, resp);
 }
 

--- a/scripts/emulator/docker-compose.yml
+++ b/scripts/emulator/docker-compose.yml
@@ -21,6 +21,17 @@ services:
       - local-net
     depends_on:
       - kkemu
+  python-keepkey-report:
+    build:
+      context: '../../'
+      dockerfile: 'scripts/emulator/python-keepkey.Dockerfile'
+    volumes:
+      - test-reports:/kkemu/test-reports:rw
+    networks:
+      - local-net
+    depends_on:
+      - kkemu
+    entrypoint: ['/bin/sh', './scripts/emulator/python-keepkey-report.sh']
   firmware-unit:
     build:
       context: '../../'

--- a/scripts/emulator/python-keepkey-report.sh
+++ b/scripts/emulator/python-keepkey-report.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# Two-pass test report: clean results + targeted screenshots.
+# Pass 1: Full suite WITHOUT screenshots — accurate junit
+# Pass 2: Targeted subset WITH screenshots — key OLED screens
+# Report merges both into a PDF artifact.
+
+mkdir -p /kkemu/test-reports/python-keepkey
+
+cd deps/python-keepkey/tests
+
+# Pass 1: Full suite, no screenshots
+echo "=== Pass 1: Full test suite ==="
+KK_TRANSPORT_MAIN=kkemu:11044 \
+KK_TRANSPORT_DEBUG=kkemu:11045 \
+  pytest -v --junitxml=/kkemu/test-reports/python-keepkey/junit.xml
+echo "$?" > /kkemu/test-reports/python-keepkey/status
+
+# Pass 2: Targeted screenshots
+echo "=== Pass 2: Targeted screenshots ==="
+export KEEPKEY_SCREENSHOT=1
+export SCREENSHOT_DIR=/kkemu/test-reports/python-keepkey/screenshots
+KK_TRANSPORT_MAIN=kkemu:11044 \
+KK_TRANSPORT_DEBUG=kkemu:11045 \
+  pytest -v -s -k "test_wipe or test_show or test_one_one_fee or test_ethereum_signtx_nodata or test_apply_settings or test_ping or test_entropy or test_encrypt or test_decrypt or test_ripple_sign or test_cosmos_sign_tx or test_thorchain_sign_tx" \
+  2>&1 || true
+
+# Generate report PDF
+cd /kkemu/deps/python-keepkey
+python3 scripts/generate-test-report.py \
+  --junit=/kkemu/test-reports/python-keepkey/junit.xml \
+  --screenshots=/kkemu/test-reports/python-keepkey/screenshots \
+  --output=/kkemu/test-reports/python-keepkey/test-report.pdf \
+  || echo "Report generation failed (non-fatal)"


### PR DESCRIPTION
## Summary
Add test report PDF as CI artifact with real OLED screenshots from emulator.

## Changes
- `messages.options`: DebugLinkState.layout max_size 1024->2048
- `fsm_msg_debug.h`: pack 256x64 canvas into layout for DebugLink capture
- `fsm.c`: add keepkey_display.h include
- New CI job `python-test-report` (parallel, does not gate)
- `python-keepkey` pinned to upstream `release/7.14.0`

## Test plan
- [ ] CI green
- [ ] Test report PDF has green checkmarks + embedded OLED screenshots