### PR TITLE
fix(security): fault injection hardening (F3, F5)

### DIFF
--- a/lib/board/signatures.c
+++ b/lib/board/signatures.c
@@ -20,7 +20,9 @@
 #include "trezor/crypto/sha2.h"
 #include "trezor/crypto/ecdsa.h"
 #include "trezor/crypto/secp256k1.h"
+#include "trezor/crypto/memzero.h"
 #include "keepkey/board/memory.h"
+#include "keepkey/board/memcmp_s.h"
 #include "keepkey/board/signatures.h"
 #include "keepkey/board/pubkeys.h"
 
@@ -68,23 +70,51 @@ int signatures_ok(void) {
     return KEY_EXPIRED;
   } /* Expired signing key */
 
+  /* F3 hardening: double-compute SHA-256, compare in constant time */
+  uint8_t firmware_fingerprint2[32];
   sha256_Raw((uint8_t *)FLASH_APP_START, codelen, firmware_fingerprint);
+  asm volatile("" ::: "memory");
+  sha256_Raw((uint8_t *)FLASH_APP_START, codelen, firmware_fingerprint2);
 
-  if (ecdsa_verify_digest(&secp256k1, pubkey[sigindex1 - 1],
-                          (uint8_t *)FLASH_META_SIG1,
-                          firmware_fingerprint) != 0) { /* Failure */
+  if (memcmp_s(firmware_fingerprint, firmware_fingerprint2, 32) != 0) {
+    memzero(firmware_fingerprint, sizeof(firmware_fingerprint));
+    memzero(firmware_fingerprint2, sizeof(firmware_fingerprint2));
+    return SIG_FAIL;
+  }
+  memzero(firmware_fingerprint2, sizeof(firmware_fingerprint2));
+
+  /* F3 hardening: infective aggregation — accumulate all three ECDSA
+   * results instead of early-returning on each. Forces attacker to
+   * corrupt all three verify calls, not just skip one branch. */
+  volatile int verify_acc = 0;
+  volatile int verify_sentinel = 0;
+
+  verify_acc |= ecdsa_verify_digest(&secp256k1, pubkey[sigindex1 - 1],
+                                    (uint8_t *)FLASH_META_SIG1,
+                                    firmware_fingerprint);
+  verify_sentinel++;
+  asm volatile("" ::: "memory");
+
+  verify_acc |= ecdsa_verify_digest(&secp256k1, pubkey[sigindex2 - 1],
+                                    (uint8_t *)FLASH_META_SIG2,
+                                    firmware_fingerprint);
+  verify_sentinel++;
+  asm volatile("" ::: "memory");
+
+  verify_acc |= ecdsa_verify_digest(&secp256k1, pubkey[sigindex3 - 1],
+                                    (uint8_t *)FLASH_META_SIG3,
+                                    firmware_fingerprint);
+  verify_sentinel++;
+  asm volatile("" ::: "memory");
+
+  memzero(firmware_fingerprint, sizeof(firmware_fingerprint));
+
+  /* All three verifies must have executed and all must have passed */
+  if (verify_sentinel != 3) {
     return SIG_FAIL;
   }
 
-  if (ecdsa_verify_digest(&secp256k1, pubkey[sigindex2 - 1],
-                          (uint8_t *)FLASH_META_SIG2,
-                          firmware_fingerprint) != 0) { /* Failure */
-    return SIG_FAIL;
-  }
-
-  if (ecdsa_verify_digest(&secp256k1, pubkey[sigindex3 - 1],
-                          (uint8_t *)FLASH_META_SIG3,
-                          firmware_fingerprint) != 0) { /* Failure */
+  if (verify_acc != 0) {
     return SIG_FAIL;
   }
 

--- a/tools/firmware/keepkey_main.c
+++ b/tools/firmware/keepkey_main.c
@@ -174,8 +174,24 @@ int main(void) {
   _mmhusr_isr = (void *)&mmhisr;
 
   { // limit sigRet lifetime to this block
+    /* F5 hardening: replace full signatures_ok() (~1 sec crypto) with fast
+     * metadata presence check. The bootloader has already performed the
+     * authoritative signature verification before jumping here. We only
+     * need to know whether the bootloader considered us signed, which is
+     * indicated by valid signature indices in flash metadata. */
     int sigRet = SIG_FAIL;
-    sigRet = signatures_ok();
+
+    volatile uint8_t si1 = *((volatile uint8_t *)FLASH_META_SIGINDEX1);
+    volatile uint8_t si2 = *((volatile uint8_t *)FLASH_META_SIGINDEX2);
+    volatile uint8_t si3 = *((volatile uint8_t *)FLASH_META_SIGINDEX3);
+
+    if (si1 >= 1 && si1 <= PUBKEYS &&
+        si2 >= 1 && si2 <= PUBKEYS &&
+        si3 >= 1 && si3 <= PUBKEYS &&
+        si1 != si2 && si1 != si3 && si2 != si3) {
+      sigRet = SIG_OK;
+    }
+
     flash_collectHWEntropy(SIG_OK == sigRet);
 
     /* Drop privileges */


### PR DESCRIPTION
## Summary
- **F3**: Double-compute SHA-256 + constant-time compare + infective aggregation of all 3 ECDSA verifies
- **F5**: Firmware replaces full `signatures_ok()` with fast metadata presence check (bootloader already verified)

## Security notes
- Infective aggregation forces attacker to corrupt all 3 verify calls, not just skip one branch
- `asm volatile("" ::: "memory")` barriers prevent compiler reordering
- `volatile` sentinel counter detects skipped verify calls

## Test plan
- CI: ARM cross-compile + emulator build verify no regressions
- Existing signing tests still pass