### PR TITLE
feat: show previous completed word during recovery cipher

### DIFF
--- a/include/keepkey/firmware/app_layout.h
+++ b/include/keepkey/firmware/app_layout.h
@@ -119,7 +119,8 @@ void layout_ethereum_address_notification(const char *desc, const char *address,
 void layout_nano_address_notification(const char *desc, const char *address,
                                       NotificationType type);
 void layout_pin(const char *prompt, char *pin);
-void layout_cipher(const char *current_word, const char *cipher);
+void layout_cipher(const char *current_word, const char *cipher,
+                    const char *prev_word_info);
 void layout_address(const char *address, QRSize qr_size);
 void set_leaving_handler(leaving_handler_t leaving_func);
 

--- a/lib/firmware/app_layout.c
+++ b/lib/firmware/app_layout.c
@@ -695,7 +695,8 @@ void layout_pin(const char *str, char pin[]) {
  * OUTPUT
  *     none
  */
-void layout_cipher(const char *current_word, const char *cipher) {
+void layout_cipher(const char *current_word, const char *cipher,
+                    const char *prev_word_info) {
   DrawableParams sp;
   const Font *title_font = get_body_font();
   Canvas *canvas = layout_get_canvas();
@@ -703,8 +704,18 @@ void layout_cipher(const char *current_word, const char *cipher) {
   call_leaving_handler();
   layout_clear();
 
-  /* Draw prompt */
-  sp.y = 11;
+  /* Draw previous word info at top-left — must be x < 76 to avoid
+   * being wiped by cipher animation which clears x >= CIPHER_START_X */
+  if (prev_word_info && prev_word_info[0]) {
+    sp.y = 2;
+    sp.x = 4;
+    sp.color = CIPHER_FONT_COLOR;  /* gray — less prominent than current word */
+    draw_string(canvas, title_font, prev_word_info, &sp, 68,
+                font_height(title_font));
+  }
+
+  /* Draw prompt — push down when prev word is shown */
+  sp.y = (prev_word_info && prev_word_info[0]) ? 14 : 11;
   sp.x = 4;
   sp.color = BODY_COLOR;
   draw_string(canvas, title_font, "Recovery Cipher:", &sp, 58,

--- a/lib/firmware/recovery_cipher.c
+++ b/lib/firmware/recovery_cipher.c
@@ -371,13 +371,29 @@ void next_character(void) {
   }
 #endif
 
+  /* Save word so we can show it as "prev" on next word.
+   * When auto-complete fires, current_word holds the full expanded word
+   * (e.g. "alcohol" not "alc"). Otherwise save the typed prefix. */
+  static char CONFIDENTIAL last_completed_word[12];
+  if (strlen(current_word) > 0) {
+    strlcpy(last_completed_word, current_word, sizeof(last_completed_word));
+  }
+
   /* Format current word and display it along with cipher */
   static char CONFIDENTIAL formatted_word[CURRENT_WORD_BUF + 10];
   format_current_word(word_pos, current_word, auto_completed, &formatted_word);
   memzero(current_word, sizeof(current_word));
 
+  /* Format previous word indicator (e.g. "(1.alcohol)" when entering word 2) */
+  static char prev_info[16];
+  prev_info[0] = '\0';
+  if (word_pos > 0 && last_completed_word[0]) {
+    snprintf(prev_info, sizeof(prev_info), "(%" PRIu32 ".%s)",
+             word_pos, last_completed_word);
+  }
+
   /* Show cipher and partial word */
-  layout_cipher(formatted_word, cipher);
+  layout_cipher(formatted_word, cipher, prev_info);
   memzero(formatted_word, sizeof(formatted_word));
 }
 

--- a/lib/firmware/recovery_cipher.c
+++ b/lib/firmware/recovery_cipher.c
@@ -385,7 +385,7 @@ void next_character(void) {
   memzero(current_word, sizeof(current_word));
 
   /* Format previous word indicator (e.g. "(1.alcohol)" when entering word 2) */
-  static char prev_info[16];
+  static char prev_info[32];
   prev_info[0] = '\0';
   if (word_pos > 0 && last_completed_word[0]) {
     snprintf(prev_info, sizeof(prev_info), "(%" PRIu32 ".%s)",


### PR DESCRIPTION
## Summary
- Display previous word (e.g. "(1.alcohol)") at top-left during cipher recovery
- Positioned at x<76 to avoid cipher animation wipe zone
- Prompt line shifts down when prev word is visible
- Tracks last completed word (including auto-completed expansions)

## Files changed
- `include/keepkey/firmware/app_layout.h` — add `prev_word_info` param to `layout_cipher`
- `lib/firmware/app_layout.c` — render prev word + conditional prompt positioning
- `lib/firmware/recovery_cipher.c` — track last completed word, format prev indicator

## Test plan
- CI: build ARM + emulator, existing recovery tests
- Manual: run cipher recovery, verify prev word appears after first word entry