### PR TITLE
feat: BIP-85 child mnemonic derivation (display only)

### DIFF
--- a/include/keepkey/firmware/bip85.h
+++ b/include/keepkey/firmware/bip85.h
@@ -1,0 +1,22 @@
+#ifndef BIP85_H
+#define BIP85_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/**
+ * Derive a child BIP-39 mnemonic via BIP-85.
+ *
+ * Path: m/83696968'/39'/0'/<word_count>'/<index>'
+ *
+ * @param word_count  Number of words: 12, 18, or 24.
+ * @param index       Child index (0-based).
+ * @param mnemonic    Output buffer (must be at least 241 bytes).
+ * @param mnemonic_len Size of the output buffer.
+ * @return true on success, false on error.
+ */
+bool bip85_derive_mnemonic(uint32_t word_count, uint32_t index,
+                           char *mnemonic, size_t mnemonic_len);
+
+#endif

--- a/include/keepkey/firmware/fsm.h
+++ b/include/keepkey/firmware/fsm.h
@@ -129,4 +129,6 @@ void fsm_msgFlashWrite(FlashWrite *msg);
 void fsm_msgFlashHash(FlashHash *msg);
 void fsm_msgSoftReset(SoftReset *msg);
 
+void fsm_msgGetBip85Mnemonic(const GetBip85Mnemonic *msg);
+
 #endif

--- a/lib/firmware/CMakeLists.txt
+++ b/lib/firmware/CMakeLists.txt
@@ -2,6 +2,7 @@ set(sources
     app_confirm.c
     app_layout.c
     authenticator.c
+    bip85.c
     binance.c
     coins.c
     crypto.c

--- a/lib/firmware/bip85.c
+++ b/lib/firmware/bip85.c
@@ -1,0 +1,98 @@
+#include "keepkey/firmware/bip85.h"
+#include "keepkey/firmware/storage.h"
+#include "trezor/crypto/bip32.h"
+#include "trezor/crypto/bip39.h"
+#include "trezor/crypto/curves.h"
+#include "trezor/crypto/hmac.h"
+#include "trezor/crypto/memzero.h"
+
+#include <string.h>
+
+/*
+ * BIP-85: Deterministic Entropy From BIP32 Keychains
+ *
+ * For BIP-39 mnemonic derivation:
+ *   path = m / 83696968' / 39' / 0' / <word_count>' / <index>'
+ *   k    = derived_node.private_key  (32 bytes)
+ *   hmac = HMAC-SHA512(key="bip-entropy-from-k", msg=k)
+ *   entropy = hmac[0 : entropy_bytes]
+ *     12 words -> 16 bytes, 18 words -> 24 bytes, 24 words -> 32 bytes
+ *   mnemonic = bip39_from_entropy(entropy)
+ */
+
+/* BIP-85 application number for deriving entropy from a key */
+static const uint8_t BIP85_HMAC_KEY[] = "bip-entropy-from-k";
+#define BIP85_HMAC_KEY_LEN 18
+
+bool bip85_derive_mnemonic(uint32_t word_count, uint32_t index,
+                           char *mnemonic, size_t mnemonic_len) {
+  /* Reject index >= 0x80000000 to avoid hardened-bit collision */
+  if (index & 0x80000000) {
+    return false;
+  }
+
+  /* Validate word count and compute entropy length */
+  int entropy_bytes;
+  switch (word_count) {
+    case 12: entropy_bytes = 16; break;
+    case 18: entropy_bytes = 24; break;
+    case 24: entropy_bytes = 32; break;
+    default: return false;
+  }
+
+  /* BIP-85 derivation path: m/83696968'/39'/0'/<word_count>'/<index>' */
+  uint32_t address_n[5];
+  address_n[0] = 0x80000000 | 83696968;  /* purpose (hardened) */
+  address_n[1] = 0x80000000 | 39;        /* BIP-39 app (hardened) */
+  address_n[2] = 0x80000000 | 0;         /* English language (hardened) */
+  address_n[3] = 0x80000000 | word_count; /* word count (hardened) */
+  address_n[4] = 0x80000000 | index;     /* child index (hardened) */
+
+  /* Get the master node from storage (respects passphrase) */
+  static CONFIDENTIAL HDNode node;
+  if (!storage_getRootNode(SECP256K1_NAME, true, &node)) {
+    memzero(&node, sizeof(node));
+    return false;
+  }
+
+  /* Derive to the BIP-85 path */
+  for (int i = 0; i < 5; i++) {
+    if (hdnode_private_ckd(&node, address_n[i]) == 0) {
+      memzero(&node, sizeof(node));
+      return false;
+    }
+  }
+
+  /* HMAC-SHA512(key="bip-entropy-from-k", msg=private_key) */
+  static CONFIDENTIAL uint8_t hmac_out[64];
+  hmac_sha512(BIP85_HMAC_KEY, BIP85_HMAC_KEY_LEN,
+              node.private_key, 32, hmac_out);
+
+  /* We no longer need the derived node */
+  memzero(&node, sizeof(node));
+
+  /* Truncate HMAC output to the required entropy length */
+  static CONFIDENTIAL uint8_t entropy[32];
+  memcpy(entropy, hmac_out, entropy_bytes);
+  memzero(hmac_out, sizeof(hmac_out));
+
+  /* Convert entropy to BIP-39 mnemonic */
+  const char *words = mnemonic_from_data(entropy, entropy_bytes);
+  memzero(entropy, sizeof(entropy));
+
+  if (!words) {
+    return false;
+  }
+
+  /* Copy to output buffer */
+  size_t words_len = strlen(words);
+  if (words_len >= mnemonic_len) {
+    mnemonic_clear();
+    return false;
+  }
+
+  memcpy(mnemonic, words, words_len + 1);
+  mnemonic_clear();
+
+  return true;
+}

--- a/lib/firmware/fsm.c
+++ b/lib/firmware/fsm.c
@@ -35,6 +35,7 @@
 #include "keepkey/firmware/app_confirm.h"
 #include "keepkey/firmware/app_layout.h"
 #include "keepkey/firmware/authenticator.h"
+#include "keepkey/firmware/bip85.h"
 #include "keepkey/firmware/coins.h"
 #include "keepkey/firmware/cosmos.h"
 #include "keepkey/firmware/binance.h"

--- a/lib/firmware/fsm.c
+++ b/lib/firmware/fsm.c
@@ -284,3 +284,4 @@ void fsm_msgClearSession(ClearSession *msg) {
 #include "fsm_msg_tendermint.h"
 #include "fsm_msg_thorchain.h"
 #include "fsm_msg_mayachain.h"
+#include "fsm_msg_bip85.h"

--- a/lib/firmware/fsm_msg_bip85.h
+++ b/lib/firmware/fsm_msg_bip85.h
@@ -1,0 +1,144 @@
+void fsm_msgGetBip85Mnemonic(const GetBip85Mnemonic *msg) {
+  CHECK_INITIALIZED
+
+  /* Validate word count (required field, always present in nanopb) */
+  if (msg->word_count != 12 && msg->word_count != 18 && msg->word_count != 24) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    "word_count must be 12, 18, or 24");
+    layoutHome();
+    return;
+  }
+
+  /* Reject index >= 0x80000000 (hardened-bit collision) */
+  if (msg->index & 0x80000000) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    "index must be less than 2147483648");
+    layoutHome();
+    return;
+  }
+
+  CHECK_PIN
+
+  /* User confirmation */
+  char desc[80];
+  snprintf(desc, sizeof(desc),
+           "Derive %lu-word child seed at index %lu?",
+           (unsigned long)msg->word_count, (unsigned long)msg->index);
+
+  if (!confirm(ButtonRequestType_ButtonRequest_Other,
+               "BIP-85 Derive Seed", "%s", desc)) {
+    fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                    "BIP-85 derivation cancelled");
+    layoutHome();
+    return;
+  }
+
+  layout_simple_message("Deriving child seed...");
+
+  /* Derive the mnemonic */
+  static CONFIDENTIAL char mnemonic_buf[241];
+  if (!bip85_derive_mnemonic(msg->word_count, msg->index,
+                             mnemonic_buf, sizeof(mnemonic_buf))) {
+    memzero(mnemonic_buf, sizeof(mnemonic_buf));
+    fsm_sendFailure(FailureType_Failure_Other,
+                    "BIP-85 derivation failed");
+    layoutHome();
+    return;
+  }
+
+  /*
+   * Display mnemonic on device screen only — never send over USB.
+   * Uses the same paginated display as the backup flow in reset.c.
+   */
+  uint32_t word_count = 0, page_count = 0;
+  static char CONFIDENTIAL tokened_mnemonic[TOKENED_MNEMONIC_BUF];
+  static char CONFIDENTIAL formatted_mnemonic[MAX_PAGES][FORMATTED_MNEMONIC_BUF];
+  static char CONFIDENTIAL mnemonic_display[FORMATTED_MNEMONIC_BUF];
+  static char CONFIDENTIAL formatted_word[MAX_WORD_LEN + ADDITIONAL_WORD_PAD];
+
+  strlcpy(tokened_mnemonic, mnemonic_buf, TOKENED_MNEMONIC_BUF);
+  memzero(mnemonic_buf, sizeof(mnemonic_buf));
+
+  /* Clear formatting buffers */
+  memzero(formatted_mnemonic, sizeof(formatted_mnemonic));
+  memzero(mnemonic_display, sizeof(mnemonic_display));
+
+  char *tok = strtok(tokened_mnemonic, " ");
+
+  while (tok) {
+    snprintf(formatted_word, MAX_WORD_LEN + ADDITIONAL_WORD_PAD,
+             (word_count & 1) ? "%lu.%s\n" : "%lu.%s",
+             (unsigned long)(word_count + 1), tok);
+
+    /* Check that we have enough room on display to show word */
+    snprintf(mnemonic_display, FORMATTED_MNEMONIC_BUF, "%s   %s",
+             formatted_mnemonic[page_count], formatted_word);
+
+    if (calc_str_line(get_body_font(), mnemonic_display, BODY_WIDTH) > 3) {
+      page_count++;
+
+      if (MAX_PAGES <= page_count) {
+        memzero(tokened_mnemonic, sizeof(tokened_mnemonic));
+        memzero(formatted_mnemonic, sizeof(formatted_mnemonic));
+        memzero(mnemonic_display, sizeof(mnemonic_display));
+        memzero(formatted_word, sizeof(formatted_word));
+        fsm_sendFailure(FailureType_Failure_Other,
+                        "Too many pages of mnemonic words");
+        layoutHome();
+        return;
+      }
+
+      snprintf(mnemonic_display, FORMATTED_MNEMONIC_BUF, "%s   %s",
+               formatted_mnemonic[page_count], formatted_word);
+    }
+
+    strlcpy(formatted_mnemonic[page_count], mnemonic_display,
+            FORMATTED_MNEMONIC_BUF);
+
+    tok = strtok(NULL, " ");
+    word_count++;
+  }
+
+  /* Switch from 0-indexing to 1-indexing */
+  page_count++;
+
+  display_constant_power(true);
+
+  /* Show each page of the mnemonic on screen */
+  for (uint32_t current_page = 0; current_page < page_count; current_page++) {
+    char title[MEDIUM_STR_BUF];
+
+    if (page_count > 1) {
+      snprintf(title, MEDIUM_STR_BUF, "BIP-85 Seed %" PRIu32 "/%" PRIu32,
+               current_page + 1, page_count);
+    } else {
+      snprintf(title, MEDIUM_STR_BUF, "BIP-85 Seed");
+    }
+
+    if (!confirm_constant_power(
+            ButtonRequestType_ButtonRequest_ConfirmWord, title, "%s",
+            formatted_mnemonic[current_page])) {
+      memzero(tokened_mnemonic, sizeof(tokened_mnemonic));
+      memzero(formatted_mnemonic, sizeof(formatted_mnemonic));
+      memzero(mnemonic_display, sizeof(mnemonic_display));
+      memzero(formatted_word, sizeof(formatted_word));
+      display_constant_power(false);
+      fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                      "BIP-85 display cancelled");
+      layoutHome();
+      return;
+    }
+  }
+
+  display_constant_power(false);
+
+  /* Wipe all sensitive buffers */
+  memzero(tokened_mnemonic, sizeof(tokened_mnemonic));
+  memzero(formatted_mnemonic, sizeof(formatted_mnemonic));
+  memzero(mnemonic_display, sizeof(mnemonic_display));
+  memzero(formatted_word, sizeof(formatted_word));
+
+  /* Send success — mnemonic is NOT sent over the wire */
+  fsm_sendSuccess("BIP-85 seed displayed on device");
+  layoutHome();
+}

--- a/lib/firmware/messagemap.def
+++ b/lib/firmware/messagemap.def
@@ -73,6 +73,9 @@
     MSG_IN(MessageType_MessageType_MayachainSignTx,                 MayachainSignTx,             fsm_msgMayachainSignTx)
     MSG_IN(MessageType_MessageType_MayachainMsgAck,                 MayachainMsgAck,             fsm_msgMayachainMsgAck)
 
+    MSG_IN(MessageType_MessageType_GetBip85Mnemonic,               GetBip85Mnemonic,            fsm_msgGetBip85Mnemonic)
+    MSG_OUT(MessageType_MessageType_Bip85Mnemonic,                  Bip85Mnemonic,               NO_PROCESS_FUNC)
+
     /* Normal Out Messages */
     MSG_OUT(MessageType_MessageType_Success,                        Success,                     NO_PROCESS_FUNC)
     MSG_OUT(MessageType_MessageType_Failure,                        Failure,                     NO_PROCESS_FUNC)


### PR DESCRIPTION
## Summary
- BIP-85 child mnemonic derivation, displayed on device screen only
- Mnemonic NEVER sent over USB — `Bip85Mnemonic` response contains only success status
- Supports 12/18/24 word outputs with configurable BIP-39 app index
- All sensitive buffers zeroed on every exit path (abort, error, success)

## Files
- `bip85.h` / `bip85.c` — derivation logic (HMAC-SHA512 per BIP-85 spec)
- `fsm_msg_bip85.h` — FSM handler with user confirmation flow
- Wiring: +1 line each to `fsm.h`, `CMakeLists.txt`, `messagemap.def`, `fsm.c`

## Test plan
- CI: ARM + emulator build
- Manual: send `GetBip85Mnemonic` → device shows derived words, USB response has no mnemonic