### PR TITLE
feat: Zcash Orchard shielded transaction support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.7.2)
 
 project(
   KeepKeyFirmware
-  VERSION 7.14.0
+  VERSION 7.15.0
   LANGUAGES C CXX ASM)
 
 set(BOOTLOADER_MAJOR_VERSION 2)

--- a/deps/crypto/CMakeLists.txt
+++ b/deps/crypto/CMakeLists.txt
@@ -55,7 +55,9 @@ set(sources
     trezor-firmware/crypto/aes/aescrypt.c
     trezor-firmware/crypto/aes/aes_modes.c
     #trezor-firmware/crypto/aes/aestst.c
-    trezor-firmware/crypto/aes/aestab.c)
+    trezor-firmware/crypto/aes/aestab.c
+    trezor-firmware/crypto/pallas.c
+    trezor-firmware/crypto/redpallas.c)
 
     # Clang 5.0 in the docker image (kktech/firmware:v7) is missing
     # <xmmintrin.h>, which breaks these. Until they're needed, we'll just elide

--- a/include/keepkey/firmware/fsm.h
+++ b/include/keepkey/firmware/fsm.h
@@ -127,6 +127,11 @@ void fsm_msgTronSignTx(TronSignTx *msg);
 void fsm_msgTonGetAddress(const TonGetAddress *msg);
 void fsm_msgTonSignTx(TonSignTx *msg);
 void fsm_msgEthereumTxMetadata(const EthereumTxMetadata *msg);
+void fsm_msgZcashSignPCZT(const ZcashSignPCZT *msg);
+void fsm_msgZcashPCZTAction(const ZcashPCZTAction *msg);
+void fsm_msgZcashGetOrchardFVK(const ZcashGetOrchardFVK *msg);
+void fsm_msgZcashDisplayAddress(const ZcashDisplayAddress *msg);
+void fsm_msgZcashTransparentInput(const ZcashTransparentInput *msg);
 #endif // BITCOIN_ONLY
 
 #if DEBUG_LINK

--- a/include/keepkey/firmware/zcash.h
+++ b/include/keepkey/firmware/zcash.h
@@ -1,0 +1,70 @@
+/*
+ * This file is part of the KeepKey project.
+ *
+ * Copyright (C) 2025 KeepKey
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPKEY_FIRMWARE_ZCASH_H
+#define KEEPKEY_FIRMWARE_ZCASH_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/* Orchard spending keys derived via ZIP-32 */
+typedef struct {
+  uint8_t sk[32];    /* Spending key (master secret at this level) */
+  uint8_t ask[32];   /* Spend authorizing key (scalar) */
+  uint8_t nk[32];    /* Nullifier deriving key */
+  uint8_t rivk[32];  /* Commitment randomness key */
+} ZcashOrchardKeys;
+
+/**
+ * Derive Orchard spending keys from the device seed via ZIP-32.
+ * Path: m_orchard / 32' / 133' / account'
+ *
+ * Uses BLAKE2b with personalization "ZcashIP32Orchard" for key derivation.
+ *
+ * @param seed       BIP-39 master seed
+ * @param seed_len   Seed length (typically 64 bytes)
+ * @param account    Account index (0-based, will be hardened)
+ * @param keys       Output: derived Orchard keys
+ * @return true on success
+ */
+bool zcash_derive_orchard_keys(const uint8_t *seed, uint32_t seed_len,
+                               uint32_t account, ZcashOrchardKeys *keys);
+
+/**
+ * Compute the ZIP 244 shielded sighash for Orchard spend authorization.
+ *
+ * For shielded-only transactions, transparent_sig_digest uses the "no inputs"
+ * form. For mixed transactions, transparent data must be provided separately.
+ *
+ * @param header_digest     32-byte pre-computed header digest
+ * @param transparent_digest 32-byte transparent sig digest (or empty hash)
+ * @param sapling_digest    32-byte sapling digest (or empty hash)
+ * @param orchard_digest    32-byte orchard digest
+ * @param branch_id         Consensus branch ID (LE)
+ * @param sighash_out       32-byte output sighash
+ * @return true on success
+ */
+bool zcash_compute_shielded_sighash(const uint8_t header_digest[32],
+                                    const uint8_t transparent_digest[32],
+                                    const uint8_t sapling_digest[32],
+                                    const uint8_t orchard_digest[32],
+                                    uint32_t branch_id,
+                                    uint8_t sighash_out[32]);
+
+#endif

--- a/lib/firmware/CMakeLists.txt
+++ b/lib/firmware/CMakeLists.txt
@@ -41,6 +41,7 @@ set(sources
     thorchain.c
     ton.c
     tron.c
+    zcash.c
     tiny-json.c
     transaction.c
     txin_check.c

--- a/lib/firmware/fsm.c
+++ b/lib/firmware/fsm.c
@@ -63,6 +63,7 @@
 #include "keepkey/firmware/thorchain.h"
 #include "keepkey/firmware/ton.h"
 #include "keepkey/firmware/tron.h"
+#include "keepkey/firmware/zcash.h"
 #include "keepkey/firmware/transaction.h"
 #include "keepkey/firmware/txin_check.h"
 #include "keepkey/firmware/u2f.h"
@@ -92,6 +93,7 @@
 #include "messages-solana.pb.h"
 #include "messages-tron.pb.h"
 #include "messages-ton.pb.h"
+#include "messages-zcash.pb.h"
 
 #include <stdio.h>
 
@@ -295,4 +297,5 @@ void fsm_msgClearSession(ClearSession *msg) {
 #include "fsm_msg_solana.h"
 #include "fsm_msg_tron.h"
 #include "fsm_msg_ton.h"
+#include "fsm_msg_zcash.h"
 #include "fsm_msg_bip85.h"

--- a/lib/firmware/fsm_msg_zcash.h
+++ b/lib/firmware/fsm_msg_zcash.h
@@ -1,0 +1,876 @@
+/*
+ * This file is part of the KeepKey project.
+ *
+ * Copyright (C) 2025 KeepKey
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* Zcash-specific headers — included here because fsm_msg_zcash.h
+ * is #include'd inside fsm.c, not compiled separately. */
+#include "keepkey/firmware/zcash.h"
+#include "trezor/crypto/blake2b.h"
+#include "trezor/crypto/pallas.h"
+#include "trezor/crypto/redpallas.h"
+#include "trezor/crypto/memzero.h"
+
+/* Precomputed empty digest constants for shielded-only transactions.
+ * These are BLAKE2b-256 with the respective personalizations over empty input.
+ * Verified against Keystone3 test vectors. */
+static const uint8_t EMPTY_TRANSPARENT_DIGEST[32] = {
+  0xc3, 0x3f, 0x2e, 0x95, 0x70, 0x5f, 0xaa, 0xb3,
+  0x5f, 0x8d, 0x53, 0x3f, 0xa6, 0x1e, 0x95, 0xc3,
+  0xb7, 0xaa, 0xba, 0x07, 0x76, 0xb8, 0x74, 0xa9,
+  0xf7, 0x4f, 0xc1, 0x27, 0x84, 0x37, 0x6a, 0x59
+};
+
+static const uint8_t EMPTY_SAPLING_DIGEST[32] = {
+  0x6f, 0x2f, 0xc8, 0xf9, 0x8f, 0xea, 0xfd, 0x94,
+  0xe7, 0x4a, 0x0d, 0xf4, 0xbe, 0xd7, 0x43, 0x91,
+  0xee, 0x0b, 0x5a, 0x69, 0x94, 0x5e, 0x4c, 0xed,
+  0x8c, 0xa8, 0xa0, 0x95, 0x20, 0x6f, 0x00, 0xae
+};
+
+/* Zcash shielded signing state */
+static struct {
+  bool active;
+  uint32_t account;
+  uint32_t n_actions;
+  uint32_t current_action;
+  uint64_t total_amount;
+  uint64_t fee;
+  uint32_t branch_id;
+  ZcashOrchardKeys keys;
+  uint8_t sighash[32];
+  /* Phase 2a: on-device sighash computation */
+  bool has_device_sighash;
+  /* Phase 2b: incremental orchard digest verification */
+  bool verify_orchard_digest;
+  uint8_t expected_orchard_digest[32];
+  BLAKE2B_CTX compact_ctx;
+  BLAKE2B_CTX memos_ctx;
+  BLAKE2B_CTX noncompact_ctx;
+  uint8_t orchard_flags;
+  int64_t orchard_value_balance;
+  uint8_t orchard_anchor[32];
+  /* Signatures buffer: up to 16 actions (64 bytes each) */
+  uint8_t signatures[16][64];
+  /* Phase 3: transparent shielding state */
+  uint32_t n_transparent_inputs;
+  uint32_t current_transparent_input;
+} zcash_signing;
+
+#define ZCASH_MAX_ACTIONS 16
+#define ZCASH_MAX_TRANSPARENT_INPUTS 8
+
+void fsm_msgZcashSignPCZT(const ZcashSignPCZT *msg) {
+  RESP_INIT(ZcashPCZTActionAck);
+
+  CHECK_INITIALIZED
+
+  CHECK_PIN
+
+  /* Validate parameters */
+  if (!msg->has_n_actions || msg->n_actions == 0) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("No actions specified"));
+    layoutHome();
+    return;
+  }
+
+  if (msg->n_actions > ZCASH_MAX_ACTIONS) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Too many Orchard actions"));
+    layoutHome();
+    return;
+  }
+
+  /* Determine account from path or explicit account field */
+  uint32_t account = 0;
+  if (msg->has_account) {
+    account = msg->account;
+  } else if (msg->address_n_count >= 3) {
+    /* Extract account from path: m/32'/133'/account' */
+    account = msg->address_n[2] & 0x7FFFFFFF;  /* Strip hardened bit */
+  }
+
+  /* Confirm with user */
+  char amount_str[32];
+  char fee_str[32];
+  uint64_t total = msg->has_total_amount ? msg->total_amount : 0;
+  uint64_t fee = msg->has_fee ? msg->fee : 0;
+
+  /* Format amounts (1 ZEC = 100,000,000 zatoshis).
+   * Strip trailing zeros from the fractional part for readability:
+   * 10000 zatoshis → "0.0001 ZEC" not "0.00010000 ZEC" */
+  {
+    char frac_buf[16];
+    unsigned long long w = (unsigned long long)(total / 100000000ULL);
+    unsigned long long f = (unsigned long long)(total % 100000000ULL);
+    snprintf(frac_buf, sizeof(frac_buf), "%08llu", f);
+    /* strip trailing zeros, keep at least 1 digit */
+    int flen = 8;
+    while (flen > 1 && frac_buf[flen - 1] == '0') flen--;
+    frac_buf[flen] = '\0';
+    snprintf(amount_str, sizeof(amount_str), "%llu.%s ZEC", w, frac_buf);
+  }
+  {
+    char frac_buf[16];
+    unsigned long long w = (unsigned long long)(fee / 100000000ULL);
+    unsigned long long f = (unsigned long long)(fee % 100000000ULL);
+    snprintf(frac_buf, sizeof(frac_buf), "%08llu", f);
+    int flen = 8;
+    while (flen > 1 && frac_buf[flen - 1] == '0') flen--;
+    frac_buf[flen] = '\0';
+    snprintf(fee_str, sizeof(fee_str), "%llu.%s ZEC", w, frac_buf);
+  }
+
+  /* Display confirmation — different text for shielded-only vs hybrid */
+  uint32_t n_tinputs = msg->has_n_transparent_inputs ? msg->n_transparent_inputs : 0;
+  if (n_tinputs > 0) {
+    if (!confirm(ButtonRequestType_ButtonRequest_SignTx,
+                 "Zcash Shield", "Shield transparent ZEC to Orchard?\n"
+                 "Amount: %s\nFee: %s\nInputs: %lu\nActions: %lu",
+                 amount_str, fee_str,
+                 (unsigned long)n_tinputs,
+                 (unsigned long)msg->n_actions)) {
+      fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                      _("Signing cancelled"));
+      layoutHome();
+      return;
+    }
+  } else {
+    if (!confirm(ButtonRequestType_ButtonRequest_SignTx,
+                 "Zcash Shielded", "Sign shielded transaction?\n"
+                 "Amount: %s\nFee: %s\nActions: %lu",
+                 amount_str, fee_str, (unsigned long)msg->n_actions)) {
+      fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                      _("Signing cancelled"));
+      layoutHome();
+      return;
+    }
+  }
+
+  /* Get the real BIP-39 seed for ZIP-32 Orchard derivation.
+   * storage_getSeed() returns the 64-byte mnemonic-derived seed,
+   * handling passphrase entry if needed. This is NOT the BIP-32
+   * root key — ZIP-32 Orchard uses a completely separate derivation
+   * tree rooted at the raw seed. */
+  const uint8_t *seed = storage_getRawSeed(true);
+  if (!seed) {
+    fsm_sendFailure(FailureType_Failure_NotInitialized,
+                    _("Device not initialized or seed unavailable"));
+    layoutHome();
+    return;
+  }
+
+  if (!zcash_derive_orchard_keys(seed, 64, account,
+                                 &zcash_signing.keys)) {
+    fsm_sendFailure(FailureType_Failure_Other,
+                    _("Orchard key derivation failed"));
+    layoutHome();
+    return;
+  }
+
+  /* Initialize signing state */
+  zcash_signing.active = true;
+  zcash_signing.account = account;
+  zcash_signing.n_actions = msg->n_actions;
+  zcash_signing.current_action = 0;
+  zcash_signing.total_amount = total;
+  zcash_signing.fee = fee;
+  zcash_signing.branch_id = msg->has_branch_id ? msg->branch_id : 0x37519621;
+  zcash_signing.has_device_sighash = false;
+  zcash_signing.verify_orchard_digest = false;
+  zcash_signing.n_transparent_inputs =
+      msg->has_n_transparent_inputs ? msg->n_transparent_inputs : 0;
+  zcash_signing.current_transparent_input = 0;
+
+  if (zcash_signing.n_transparent_inputs > ZCASH_MAX_TRANSPARENT_INPUTS) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Too many transparent inputs"));
+    zcash_signing.active = false;
+    layoutHome();
+    return;
+  }
+
+  /* Phase 2a: Compute sighash on-device if sub-digests are provided.
+   *
+   * TRUST MODEL:
+   *
+   * What the device verifies:
+   *   - Orchard digest: recomputed from streamed action data (Phase 2b)
+   *     covering nullifiers, commitments, ephemeral keys, ciphertexts,
+   *     value commitments, randomized keys, flags, value balance, anchor.
+   *   - Sighash: assembled on-device from the 4 sub-digests.
+   *
+   * What the device trusts from the host:
+   *   - header_digest, transparent_digest, sapling_digest: accepted
+   *     without verification. The device cannot recompute these without
+   *     the full transaction data, which exceeds memory constraints.
+   *   - Displayed amounts (total_amount, fee): these are for user
+   *     confirmation only. Orchard values are hidden by Pedersen
+   *     commitments (cv_net) — the device cannot extract plaintext
+   *     amounts from the verified digest. This is inherent to the
+   *     Zcash shielded protocol, not a firmware limitation.
+   *
+   * For shielded-only transactions (no transparent inputs):
+   *   transparent_digest defaults to the well-known empty hash,
+   *   so no trust assumption is needed for that component.
+   *
+   * For mixed transactions:
+   *   The host is trusted for non-Orchard components. This matches
+   *   the trust model of other Zcash hardware wallet implementations
+   *   (Keystone, Trezor) for the streaming PCZT protocol. */
+  if (msg->has_header_digest && msg->header_digest.size == 32 &&
+      msg->has_orchard_digest && msg->orchard_digest.size == 32) {
+
+    uint8_t t_digest[32], s_digest[32];
+
+    /* Use provided transparent digest, or default to empty */
+    if (msg->has_transparent_digest && msg->transparent_digest.size == 32) {
+      memcpy(t_digest, msg->transparent_digest.bytes, 32);
+    } else {
+      memcpy(t_digest, EMPTY_TRANSPARENT_DIGEST, 32);
+    }
+
+    /* Use provided sapling digest, or default to empty */
+    if (msg->has_sapling_digest && msg->sapling_digest.size == 32) {
+      memcpy(s_digest, msg->sapling_digest.bytes, 32);
+    } else {
+      memcpy(s_digest, EMPTY_SAPLING_DIGEST, 32);
+    }
+
+    zcash_compute_shielded_sighash(
+        msg->header_digest.bytes, t_digest, s_digest,
+        msg->orchard_digest.bytes,
+        zcash_signing.branch_id,
+        zcash_signing.sighash);
+    zcash_signing.has_device_sighash = true;
+
+    /* Phase 2b: Initialize orchard digest verification if bundle metadata
+     * is provided (orchard_flags, orchard_value_balance, orchard_anchor).
+     * The device will incrementally hash each action's data and verify
+     * the computed orchard_digest matches the one used for sighash. */
+    if (msg->has_orchard_flags && msg->has_orchard_value_balance &&
+        msg->has_orchard_anchor && msg->orchard_anchor.size == 32) {
+
+      memcpy(zcash_signing.expected_orchard_digest,
+             msg->orchard_digest.bytes, 32);
+      zcash_signing.orchard_flags = (uint8_t)msg->orchard_flags;
+      zcash_signing.orchard_value_balance = msg->orchard_value_balance;
+      memcpy(zcash_signing.orchard_anchor, msg->orchard_anchor.bytes, 32);
+
+      /* Initialize BLAKE2b streaming contexts for the 3 sub-hashes */
+      blake2b_InitPersonal(&zcash_signing.compact_ctx, 32,
+                           "ZTxIdOrcActCHash", 16);
+      blake2b_InitPersonal(&zcash_signing.memos_ctx, 32,
+                           "ZTxIdOrcActMHash", 16);
+      blake2b_InitPersonal(&zcash_signing.noncompact_ctx, 32,
+                           "ZTxIdOrcActNHash", 16);
+      zcash_signing.verify_orchard_digest = true;
+    }
+  }
+
+  /* Request first action data */
+  resp->has_next_index = true;
+  resp->next_index = 0;
+  msg_write(MessageType_MessageType_ZcashPCZTActionAck, resp);
+  layoutProgress(_("Signing Zcash"), 0);
+}
+
+void fsm_msgZcashGetOrchardFVK(const ZcashGetOrchardFVK *msg) {
+  RESP_INIT(ZcashOrchardFVK);
+
+  CHECK_INITIALIZED
+
+  CHECK_PIN
+
+  /* Confirmation required: FVK reveals all transaction history */
+  if (!confirm(ButtonRequestType_ButtonRequest_Other,
+               "Zcash Orchard", "Export Full Viewing Key?\n"
+               "This reveals all\ntransaction history.")) {
+    fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
+    layoutHome();
+    return;
+  }
+
+  /* Determine account from path or explicit account field */
+  uint32_t account = 0;
+  if (msg->has_account) {
+    account = msg->account;
+  } else if (msg->address_n_count >= 3) {
+    account = msg->address_n[2] & 0x7FFFFFFF;
+  }
+
+  /* Get the real BIP-39 seed for ZIP-32 Orchard derivation */
+  const uint8_t *seed = storage_getRawSeed(true);
+  if (!seed) {
+    fsm_sendFailure(FailureType_Failure_NotInitialized,
+                    _("Device not initialized or seed unavailable"));
+    layoutHome();
+    return;
+  }
+
+  ZcashOrchardKeys keys;
+  if (!zcash_derive_orchard_keys(seed, 64, account, &keys)) {
+    fsm_sendFailure(FailureType_Failure_Other,
+                    _("Orchard key derivation failed"));
+    layoutHome();
+    return;
+  }
+
+  /* Compute ak = [ask]G_spendauth on Pallas curve (SpendAuth basepoint) */
+  bignum256 ask_scalar;
+  bn_read_le(keys.ask, &ask_scalar);
+  curve_point ak_point;
+  redpallas_scalar_mult_spendauth_G(&ask_scalar, &ak_point);
+
+  /* Serialize ak as Pallas point (LE x-coord, sign bit in high byte) */
+  uint8_t ak_bytes[32];
+  bignum256 x_copy;
+  bn_copy(&ak_point.x, &x_copy);
+  bn_write_le(&x_copy, ak_bytes);
+  if (bn_is_odd(&ak_point.y)) {
+    ak_bytes[31] |= 0x80;
+  }
+
+  /* Build response */
+  resp->has_ak = true;
+  resp->ak.size = 32;
+  memcpy(resp->ak.bytes, ak_bytes, 32);
+
+  resp->has_nk = true;
+  resp->nk.size = 32;
+  memcpy(resp->nk.bytes, keys.nk, 32);
+
+  resp->has_rivk = true;
+  resp->rivk.size = 32;
+  memcpy(resp->rivk.bytes, keys.rivk, 32);
+
+  /* Clean up sensitive data */
+  memzero(&ask_scalar, sizeof(ask_scalar));
+  memzero(&keys, sizeof(keys));
+
+  msg_write(MessageType_MessageType_ZcashOrchardFVK, resp);
+  layoutHome();
+}
+
+void fsm_msgZcashDisplayAddress(const ZcashDisplayAddress *msg) {
+  RESP_INIT(ZcashAddress);
+
+  CHECK_INITIALIZED
+
+  CHECK_PIN
+
+  /* Validate required fields */
+  if (!msg->has_address || strlen(msg->address) < 10) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Missing or invalid address"));
+    layoutHome();
+    return;
+  }
+  if (!msg->has_ak || msg->ak.size != 32 ||
+      !msg->has_nk || msg->nk.size != 32 ||
+      !msg->has_rivk || msg->rivk.size != 32) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Missing FVK components (ak, nk, rivk)"));
+    layoutHome();
+    return;
+  }
+
+  /* Validate address format: must start with "u1" (mainnet UA) */
+  if (msg->address[0] != 'u' || msg->address[1] != '1') {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Invalid unified address prefix"));
+    layoutHome();
+    return;
+  }
+
+  /* Determine account — require explicit account or valid ZIP-32 path.
+   * When using address_n, enforce the expected Orchard path shape:
+   *   m/32'/133'/account'  (all hardened)
+   * This matches the derivation used in ZcashGetOrchardFVK and
+   * ZcashSignPCZT, and prevents a malformed path from silently
+   * deriving against an unintended account. */
+  uint32_t account;
+  if (msg->has_account) {
+    account = msg->account;
+  } else if (msg->address_n_count == 3 &&
+             msg->address_n[0] == (0x80000000 | 32) &&
+             msg->address_n[1] == (0x80000000 | 133) &&
+             (msg->address_n[2] & 0x80000000)) {
+    account = msg->address_n[2] & 0x7FFFFFFF;
+  } else {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Require account field or ZIP-32 path m/32'/133'/account'"));
+    layoutHome();
+    return;
+  }
+
+  /* Get the real BIP-39 seed for ZIP-32 Orchard derivation */
+  const uint8_t *seed = storage_getRawSeed(true);
+  if (!seed) {
+    fsm_sendFailure(FailureType_Failure_NotInitialized,
+                    _("Device not initialized or seed unavailable"));
+    layoutHome();
+    return;
+  }
+
+  ZcashOrchardKeys keys;
+  if (!zcash_derive_orchard_keys(seed, 64, account, &keys)) {
+    fsm_sendFailure(FailureType_Failure_Other,
+                    _("Orchard key derivation failed"));
+    layoutHome();
+    return;
+  }
+
+  /* Compute ak = [ask]G_spendauth on Pallas curve (SpendAuth basepoint) */
+  bignum256 ask_scalar;
+  bn_read_le(keys.ask, &ask_scalar);
+  curve_point ak_point;
+  redpallas_scalar_mult_spendauth_G(&ask_scalar, &ak_point);
+
+  /* Serialize ak as Pallas point (LE x-coord, sign bit in high byte) */
+  uint8_t ak_bytes[32];
+  bignum256 x_copy;
+  bn_copy(&ak_point.x, &x_copy);
+  bn_write_le(&x_copy, ak_bytes);
+  if (bn_is_odd(&ak_point.y)) {
+    ak_bytes[31] |= 0x80;
+  }
+
+  /* Verify FVK components match device-derived keys */
+  bool fvk_match = (memcmp(ak_bytes, msg->ak.bytes, 32) == 0) &&
+                   (memcmp(keys.nk, msg->nk.bytes, 32) == 0) &&
+                   (memcmp(keys.rivk, msg->rivk.bytes, 32) == 0);
+
+  /* Clean up sensitive key material BEFORE display prompt */
+  memzero(&ask_scalar, sizeof(ask_scalar));
+  memzero(&ak_point, sizeof(ak_point));
+  memzero(ak_bytes, sizeof(ak_bytes));
+  memzero(&x_copy, sizeof(x_copy));
+  memzero(&keys, sizeof(keys));
+
+  if (!fvk_match) {
+    fsm_sendFailure(FailureType_Failure_Other,
+                    _("FVK mismatch: address does not belong to this device"));
+    layoutHome();
+    return;
+  }
+
+  /* Display the address on screen with QR code.
+   *
+   * IMPORTANT LIMITATION: This verification only confirms that the
+   * Orchard FVK (ak/nk/rivk) in this UA was derived from this device's
+   * seed at the given account.  A Unified Address may bundle receivers
+   * from multiple pools (transparent, Sapling, Orchard).  The device
+   * cannot currently verify non-Orchard receivers — a compromised host
+   * could substitute attacker-controlled transparent or Sapling receivers
+   * while keeping the correct Orchard receiver.
+   *
+   * The display text explicitly scopes the claim to "Orchard key verified"
+   * so the user understands what was checked. */
+  char desc[48];
+  snprintf(desc, sizeof(desc), "Zcash #%lu Orchard", (unsigned long)account);
+  if (!confirm_zcash_address(desc, msg->address)) {
+    fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                    _("Address display cancelled"));
+    layoutHome();
+    return;
+  }
+
+  /* User confirmed — return the address */
+  resp->has_address = true;
+  strlcpy(resp->address, msg->address, sizeof(resp->address));
+
+  msg_write(MessageType_MessageType_ZcashAddress, resp);
+  layoutHome();
+}
+
+void fsm_msgZcashPCZTAction(const ZcashPCZTAction *msg) {
+  if (!zcash_signing.active) {
+    fsm_sendFailure(FailureType_Failure_UnexpectedMessage,
+                    _("Not in Zcash signing mode"));
+    layoutHome();
+    return;
+  }
+
+  /* Enforce transparent phase completion: if the session declared
+   * transparent inputs, ALL must be signed before Orchard actions.
+   * This prevents a malicious host from skipping transparent-input
+   * confirmations and jumping straight to Orchard signing. */
+  if (zcash_signing.current_transparent_input <
+      zcash_signing.n_transparent_inputs) {
+    fsm_sendFailure(FailureType_Failure_UnexpectedMessage,
+                    _("Transparent inputs not yet complete"));
+    zcash_signing.active = false;
+    memzero(&zcash_signing.keys, sizeof(zcash_signing.keys));
+    layoutHome();
+    return;
+  }
+
+  /* Validate action index */
+  if (!msg->has_index || msg->index != zcash_signing.current_action) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Unexpected action index"));
+    zcash_signing.active = false;
+    memzero(&zcash_signing.keys, sizeof(zcash_signing.keys));
+    layoutHome();
+    return;
+  }
+
+  /* Validate required fields */
+  if (!msg->has_alpha || msg->alpha.size != 32) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Missing or invalid alpha randomizer"));
+    zcash_signing.active = false;
+    memzero(&zcash_signing.keys, sizeof(zcash_signing.keys));
+    layoutHome();
+    return;
+  }
+
+  /* Phase 2a: require sighash only in legacy mode */
+  if (!zcash_signing.has_device_sighash) {
+    if (!msg->has_sighash || msg->sighash.size != 32) {
+      fsm_sendFailure(FailureType_Failure_SyntaxError,
+                      _("Missing or invalid sighash"));
+      zcash_signing.active = false;
+      memzero(&zcash_signing.keys, sizeof(zcash_signing.keys));
+      layoutHome();
+      return;
+    }
+  }
+
+  /* Phase 2b: feed action data into incremental BLAKE2b contexts */
+  if (zcash_signing.verify_orchard_digest &&
+      msg->has_nullifier && msg->nullifier.size == 32 &&
+      msg->has_cmx && msg->cmx.size == 32 &&
+      msg->has_epk && msg->epk.size == 32 &&
+      msg->has_enc_compact && msg->enc_compact.size == 52 &&
+      msg->has_enc_memo && msg->enc_memo.size == 512 &&
+      msg->has_enc_noncompact && msg->enc_noncompact.size > 0 &&
+      msg->has_cv_net && msg->cv_net.size == 32 &&
+      msg->has_rk && msg->rk.size == 32 &&
+      msg->has_out_ciphertext && msg->out_ciphertext.size == 80) {
+
+    /* Compact: nf || cmx || epk || enc[0..52] */
+    blake2b_Update(&zcash_signing.compact_ctx, msg->nullifier.bytes, 32);
+    blake2b_Update(&zcash_signing.compact_ctx, msg->cmx.bytes, 32);
+    blake2b_Update(&zcash_signing.compact_ctx, msg->epk.bytes, 32);
+    blake2b_Update(&zcash_signing.compact_ctx, msg->enc_compact.bytes, 52);
+
+    /* Memos: enc[52..564] */
+    blake2b_Update(&zcash_signing.memos_ctx, msg->enc_memo.bytes, 512);
+
+    /* Noncompact: cv_net || rk || enc[564..] || out_ciphertext */
+    blake2b_Update(&zcash_signing.noncompact_ctx, msg->cv_net.bytes, 32);
+    blake2b_Update(&zcash_signing.noncompact_ctx, msg->rk.bytes, 32);
+    blake2b_Update(&zcash_signing.noncompact_ctx,
+                   msg->enc_noncompact.bytes, msg->enc_noncompact.size);
+    blake2b_Update(&zcash_signing.noncompact_ctx,
+                   msg->out_ciphertext.bytes, 80);
+  }
+
+  /* Use device-computed sighash if available, otherwise legacy host sighash */
+  const uint8_t *sighash = zcash_signing.has_device_sighash
+      ? zcash_signing.sighash
+      : msg->sighash.bytes;
+
+  /* Sign this action with RedPallas:
+   * sig = RedPallas.sign(ask, alpha, sighash) */
+  if (redpallas_sign_digest(zcash_signing.keys.ask,
+                            msg->alpha.bytes,
+                            sighash,
+                            zcash_signing.signatures[msg->index]) != 0) {
+    fsm_sendFailure(FailureType_Failure_Other,
+                    _("RedPallas signing failed"));
+    zcash_signing.active = false;
+    memzero(&zcash_signing.keys, sizeof(zcash_signing.keys));
+    layoutHome();
+    return;
+  }
+
+  zcash_signing.current_action++;
+
+  /* Update progress */
+  uint32_t progress = (zcash_signing.current_action * 1000) /
+                      zcash_signing.n_actions;
+  layoutProgress(_("Signing Zcash"), progress);
+
+  /* Check if all actions are signed */
+  if (zcash_signing.current_action >= zcash_signing.n_actions) {
+
+    /* Phase 2b: verify orchard digest before returning signatures */
+    if (zcash_signing.verify_orchard_digest) {
+      uint8_t compact_hash[32], memos_hash[32], noncompact_hash[32];
+
+      blake2b_Final(&zcash_signing.compact_ctx, compact_hash, 32);
+      blake2b_Final(&zcash_signing.memos_ctx, memos_hash, 32);
+      blake2b_Final(&zcash_signing.noncompact_ctx, noncompact_hash, 32);
+
+      /* Compute orchard_digest = BLAKE2b("ZTxIdOrchardHash",
+       *   compact_hash || memos_hash || noncompact_hash ||
+       *   flags(1) || value_balance(8) || anchor(32)) */
+      BLAKE2B_CTX orchard_ctx;
+      blake2b_InitPersonal(&orchard_ctx, 32, "ZTxIdOrchardHash", 16);
+      blake2b_Update(&orchard_ctx, compact_hash, 32);
+      blake2b_Update(&orchard_ctx, memos_hash, 32);
+      blake2b_Update(&orchard_ctx, noncompact_hash, 32);
+      blake2b_Update(&orchard_ctx, &zcash_signing.orchard_flags, 1);
+      blake2b_Update(&orchard_ctx,
+                     (const uint8_t *)&zcash_signing.orchard_value_balance, 8);
+      blake2b_Update(&orchard_ctx, zcash_signing.orchard_anchor, 32);
+
+      uint8_t computed_orchard_digest[32];
+      blake2b_Final(&orchard_ctx, computed_orchard_digest, 32);
+
+      /* Verify computed matches expected */
+      if (memcmp(computed_orchard_digest,
+                 zcash_signing.expected_orchard_digest, 32) != 0) {
+        fsm_sendFailure(FailureType_Failure_Other,
+                        _("Orchard digest mismatch: transaction data "
+                          "does not match sighash"));
+        zcash_signing.active = false;
+        memzero(&zcash_signing.keys, sizeof(zcash_signing.keys));
+        memzero(zcash_signing.signatures, sizeof(zcash_signing.signatures));
+        layoutHome();
+        return;
+      }
+    }
+
+    /* All done - send the collected signatures */
+    ZcashSignedPCZT *resp_signed = (ZcashSignedPCZT *)msg_resp;
+    memset(resp_signed, 0, sizeof(ZcashSignedPCZT));
+
+    resp_signed->signatures_count = zcash_signing.n_actions;
+    for (uint32_t i = 0; i < zcash_signing.n_actions; i++) {
+      resp_signed->signatures[i].size = 64;
+      memcpy(resp_signed->signatures[i].bytes, zcash_signing.signatures[i], 64);
+    }
+
+    /* Clean up */
+    zcash_signing.active = false;
+    memzero(&zcash_signing.keys, sizeof(zcash_signing.keys));
+    memzero(zcash_signing.signatures, sizeof(zcash_signing.signatures));
+
+    msg_write(MessageType_MessageType_ZcashSignedPCZT, resp_signed);
+    layoutHome();
+  } else {
+    /* Request next action */
+    ZcashPCZTActionAck *resp_ack = (ZcashPCZTActionAck *)msg_resp;
+    memset(resp_ack, 0, sizeof(ZcashPCZTActionAck));
+    resp_ack->has_next_index = true;
+    resp_ack->next_index = zcash_signing.current_action;
+    msg_write(MessageType_MessageType_ZcashPCZTActionAck, resp_ack);
+  }
+}
+
+/* Phase 3: Transparent input signing for hybrid shielding transactions.
+ *
+ * The host sends one ZcashTransparentInput per transparent input after
+ * the initial ZcashSignPCZT. The device derives the secp256k1 key at
+ * the provided BIP44 path, ECDSA-signs the per-input sighash, and
+ * returns a DER signature.
+ *
+ * After all transparent inputs, the device transitions to the Orchard
+ * action phase (ZcashPCZTAction streaming). */
+void fsm_msgZcashTransparentInput(const ZcashTransparentInput *msg) {
+  RESP_INIT(ZcashTransparentSig);
+
+  if (!zcash_signing.active) {
+    fsm_sendFailure(FailureType_Failure_UnexpectedMessage,
+                    _("Not in Zcash signing mode"));
+    layoutHome();
+    return;
+  }
+
+  if (zcash_signing.n_transparent_inputs == 0) {
+    fsm_sendFailure(FailureType_Failure_UnexpectedMessage,
+                    _("No transparent inputs expected"));
+    zcash_signing.active = false;
+    memzero(&zcash_signing.keys, sizeof(zcash_signing.keys));
+    layoutHome();
+    return;
+  }
+
+  if (msg->index != zcash_signing.current_transparent_input) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Unexpected transparent input index"));
+    zcash_signing.active = false;
+    memzero(&zcash_signing.keys, sizeof(zcash_signing.keys));
+    layoutHome();
+    return;
+  }
+
+  if (msg->sighash.size != 32) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Invalid sighash size"));
+    zcash_signing.active = false;
+    memzero(&zcash_signing.keys, sizeof(zcash_signing.keys));
+    layoutHome();
+    return;
+  }
+
+  /* PATH ENFORCEMENT: transparent inputs must use exactly
+   * m/44'/133'/account'/change/index where:
+   *   - account' is hardened and matches the session account
+   *   - change is 0 (external) or 1 (internal)
+   *   - index is unhardened
+   *
+   * This prevents a compromised host from pivoting a shielding approval
+   * into signing with arbitrary secp256k1 keys on the device. */
+  if (msg->address_n_count != 5) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Path must be m/44'/133'/account'/change/index"));
+    zcash_signing.active = false;
+    memzero(&zcash_signing.keys, sizeof(zcash_signing.keys));
+    layoutHome();
+    return;
+  }
+
+  if (msg->address_n[0] != (0x80000000 | 44) ||
+      msg->address_n[1] != (0x80000000 | 133)) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Path must start with m/44'/133'"));
+    zcash_signing.active = false;
+    memzero(&zcash_signing.keys, sizeof(zcash_signing.keys));
+    layoutHome();
+    return;
+  }
+
+  /* Account must be hardened and match the approved session */
+  if (!(msg->address_n[2] & 0x80000000)) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Account must be hardened"));
+    zcash_signing.active = false;
+    memzero(&zcash_signing.keys, sizeof(zcash_signing.keys));
+    layoutHome();
+    return;
+  }
+
+  uint32_t path_account = msg->address_n[2] & 0x7FFFFFFF;
+  if (path_account != zcash_signing.account) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Account does not match approved session"));
+    zcash_signing.active = false;
+    memzero(&zcash_signing.keys, sizeof(zcash_signing.keys));
+    layoutHome();
+    return;
+  }
+
+  /* Change must be 0 (external) or 1 (internal), unhardened */
+  if (msg->address_n[3] > 1) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Change must be 0 or 1"));
+    zcash_signing.active = false;
+    memzero(&zcash_signing.keys, sizeof(zcash_signing.keys));
+    layoutHome();
+    return;
+  }
+
+  /* Index must be unhardened */
+  if (msg->address_n[4] & 0x80000000) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Index must not be hardened"));
+    zcash_signing.active = false;
+    memzero(&zcash_signing.keys, sizeof(zcash_signing.keys));
+    layoutHome();
+    return;
+  }
+
+  /* Per-input confirmation: show the user what's being signed */
+  {
+    char input_str[64];
+    uint64_t amt = msg->has_amount ? msg->amount : 0;
+    {
+      char frac_buf[16];
+      unsigned long long w = (unsigned long long)(amt / 100000000ULL);
+      unsigned long long f = (unsigned long long)(amt % 100000000ULL);
+      snprintf(frac_buf, sizeof(frac_buf), "%08llu", f);
+      int flen = 8;
+      while (flen > 1 && frac_buf[flen - 1] == '0') flen--;
+      frac_buf[flen] = '\0';
+      snprintf(input_str, sizeof(input_str), "Input %lu: %llu.%s ZEC",
+               (unsigned long)(msg->index + 1), w, frac_buf);
+    }
+    if (!confirm(ButtonRequestType_ButtonRequest_SignTx,
+                 "Sign Input", "Sign transparent input?\n%s",
+                 input_str)) {
+      fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                      _("Signing cancelled"));
+      zcash_signing.active = false;
+      memzero(&zcash_signing.keys, sizeof(zcash_signing.keys));
+      layoutHome();
+      return;
+    }
+  }
+
+  /* Derive the secp256k1 key at the validated Zcash BIP44 path */
+  const CoinType *coin = fsm_getCoin(true, "Zcash");
+  if (!coin) {
+    fsm_sendFailure(FailureType_Failure_Other, _("Unknown coin: Zcash"));
+    zcash_signing.active = false;
+    memzero(&zcash_signing.keys, sizeof(zcash_signing.keys));
+    layoutHome();
+    return;
+  }
+
+  HDNode *node = fsm_getDerivedNode(coin->curve_name, msg->address_n,
+                                    msg->address_n_count, NULL);
+  if (!node) {
+    zcash_signing.active = false;
+    memzero(&zcash_signing.keys, sizeof(zcash_signing.keys));
+    layoutHome();
+    return;
+  }
+
+  hdnode_fill_public_key(node);
+
+  /* ECDSA sign the per-input sighash */
+  uint8_t sig[64];
+  if (hdnode_sign_digest(node, msg->sighash.bytes, sig, NULL, NULL) != 0) {
+    fsm_sendFailure(FailureType_Failure_Other,
+                    _("ECDSA signing failed"));
+    memzero(node, sizeof(*node));
+    zcash_signing.active = false;
+    memzero(&zcash_signing.keys, sizeof(zcash_signing.keys));
+    layoutHome();
+    return;
+  }
+
+  /* DER encode the signature */
+  uint8_t der_sig[73];
+  int der_len = ecdsa_sig_to_der(sig, der_sig);
+
+  /* Build response — signature is a required field (no has_ prefix in nanopb) */
+  resp->signature.size = der_len;
+  memcpy(resp->signature.bytes, der_sig, der_len);
+
+  zcash_signing.current_transparent_input++;
+  resp->has_next_index = true;
+
+  if (zcash_signing.current_transparent_input >=
+      zcash_signing.n_transparent_inputs) {
+    resp->next_index = 0xFF;
+  } else {
+    resp->next_index = zcash_signing.current_transparent_input;
+  }
+
+  memzero(node, sizeof(*node));
+  memzero(sig, sizeof(sig));
+
+  msg_write(MessageType_MessageType_ZcashTransparentSig, resp);
+  layoutProgress(_("Signing Zcash"), 0);
+}

--- a/lib/firmware/messagemap.def
+++ b/lib/firmware/messagemap.def
@@ -96,6 +96,17 @@
     MSG_IN(MessageType_MessageType_EthereumTxMetadata,             EthereumTxMetadata,          fsm_msgEthereumTxMetadata)
     MSG_OUT(MessageType_MessageType_EthereumMetadataAck,           EthereumMetadataAck,         NO_PROCESS_FUNC)
 
+    MSG_IN(MessageType_MessageType_ZcashSignPCZT,                  ZcashSignPCZT,               fsm_msgZcashSignPCZT)
+    MSG_IN(MessageType_MessageType_ZcashPCZTAction,                ZcashPCZTAction,             fsm_msgZcashPCZTAction)
+    MSG_IN(MessageType_MessageType_ZcashGetOrchardFVK,             ZcashGetOrchardFVK,          fsm_msgZcashGetOrchardFVK)
+    MSG_IN(MessageType_MessageType_ZcashDisplayAddress,            ZcashDisplayAddress,         fsm_msgZcashDisplayAddress)
+    MSG_IN(MessageType_MessageType_ZcashTransparentInput,          ZcashTransparentInput,       fsm_msgZcashTransparentInput)
+    MSG_OUT(MessageType_MessageType_ZcashOrchardFVK,                ZcashOrchardFVK,             NO_PROCESS_FUNC)
+    MSG_OUT(MessageType_MessageType_ZcashPCZTResult,                ZcashPCZTResult,             NO_PROCESS_FUNC)
+    MSG_OUT(MessageType_MessageType_ZcashActionResult,              ZcashActionResult,           NO_PROCESS_FUNC)
+    MSG_OUT(MessageType_MessageType_ZcashAddressAck,                ZcashAddressAck,             NO_PROCESS_FUNC)
+    MSG_OUT(MessageType_MessageType_ZcashTransparentSig,            ZcashTransparentSig,         NO_PROCESS_FUNC)
+
     /* Normal Out Messages */
     MSG_OUT(MessageType_MessageType_Success,                        Success,                     NO_PROCESS_FUNC)
     MSG_OUT(MessageType_MessageType_Failure,                        Failure,                     NO_PROCESS_FUNC)

--- a/lib/firmware/zcash.c
+++ b/lib/firmware/zcash.c
@@ -1,0 +1,308 @@
+/*
+ * This file is part of the KeepKey project.
+ *
+ * Copyright (C) 2025 KeepKey
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "keepkey/firmware/zcash.h"
+
+#include <string.h>
+
+#include "trezor/crypto/bignum.h"
+#include "trezor/crypto/blake2b.h"
+#include "trezor/crypto/hasher.h"
+#include "trezor/crypto/memzero.h"
+#include "trezor/crypto/pallas.h"
+#include "trezor/crypto/redpallas.h"
+
+/*
+ * ZIP-32 Orchard key derivation.
+ *
+ * Master key:
+ *   I = BLAKE2b-512("ZcashIP32Orchard", seed)
+ *   sk = I[0..32], chain_code = I[32..64]
+ *
+ * Child derivation (hardened only):
+ *   I = BLAKE2b-512("ZcashIP32Orchard", chain_code,
+ *                    0x11 || sk || i_be)
+ *   where 0x11 indicates hardened derivation with Orchard,
+ *   and i_be is the 4-byte big-endian child index with the hardened bit set.
+ *
+ * From the spending key sk, subkeys are derived using PRF^expand:
+ *   PRF^expand(sk, t) = BLAKE2b-512("Zcash_ExpandSeed", sk || t)
+ *
+ *   ask  = ToScalar(PRF^expand(sk, [0x06]))
+ *   nk   = ToBase(PRF^expand(sk, [0x07]))
+ *   rivk = ToScalar(PRF^expand(sk, [0x08]))
+ *
+ * ToScalar: interpret 64 bytes as LE integer, reduce mod order
+ * ToBase: interpret 64 bytes as LE integer, reduce mod prime
+ */
+
+/*
+ * BLAKE2b-512 with personalization "ZcashIP32Orchard" — master key only.
+ * Used for: I = BLAKE2b-512("ZcashIP32Orchard", seed)
+ * NOT used for child derivation (which uses PRF^expand).
+ */
+static void zip32_orchard_master(const uint8_t *seed, size_t seed_len,
+                                 uint8_t out[64]) {
+  BLAKE2B_CTX ctx;
+  blake2b_InitPersonal(&ctx, 64, "ZcashIP32Orchard", 16);
+  blake2b_Update(&ctx, seed, seed_len);
+  blake2b_Final(&ctx, out, 64);
+}
+
+/* PRF^expand(sk, t) = BLAKE2b-512("Zcash_ExpandSeed", sk || t) */
+static void prf_expand(const uint8_t sk[32], const uint8_t *t, size_t t_len,
+                       uint8_t out[64]) {
+  BLAKE2B_CTX ctx;
+  blake2b_InitPersonal(&ctx, 64, "Zcash_ExpandSeed", 16);
+  blake2b_Update(&ctx, sk, 32);
+  blake2b_Update(&ctx, t, t_len);
+  blake2b_Final(&ctx, out, 64);
+}
+
+/*
+ * 2^256 mod q (Pallas scalar field order), little-endian.
+ * q = 0x40000000000000000000000000000000224698fc0994a8dd8c46eb2100000001
+ * R = 0x3FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF992C350BE34205675B2B3E9CFFFFFFFD
+ * Verified: R + 3*q == 2^256.
+ */
+static const uint8_t two_256_mod_q[32] = {
+    0xfd, 0xff, 0xff, 0xff, 0x9c, 0x3e, 0x2b, 0x5b,
+    0x67, 0x05, 0x42, 0xe3, 0x0b, 0x35, 0x2c, 0x99,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x3f,
+};
+
+/*
+ * 2^256 mod p (Pallas base field prime), little-endian.
+ * p = 0x40000000000000000000000000000000224698fc094cf91b992d30ed00000001
+ * R = 0x3FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF992C350BE41914AD34786D38FFFFFFFD
+ * Verified: R + 3*p == 2^256.
+ */
+static const uint8_t two_256_mod_p[32] = {
+    0xfd, 0xff, 0xff, 0xff, 0x38, 0x6d, 0x78, 0x34,
+    0xad, 0x14, 0x19, 0xe4, 0x0b, 0x35, 0x2c, 0x99,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x3f,
+};
+
+/*
+ * ToScalar: reduce a 512-bit LE integer mod Pallas scalar order.
+ *
+ * Uses wide reduction matching the orchard crate's from_uniform_bytes:
+ *   result = (lo + hi * 2^256) mod q
+ * where lo = input[0..31], hi = input[32..63] (little-endian).
+ */
+static void to_scalar(const uint8_t input[64], uint8_t output[32]) {
+  bignum256 lo, hi, t256, result;
+
+  bn_read_le(input, &lo);
+  pallas_mod_q(&lo);
+
+  bn_read_le(input + 32, &hi);
+  pallas_mod_q(&hi);
+
+  bn_read_le(two_256_mod_q, &t256);
+
+  /* result = hi * (2^256 mod q) mod q */
+  bn_copy(&hi, &result);
+  pallas_mul_mod_q(&result, &t256);
+
+  /* result = result + lo mod q */
+  pallas_add_mod_q(&result, &lo);
+
+  bn_write_le(&result, output);
+
+  memzero(&lo, sizeof(lo));
+  memzero(&hi, sizeof(hi));
+  memzero(&result, sizeof(result));
+}
+
+/*
+ * ToBase: reduce a 512-bit LE integer mod Pallas base field prime.
+ *
+ * Uses wide reduction:
+ *   result = (lo + hi * 2^256) mod p
+ * where lo = input[0..31], hi = input[32..63] (little-endian).
+ */
+static void to_base(const uint8_t input[64], uint8_t output[32]) {
+  bignum256 lo, hi, t256, result;
+
+  bn_read_le(input, &lo);
+  pallas_mod_p(&lo);
+
+  bn_read_le(input + 32, &hi);
+  pallas_mod_p(&hi);
+
+  bn_read_le(two_256_mod_p, &t256);
+
+  /* result = hi * (2^256 mod p) mod p */
+  bn_copy(&hi, &result);
+  pallas_mul_mod_p(&result, &t256);
+
+  /* result = result + lo mod p */
+  bignum256 sum;
+  pallas_add_mod_p(&result, &lo, &sum);
+  bn_copy(&sum, &result);
+  memzero(&sum, sizeof(sum));
+
+  bn_write_le(&result, output);
+
+  memzero(&lo, sizeof(lo));
+  memzero(&hi, sizeof(hi));
+  memzero(&result, sizeof(result));
+}
+
+/* Hardened child index */
+#define ZIP32_HARDENED 0x80000000
+
+bool zcash_derive_orchard_keys(const uint8_t *seed, uint32_t seed_len,
+                               uint32_t account, ZcashOrchardKeys *keys) {
+  uint8_t I[64];
+  uint8_t sk[32], chain_code[32];
+
+  /* Step 1: Master key from seed
+   * I = BLAKE2b-512("ZcashIP32Orchard", seed) */
+  zip32_orchard_master(seed, seed_len, I);
+  memcpy(sk, I, 32);
+  memcpy(chain_code, I + 32, 32);
+
+  /* Step 2: Derive path m_orchard / 32' / 133' / account'
+   *
+   * CKDOrchard child derivation (ZIP-32 hardened-only):
+   *   I = PRF^expand(chain_code, [0x81] || sk || I2LEOSP32(index))
+   *
+   * PRF^expand(sk, t) = BLAKE2b-512("Zcash_ExpandSeed", sk || t)
+   *
+   * So: I = BLAKE2b-512("Zcash_ExpandSeed",
+   *           chain_code || 0x81 || sk || index_le)
+   */
+  uint32_t path[3] = {
+      32 | ZIP32_HARDENED,       /* Purpose (Orchard) */
+      133 | ZIP32_HARDENED,      /* Coin type (Zcash) */
+      account | ZIP32_HARDENED   /* Account */
+  };
+
+  for (int i = 0; i < 3; i++) {
+    /* Build PRF^expand input: [0x81] || sk || I2LEOSP32(index) */
+    uint8_t child_input[1 + 32 + 4];
+    child_input[0] = 0x81;  /* ORCHARD_ZIP32_CHILD domain separator */
+    memcpy(child_input + 1, sk, 32);
+    /* Little-endian index (I2LEOSP32) */
+    uint32_t idx = path[i];
+    child_input[33] = idx & 0xff;
+    child_input[34] = (idx >> 8) & 0xff;
+    child_input[35] = (idx >> 16) & 0xff;
+    child_input[36] = (idx >> 24) & 0xff;
+
+    /* PRF^expand(chain_code, child_input) */
+    prf_expand(chain_code, child_input, sizeof(child_input), I);
+    memcpy(sk, I, 32);
+    memcpy(chain_code, I + 32, 32);
+
+    memzero(child_input, sizeof(child_input));
+  }
+
+  /* Step 3: Derive subkeys from final spending key */
+  memcpy(keys->sk, sk, 32);
+
+  uint8_t expanded[64];
+
+  /* ask = ToScalar(PRF^expand(sk, [0x06])) */
+  uint8_t t_ask = 0x06;
+  prf_expand(sk, &t_ask, 1, expanded);
+  to_scalar(expanded, keys->ask);
+
+  /*
+   * Zcash spec (§ 4.2.3): If [ask]*G_spendauth has odd y (ỹ = 1),
+   * negate ask so that the resulting ak always has ỹ = 0.
+   * This matches the orchard crate's SpendAuthorizingKey::from() behavior.
+   */
+  {
+    bignum256 ask_test;
+    bn_read_le(keys->ask, &ask_test);
+    curve_point ak_test;
+    redpallas_scalar_mult_spendauth_G(&ask_test, &ak_test);
+    if (bn_is_odd(&ak_test.y)) {
+      /* ask = order - ask (negate mod q) */
+      bignum256 neg_ask;
+      bn_copy(&pallas_order, &neg_ask);
+      bignum256 ask_val;
+      bn_read_le(keys->ask, &ask_val);
+      bn_normalize(&ask_val);
+      bn_normalize(&neg_ask);
+      /* neg_ask = order - ask */
+      int32_t borrow = 0;
+      for (int i = 0; i < 9; i++) {
+        int32_t diff = (int32_t)neg_ask.val[i] - (int32_t)ask_val.val[i] + borrow;
+        if (diff < 0) {
+          diff += (1 << 29);
+          borrow = -1;
+        } else {
+          borrow = 0;
+        }
+        neg_ask.val[i] = (uint32_t)diff;
+      }
+      bn_write_le(&neg_ask, keys->ask);
+      memzero(&neg_ask, sizeof(neg_ask));
+      memzero(&ask_val, sizeof(ask_val));
+    }
+    memzero(&ask_test, sizeof(ask_test));
+    memzero(&ak_test, sizeof(ak_test));
+  }
+
+  /* nk = ToBase(PRF^expand(sk, [0x07])) */
+  uint8_t t_nk = 0x07;
+  prf_expand(sk, &t_nk, 1, expanded);
+  to_base(expanded, keys->nk);
+
+  /* rivk = ToScalar(PRF^expand(sk, [0x08])) */
+  uint8_t t_rivk = 0x08;
+  prf_expand(sk, &t_rivk, 1, expanded);
+  to_scalar(expanded, keys->rivk);
+
+  /* Clean up */
+  memzero(I, sizeof(I));
+  memzero(sk, sizeof(sk));
+  memzero(chain_code, sizeof(chain_code));
+  memzero(expanded, sizeof(expanded));
+
+  return true;
+}
+
+bool zcash_compute_shielded_sighash(const uint8_t header_digest[32],
+                                    const uint8_t transparent_digest[32],
+                                    const uint8_t sapling_digest[32],
+                                    const uint8_t orchard_digest[32],
+                                    uint32_t branch_id,
+                                    uint8_t sighash_out[32]) {
+  Hasher h;
+  uint8_t personal[16];
+
+  memcpy(personal, "ZcashTxHash_", 12);
+  memcpy(personal + 12, &branch_id, 4);
+
+  hasher_InitParam(&h, HASHER_BLAKE2B_PERSONAL, personal, 16);
+  hasher_Update(&h, header_digest, 32);
+  hasher_Update(&h, transparent_digest, 32);
+  hasher_Update(&h, sapling_digest, 32);
+  hasher_Update(&h, orchard_digest, 32);
+  hasher_Final(&h, sighash_out);
+
+  return true;
+}


### PR DESCRIPTION
## Summary
Zcash Orchard shielded transaction support with transparent-to-shielded bridging. Cherry-picked onto clean develop.

## New Handlers
- **ZcashSignPCZT**: Session init, key derivation, sighash setup
- **ZcashPCZTAction**: Per-action Orchard signing (RedPallas/Pallas)
- **ZcashTransparentInput**: UTXO signing for transparent bridge
- **ZcashGetOrchardFVK**: Full viewing key export
- **ZcashDisplayAddress**: Unified address with Orchard key verification

## Security
- ZIP-32 path enforcement (m/32'/133'/account')
- FVK-match verification before address display
- Per-transparent-input confirmation with account pivot prevention
- Phase ordering: transparent inputs must complete before Orchard actions
- CHECK_INITIALIZED + CHECK_PIN on all entry handlers
- All key material zeroed on every exit path

## Noted Concerns (documented, non-blocking)
- Non-Orchard UA receivers not independently verified
- Host-supplied alpha randomizer not validated as non-zero Pallas scalar
- Phase 2b orchard digest verification is optional (recommend mandatory)

## Test plan
- [ ] Emulator: ZcashDisplayAddress with unified address
- [ ] Emulator: ZcashSignPCZT + ZcashPCZTAction flow
- [ ] Emulator: ZcashTransparentInput per-input confirmation
- [ ] Phase ordering violation → session abort
- [ ] Path validation — reject non-ZIP-32 paths in DisplayAddress

## AI Review: PASS