### PR TITLE
fix: enforce BIP-39 wordlist validation during cipher recovery

### DIFF
--- a/lib/firmware/recovery_cipher.c
+++ b/lib/firmware/recovery_cipher.c
@@ -462,6 +462,24 @@ void recovery_character(const char *character) {
       }
     }
   } else {
+    /* Per-word BIP39 validation: reject immediately if the decoded word
+     * doesn't match any entry in the wordlist. */
+    if (enforce_wordlist && strlen(decoded_word) > 0) {
+      static CONFIDENTIAL char check_word[CURRENT_WORD_BUF];
+      strlcpy(check_word, decoded_word, sizeof(check_word));
+      bool valid = attempt_auto_complete(check_word);
+      memzero(check_word, sizeof(check_word));
+      if (!valid) {
+        memzero(coded_word, sizeof(coded_word));
+        memzero(decoded_word, sizeof(decoded_word));
+        recovery_cipher_abort();
+        fsm_sendFailure(FailureType_Failure_SyntaxError,
+                        "Word not found in BIP39 wordlist");
+        layoutHome();
+        return;
+      }
+    }
+
     memzero(coded_word, sizeof(coded_word));
     memzero(decoded_word, sizeof(decoded_word));
 
@@ -575,7 +593,7 @@ void recovery_cipher_finalize(void) {
   }
   memzero(temp_word, sizeof(temp_word));
 
-  if (!auto_completed && !enforce_wordlist) {
+  if (!auto_completed && enforce_wordlist) {
     if (!dry_run) {
       storage_reset();
     }


### PR DESCRIPTION
## Summary
Two fixes to BIP-39 wordlist enforcement during cipher recovery:
1. Per-word early validation against BIP-39 wordlist
2. Logic inversion bug fix in `recovery_cipher_finalize()`

## Changes
- 1 file, +19/-1 lines

## AI Code Review: PASS
## AI Test Report Review: pending CI