### PR TITLE
feat(ci): test-report.pdf pipeline with branch/commit header

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -586,6 +586,8 @@ jobs:
         run: |
           python3 scripts/generate-test-report.py \
             --fw-version="${{ steps.version.outputs.fw_version }}" \
+            --branch="${{ github.head_ref || github.ref_name }}" \
+            --commit="${{ github.event.pull_request.head.sha || github.sha }}" \
             --junit=test-reports/python-keepkey/junit.xml \
             --screenshots=test-reports/screenshots \
             --output=test-report.pdf

--- a/scripts/generate-test-report.py
+++ b/scripts/generate-test-report.py
@@ -936,7 +936,7 @@ SECTIONS = [
 # ---------------------------------------------------------------
 # Render
 # ---------------------------------------------------------------
-def render(output_path, fw_version, results, screenshot_dir=None):
+def render(output_path, fw_version, results, screenshot_dir=None, branch=None, commit=None):
     pdf = PDF(); pb = PB(pdf)
     ts = datetime.now().strftime('%Y-%m-%d %H:%M')
     active = [(l,t,mf,bg,fl,tests) for l,t,mf,bg,fl,tests in SECTIONS if ver_ge(fw_version, mf)]
@@ -960,6 +960,12 @@ def render(output_path, fw_version, results, screenshot_dir=None):
         pb.text(11, f'Firmware {fw_version}  |  {ts}  |  {failed} FAILED of {total} tests', bold=True, color=RED)
     else:
         pb.text(10, f'Firmware {fw_version}  |  {ts}  |  {total} tests: {passed} passed, {skipped} pending')
+    # Branch + commit for audit trail
+    if branch or commit:
+        meta = []
+        if branch: meta.append(f'Branch: {branch}')
+        if commit: meta.append(f'Commit: {commit}')
+        pb.text(8, '  |  '.join(meta), color=GRAY)
     pb.gap(6)
     pb.text(12, 'Sections', bold=True)
     _shown_new = _shown_old = False
@@ -1045,6 +1051,8 @@ def main():
     p.add_argument('--fw-version', default=None)
     p.add_argument('--junit', default=None, help='JUnit XML for pass/fail results')
     p.add_argument('--screenshots', default=None, help='Directory with per-test OLED screenshots')
+    p.add_argument('--branch', default=None, help='Git branch name for report header')
+    p.add_argument('--commit', default=None, help='Git commit SHA for report header')
     args = p.parse_args()
 
     fw = args.fw_version
@@ -1055,7 +1063,7 @@ def main():
         else: print('No emulator, defaulting to 7.10.0'); fw = '7.10.0'
 
     results = parse_junit(args.junit) if args.junit else {}
-    render(args.output, fw, results, args.screenshots)
+    render(args.output, fw, results, args.screenshots, branch=args.branch, commit=args.commit)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
## Summary
- Adds `--branch` and `--commit` CLI args to `generate-test-report.py`
- Report PDF header now shows branch name + commit SHA for audit trail
- CI workflow passes GitHub context (`github.head_ref`, `github.event.pull_request.head.sha`) to the report generator
- Satisfies SOP Gate 3 requirement: "Branch, commit SHA, and firmware version must match the PR"

## Test plan
- [ ] CI generates `test-report.pdf` artifact
- [ ] PDF header shows correct firmware version (7.14.0)
- [ ] PDF header shows branch name and commit SHA
- [ ] OLED screenshots embedded in test entries