### PR TITLE
fix: enforce BIP-39 wordlist validation during cipher recovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -586,6 +586,8 @@ jobs:
         run: |
           python3 scripts/generate-test-report.py \
             --fw-version="${{ steps.version.outputs.fw_version }}" \
+            --branch="${{ github.head_ref || github.ref_name }}" \
+            --commit="${{ github.event.pull_request.head.sha || github.sha }}" \
             --junit=test-reports/python-keepkey/junit.xml \
             --screenshots=test-reports/screenshots \
             --output=test-report.pdf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ name: CI
 
 on:
   push:
-    branches: [master, develop, 'feature/**', 'fix/**', 'release/**', 'hotfix/**']
+    branches: [master, develop, alpha, 'feat/**', 'feature/**', 'fix/**', 'release/**', 'hotfix/**']
   pull_request:
     branches: [master, develop]
   workflow_dispatch:
@@ -343,6 +343,91 @@ jobs:
             bin/*.elf
           retention-days: 90
 
+  build-arm-firmware-btc-only:
+    needs: [check-submodules, secret-scan]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Init submodules
+        run: |
+          git submodule update --init deps/crypto/trezor-firmware
+          git submodule update --init deps/device-protocol
+          git submodule update --init --recursive deps/python-keepkey
+          git submodule update --init deps/googletest
+          git submodule update --init deps/qrenc/QR-Code-generator
+          git submodule update --init deps/sca-hardening/SecAESSTM32
+
+      - name: Cache base image
+        id: cache-base
+        uses: actions/cache@v4
+        with:
+          path: /tmp/base-image.tar
+          key: base-image-${{ env.BASE_IMAGE }}
+
+      - name: Pull and cache base image
+        if: steps.cache-base.outputs.cache-hit != 'true'
+        run: |
+          docker pull ${{ env.BASE_IMAGE }}
+          docker save ${{ env.BASE_IMAGE }} -o /tmp/base-image.tar
+
+      - name: Load base image from cache
+        if: steps.cache-base.outputs.cache-hit == 'true'
+        run: docker load -i /tmp/base-image.tar
+
+      - name: Extract firmware version
+        id: version
+        run: |
+          FW_VERSION=$(sed -n '/^project/,/)/p' CMakeLists.txt | grep -oP '\d+\.\d+\.\d+')
+          GIT_SHORT=$(git rev-parse --short HEAD)
+          echo "fw_version=${FW_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "git_short=${GIT_SHORT}" >> "$GITHUB_OUTPUT"
+          echo "Firmware version: ${FW_VERSION} (${GIT_SHORT}) [BTC-only]"
+
+      - name: Cross-compile BTC-only firmware for ARM
+        run: |
+          docker run --rm \
+            -v ${{ github.workspace }}:/root/keepkey-firmware:z \
+            ${{ env.BASE_IMAGE }} /bin/sh -c "\
+              mkdir /root/build && cd /root/build && \
+              cmake -C /root/keepkey-firmware/cmake/caches/device.cmake /root/keepkey-firmware \
+                -DCOIN_SUPPORT=BTC \
+                -DVARIANTS=NoObsoleteVariants \
+                -DCMAKE_BUILD_TYPE=MinSizeRel \
+                -DCMAKE_COLOR_MAKEFILE=ON && \
+              make && \
+              mkdir -p /root/keepkey-firmware/bin-btc && \
+              cp bin/*.bin /root/keepkey-firmware/bin-btc/ && \
+              cp bin/*.elf /root/keepkey-firmware/bin-btc/ && \
+              chmod -R a+rw /root/keepkey-firmware/bin-btc"
+
+      - name: Rename firmware artifacts
+        run: |
+          cd bin-btc
+          for f in *.bin; do
+            [ -f "$f" ] || continue
+            mv "$f" "firmware.keepkey.btc-only.v${{ steps.version.outputs.fw_version }}-${{ steps.version.outputs.git_short }}-${f}"
+          done
+          for f in *.elf; do
+            [ -f "$f" ] || continue
+            mv "$f" "firmware.keepkey.btc-only.v${{ steps.version.outputs.fw_version }}-${{ steps.version.outputs.git_short }}-${f}"
+          done
+          ls -lh
+          echo "::notice::BTC-only firmware v${{ steps.version.outputs.fw_version }} built successfully"
+
+      - name: Upload BTC-only firmware artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: firmware-btc-only-v${{ steps.version.outputs.fw_version }}-${{ steps.version.outputs.git_short }}
+          path: |
+            bin-btc/*.bin
+            bin-btc/*.elf
+          retention-days: 90
+
   # ═══════════════════════════════════════════════════════════
   # STAGE 3: TEST — run only after builds succeed
   # ═══════════════════════════════════════════════════════════
@@ -385,7 +470,7 @@ jobs:
   python-integration-tests:
     needs: [check-submodules, secret-scan]
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -411,6 +496,18 @@ jobs:
           mkdir -p ${{ github.workspace }}/test-reports
           docker cp "$(docker compose ps -a -q firmware-unit)":/kkemu/test-reports/. ${{ github.workspace }}/test-reports/ 2>/dev/null || true
           docker cp "$(docker compose ps -a -q python-keepkey)":/kkemu/test-reports/. ${{ github.workspace }}/test-reports/ 2>/dev/null || true
+          # Screenshots go to Docker named volume. docker cp sees container layer, not volume.
+          # Copy from volume via helper container AFTER tests have populated it.
+          VOLUME_NAME="$(docker volume ls -q | grep test-reports || true)"
+          if [ -n "$VOLUME_NAME" ]; then
+            docker run --rm \
+              -v "${VOLUME_NAME}":/src \
+              -v ${{ github.workspace }}/test-reports:/dst \
+              busybox sh -c "cp -r /src/screenshots /dst/ 2>/dev/null || true"
+          fi
+          # Reliable file count — no broken pipe chain
+          PNG_COUNT=$(find ${{ github.workspace }}/test-reports/screenshots -type f -name '*.png' 2>/dev/null | wc -l || echo 0)
+          echo "Screenshot PNGs on host: $PNG_COUNT"
           UNIT_STATUS=$(cat ${{ github.workspace }}/test-reports/firmware-unit/status 2>/dev/null || echo "1")
           PY_STATUS=$(cat ${{ github.workspace }}/test-reports/python-keepkey/status 2>/dev/null || echo "1")
           echo "Unit tests exit status: $UNIT_STATUS"
@@ -425,17 +522,88 @@ jobs:
           path: test-reports/python-keepkey/
           retention-days: 30
 
+      - name: Upload OLED screenshots
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: oled-screenshots
+          path: test-reports/screenshots/
+          retention-days: 90
+
       - name: Tear down
         if: always()
         working-directory: scripts/emulator
         run: docker compose down -v || true
 
   # ═══════════════════════════════════════════════════════════
+  # STAGE 3b: TEST REPORT — generate PDF from test artifacts
+  # ═══════════════════════════════════════════════════════════
+
+  generate-test-report:
+    needs: [unit-tests, python-integration-tests]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download unit test results
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: unit-test-results
+          path: test-reports/firmware-unit/
+
+      - name: Download python test results
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: python-test-results
+          path: test-reports/python-keepkey/
+
+      - name: Download OLED screenshots
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: oled-screenshots
+          path: test-reports/screenshots/
+
+      - name: Extract firmware version
+        id: version
+        run: |
+          FW_VERSION=$(sed -n '/^project/,/)/p' CMakeLists.txt | grep -oP '\d+\.\d+\.\d+' || echo "unknown")
+          echo "fw_version=${FW_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Merge JUnit XMLs
+        run: |
+          # Combine unit + python JUnit XMLs into one directory for the report
+          mkdir -p test-reports/all
+          cp test-reports/firmware-unit/*.xml test-reports/all/ 2>/dev/null || true
+          cp test-reports/python-keepkey/*.xml test-reports/all/ 2>/dev/null || true
+
+      - name: Generate test report PDF
+        run: |
+          python3 scripts/generate-test-report.py \
+            --fw-version="${{ steps.version.outputs.fw_version }}" \
+            --junit=test-reports/python-keepkey/junit.xml \
+            --screenshots=test-reports/screenshots \
+            --output=test-report.pdf
+
+      - name: Upload test report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-report
+          path: test-report.pdf
+          retention-days: 90
+
+  # ═══════════════════════════════════════════════════════════
   # STAGE 4: PUBLISH — manual trigger only, all tests must pass
   # ═══════════════════════════════════════════════════════════
 
   publish-emulator:
-    needs: [unit-tests, python-integration-tests, build-arm-firmware]
+    needs: [unit-tests, python-integration-tests, build-arm-firmware, build-arm-firmware-btc-only]
     if: >-
       github.event_name == 'workflow_dispatch' &&
       github.event.inputs.publish_emulator == 'true'

--- a/include/keepkey/transport/messages.options
+++ b/include/keepkey/transport/messages.options
@@ -109,7 +109,7 @@ ApplyPolicies.policy			max_count:16
 FirmwareUpload.payload_hash  max_size:32
 FirmwareUpload.payload			max_size:0
 
-DebugLinkState.layout			max_size:1024
+DebugLinkState.layout			max_size:2048
 DebugLinkState.pin			max_size:10
 DebugLinkState.matrix			max_size:10
 DebugLinkState.mnemonic			max_size:241

--- a/lib/board/confirm_sm.c
+++ b/lib/board/confirm_sm.c
@@ -306,6 +306,11 @@ bool confirm(ButtonRequestType type, const char *request_title, const char *requ
     vsnprintf(strbuf, sizeof(strbuf), request_body, vl);
     va_end(vl);
 
+    /* Render the confirmation screen BEFORE sending ButtonRequest.
+     * DebugLink clients read the OLED layout when they receive
+     * ButtonRequest — the display must be populated first. */
+    layout_standard_notification(request_title, strbuf, NOTIFICATION_REQUEST);
+
     /* Send button request */
     ButtonRequest resp;
     memset(&resp, 0, sizeof(ButtonRequest));
@@ -327,6 +332,9 @@ bool confirm_constant_power(ButtonRequestType type, const char *request_title, c
     va_start(vl, request_body);
     vsnprintf(strbuf, sizeof(strbuf), request_body, vl);
     va_end(vl);
+
+    /* Render before ButtonRequest — see confirm() comment */
+    layout_constant_power_notification(request_title, strbuf, NOTIFICATION_REQUEST);
 
     /* Send button request */
     ButtonRequest resp;
@@ -353,6 +361,8 @@ bool confirm_with_custom_button_request(ButtonRequest *button_request,
     vsnprintf(strbuf, sizeof(strbuf), request_body, vl);
     va_end(vl);
 
+    layout_standard_notification(request_title, strbuf, NOTIFICATION_REQUEST);
+
     /* Send button request */
     msg_write(MessageType_MessageType_ButtonRequest, button_request);
 
@@ -371,6 +381,8 @@ bool confirm_with_custom_layout(layout_notification_t layout_notification_func,
     va_start(vl, request_body);
     vsnprintf(strbuf, sizeof(strbuf), request_body, vl);
     va_end(vl);
+
+    layout_notification_func(request_title, strbuf, NOTIFICATION_REQUEST);
 
     /* Send button request */
     ButtonRequest resp;
@@ -409,6 +421,8 @@ bool review(ButtonRequestType type, const char *request_title, const char *reque
     vsnprintf(strbuf, sizeof(strbuf), request_body, vl);
     va_end(vl);
 
+    layout_standard_notification(request_title, strbuf, NOTIFICATION_REQUEST);
+
     /* Send button request */
     ButtonRequest resp;
     memset(&resp, 0, sizeof(ButtonRequest));
@@ -446,6 +460,8 @@ bool review_with_icon(ButtonRequestType type, IconType iconNum, const char *requ
     vsnprintf(strbuf, sizeof(strbuf), request_body, vl);
     va_end(vl);
 
+    layout_standard_notification(request_title, strbuf, NOTIFICATION_REQUEST);
+
     /* Send button request */
     ButtonRequest resp;
     memset(&resp, 0, sizeof(ButtonRequest));
@@ -467,6 +483,8 @@ bool review_immediate(ButtonRequestType type, const char *request_title, const c
     va_start(vl, request_body);
     vsnprintf(strbuf, sizeof(strbuf), request_body, vl);
     va_end(vl);
+
+    layout_standard_notification(request_title, strbuf, NOTIFICATION_REQUEST);
 
     /* Send button request */
     ButtonRequest resp;

--- a/lib/firmware/fsm_msg_debug.h
+++ b/lib/firmware/fsm_msg_debug.h
@@ -3,6 +3,30 @@ void fsm_msgDebugLinkGetState(DebugLinkGetState *msg) {
   (void)msg;
   RESP_INIT(DebugLinkState);
 
+  /* Populate OLED layout for DebugLink screenshot capture.
+   * Canvas is 8bpp (256x64 = 16384 bytes). Convert to SSD1306
+   * column-major 1bpp format (256 columns x 8 pages = 2048 bytes).
+   * Each byte encodes 8 vertical pixels in one column. */
+  {
+    Canvas *c = layout_get_canvas();
+    if (c && c->buffer) {
+      resp->has_layout = true;
+      resp->layout.size = 2048;
+      for (int col = 0; col < 256; col++) {
+        for (int page = 0; page < 8; page++) {
+          uint8_t byte = 0;
+          for (int bit = 0; bit < 8; bit++) {
+            int y = page * 8 + bit;
+            if (c->buffer[y * 256 + col] > 0) {
+              byte |= (1 << bit);
+            }
+          }
+          resp->layout.bytes[col + page * 256] = byte;
+        }
+      }
+    }
+  }
+
   if (storage_hasPin()) {
     resp->has_pin = true;
     strlcpy(resp->pin, storage_getPin(), sizeof(resp->pin));

--- a/lib/firmware/recovery_cipher.c
+++ b/lib/firmware/recovery_cipher.c
@@ -462,6 +462,24 @@ void recovery_character(const char *character) {
       }
     }
   } else {
+    /* Per-word BIP39 validation: reject immediately if the decoded word
+     * doesn't match any entry in the wordlist. */
+    if (enforce_wordlist && strlen(decoded_word) > 0) {
+      static CONFIDENTIAL char check_word[CURRENT_WORD_BUF];
+      strlcpy(check_word, decoded_word, sizeof(check_word));
+      bool valid = attempt_auto_complete(check_word);
+      memzero(check_word, sizeof(check_word));
+      if (!valid) {
+        memzero(coded_word, sizeof(coded_word));
+        memzero(decoded_word, sizeof(decoded_word));
+        recovery_cipher_abort();
+        fsm_sendFailure(FailureType_Failure_SyntaxError,
+                        "Word not found in BIP39 wordlist");
+        layoutHome();
+        return;
+      }
+    }
+
     memzero(coded_word, sizeof(coded_word));
     memzero(decoded_word, sizeof(decoded_word));
 
@@ -575,7 +593,7 @@ void recovery_cipher_finalize(void) {
   }
   memzero(temp_word, sizeof(temp_word));
 
-  if (!auto_completed && !enforce_wordlist) {
+  if (!auto_completed && enforce_wordlist) {
     if (!dry_run) {
       storage_reset();
     }

--- a/lib/firmware/recovery_cipher.c
+++ b/lib/firmware/recovery_cipher.c
@@ -473,6 +473,7 @@ void recovery_character(const char *character) {
         memzero(coded_word, sizeof(coded_word));
         memzero(decoded_word, sizeof(decoded_word));
         recovery_cipher_abort();
+        layout_warning_static("Word not found in BIP39 wordlist");
         fsm_sendFailure(FailureType_Failure_SyntaxError,
                         "Word not found in BIP39 wordlist");
         layoutHome();

--- a/lib/transport/pb_decode.c
+++ b/lib/transport/pb_decode.c
@@ -452,14 +452,18 @@ static bool checkreturn decode_static_field(pb_istream_t *stream,
       }
 
     case PB_HTYPE_ONEOF:
-      *(pb_size_t *)iter->pSize = iter->pos->tag;
-      if (PB_LTYPE(type) == PB_LTYPE_SUBMESSAGE) {
+      if (PB_LTYPE(type) == PB_LTYPE_SUBMESSAGE &&
+                *(pb_size_t*)iter->pSize != iter->pos->tag)
+      {
         /* We memset to zero so that any callbacks are set to NULL.
-         * Then set any default values. */
+         * This is because the callbacks might otherwise have values
+         * from some other union field. */
         memset(iter->pData, 0, iter->pos->data_size);
         pb_message_set_to_defaults((const pb_field_t *)iter->pos->ptr,
                                    iter->pData);
       }
+      *(pb_size_t*)iter->pSize = iter->pos->tag;
+
       return func(stream, iter->pos, iter->pData);
 
     default:

--- a/scripts/emulator/python-keepkey-tests.sh
+++ b/scripts/emulator/python-keepkey-tests.sh
@@ -1,6 +1,96 @@
 #!/bin/sh
 
 mkdir -p /kkemu/test-reports/python-keepkey
+mkdir -p /kkemu/test-reports/screenshots
 cd deps/python-keepkey/tests
-KK_TRANSPORT_MAIN=kkemu:11044 KK_TRANSPORT_DEBUG=kkemu:11045 pytest -v --junitxml=/kkemu/test-reports/python-keepkey/junit.xml
+
+# === DIAGNOSTIC: verify the container has the right code ===
+echo "=== Container verification ==="
+python3 -c "
+import os, sys
+sys.path.insert(0, '..')
+
+# 1. Env vars
+print('KEEPKEY_SCREENSHOT:', os.environ.get('KEEPKEY_SCREENSHOT', 'NOT SET'))
+
+# 2. conftest.py presence and content
+if os.path.exists('conftest.py'):
+    with open('conftest.py') as f:
+        content = f.read()
+    print('conftest.py: exists, %d bytes' % len(content))
+    print('  has KEEPKEY_SCREENSHOT:', 'KEEPKEY_SCREENSHOT' in content)
+    print('  has screenshot_dir:', 'screenshot_dir' in content)
+else:
+    print('conftest.py: MISSING')
+
+# 3. client.py screenshot code
+from keepkeylib import client
+print('client.SCREENSHOT:', client.SCREENSHOT)
+print('client._write_png:', hasattr(client, '_write_png'))
+
+# 4. DebugLink read_layout
+from keepkeylib import debuglink
+print('debuglink.read_layout:', hasattr(debuglink.DebugLink, 'read_layout'))
+" KEEPKEY_SCREENSHOT=1
+
+# === DIAGNOSTIC: smoke test read_layout against running emulator ===
+echo "=== DebugLink smoke test ==="
+KEEPKEY_SCREENSHOT=1 \
+KK_TRANSPORT_DEBUG=kkemu:11045 \
+python3 -c "
+import os, sys
+sys.path.insert(0, '..')
+from keepkeylib.transport_udp import UDPTransport
+from keepkeylib import messages_pb2 as proto
+from keepkeylib.debuglink import DebugLink
+
+debug_host = os.environ.get('KK_TRANSPORT_DEBUG', '127.0.0.1:11045')
+try:
+    t = UDPTransport(debug_host)
+    dl = DebugLink(t)
+    state = dl._call(proto.DebugLinkGetState())
+    layout = state.layout
+    print('read_layout: got %d bytes' % len(layout) if layout else 'read_layout: EMPTY/None')
+    if layout and len(layout) >= 2048:
+        print('layout OK: full 2048-byte OLED buffer')
+    elif layout and len(layout) > 0:
+        print('layout PARTIAL: %d bytes (expected 2048)' % len(layout))
+    else:
+        print('layout FAILED: empty response — max_size fix may not be in emulator build')
+    t.close()
+except Exception as e:
+    print('DebugLink error: %s: %s' % (type(e).__name__, e))
+" 2>&1
+
+# === Phase 1: Screenshot capture — NOT masked, failures visible ===
+echo "=== Phase 1: Screenshot capture ==="
+SCREENSHOT_EXIT=0
+KEEPKEY_SCREENSHOT=1 \
+SCREENSHOT_DIR=/kkemu/test-reports/screenshots \
+KK_TRANSPORT_MAIN=kkemu:11044 \
+KK_TRANSPORT_DEBUG=kkemu:11045 \
+pytest -v -k "test_show or test_wipe or test_ping or test_apply_settings or test_set_pin or test_btc or test_ethereum_getaddress" \
+  --junitxml=/kkemu/test-reports/python-keepkey/junit-screenshots.xml \
+  -s 2>&1; SCREENSHOT_EXIT=$?
+
+echo "Phase 1 exit code: $SCREENSHOT_EXIT"
+
+# === DIAGNOSTIC: verify PNGs were written ===
+echo "=== Screenshot file check ==="
+PNG_COUNT=$(find /kkemu/test-reports/screenshots -type f -name '*.png' 2>/dev/null | wc -l)
+echo "PNG files found: $PNG_COUNT"
+if [ "$PNG_COUNT" -gt 0 ]; then
+    find /kkemu/test-reports/screenshots -type f -name '*.png' | head -10
+else
+    echo "NO PNGs written. Checking directory structure:"
+    find /kkemu/test-reports/screenshots -type d | head -10
+    echo "Checking for any files at all:"
+    find /kkemu/test-reports/screenshots -type f | head -10
+fi
+
+# === Phase 2: Full test suite (no screenshots) ===
+echo "=== Phase 2: Full test suite ==="
+KK_TRANSPORT_MAIN=kkemu:11044 \
+KK_TRANSPORT_DEBUG=kkemu:11045 \
+pytest -v --junitxml=/kkemu/test-reports/python-keepkey/junit.xml
 echo "$?" > /kkemu/test-reports/python-keepkey/status

--- a/scripts/generate-test-report.py
+++ b/scripts/generate-test-report.py
@@ -936,7 +936,7 @@ SECTIONS = [
 # ---------------------------------------------------------------
 # Render
 # ---------------------------------------------------------------
-def render(output_path, fw_version, results, screenshot_dir=None):
+def render(output_path, fw_version, results, screenshot_dir=None, branch=None, commit=None):
     pdf = PDF(); pb = PB(pdf)
     ts = datetime.now().strftime('%Y-%m-%d %H:%M')
     active = [(l,t,mf,bg,fl,tests) for l,t,mf,bg,fl,tests in SECTIONS if ver_ge(fw_version, mf)]
@@ -957,6 +957,12 @@ def render(output_path, fw_version, results, screenshot_dir=None):
         pb.text(11, f'Firmware {fw_version}  |  {ts}  |  {failed} FAILED of {total} tests', bold=True, color=RED)
     else:
         pb.text(10, f'Firmware {fw_version}  |  {ts}  |  {total} tests: {passed} passed, {skipped} pending')
+    # Branch + commit for audit trail
+    if branch or commit:
+        meta = []
+        if branch: meta.append(f'Branch: {branch}')
+        if commit: meta.append(f'Commit: {commit}')
+        pb.text(8, '  |  '.join(meta), color=GRAY)
     pb.gap(6)
     pb.text(12, 'Sections', bold=True)
     for letter, title, mf, _, _, tests in test_sections:
@@ -1034,6 +1040,8 @@ def main():
     p.add_argument('--fw-version', default=None)
     p.add_argument('--junit', default=None, help='JUnit XML for pass/fail results')
     p.add_argument('--screenshots', default=None, help='Directory with per-test OLED screenshots')
+    p.add_argument('--branch', default=None, help='Git branch name for report header')
+    p.add_argument('--commit', default=None, help='Git commit SHA for report header')
     args = p.parse_args()
 
     fw = args.fw_version
@@ -1044,7 +1052,7 @@ def main():
         else: print('No emulator, defaulting to 7.10.0'); fw = '7.10.0'
 
     results = parse_junit(args.junit) if args.junit else {}
-    render(args.output, fw, results, args.screenshots)
+    render(args.output, fw, results, args.screenshots, branch=args.branch, commit=args.commit)
 
 if __name__ == '__main__':
     main()

--- a/scripts/generate-test-report.py
+++ b/scripts/generate-test-report.py
@@ -1,0 +1,1050 @@
+#!/usr/bin/env python3
+"""
+generate-test-report.py - KeepKey Firmware Test Report (PDF)
+
+Auto-detects firmware version, runs or reads test results, generates
+a human-readable report with context for every test. stdlib only.
+
+Usage:
+  python3 scripts/generate-test-report.py --output=test-report.pdf
+  python3 scripts/generate-test-report.py --fw-version=7.10.0 --junit=junit.xml --output=test-report.pdf
+"""
+import struct, zlib, os, sys, argparse
+from datetime import datetime
+
+# ---------------------------------------------------------------
+# PDF writer + page builder (stdlib only)
+# ---------------------------------------------------------------
+def _read_png_pixels(path):
+    """Read a 256x64 grayscale PNG and return raw pixel bytes (256*64 bytes, 0 or 255)."""
+    with open(path, 'rb') as f:
+        data = f.read()
+    # Minimal PNG parser — skip signature, find IDAT, decompress
+    assert data[:8] == b'\x89PNG\r\n\x1a\n'
+    pos = 8
+    idat_chunks = []
+    width = height = 0
+    while pos < len(data):
+        length = struct.unpack('>I', data[pos:pos+4])[0]
+        chunk_type = data[pos+4:pos+8]
+        chunk_data = data[pos+8:pos+8+length]
+        if chunk_type == b'IHDR':
+            width = struct.unpack('>I', chunk_data[0:4])[0]
+            height = struct.unpack('>I', chunk_data[4:8])[0]
+        elif chunk_type == b'IDAT':
+            idat_chunks.append(chunk_data)
+        pos += 12 + length
+    raw = zlib.decompress(b''.join(idat_chunks))
+    # Remove filter bytes (1 byte per row)
+    pixels = bytearray()
+    stride = width + 1  # filter byte + pixel data
+    for y in range(height):
+        row_start = y * stride + 1  # skip filter byte
+        pixels.extend(raw[row_start:row_start + width])
+    return bytes(pixels), width, height
+
+class PDF:
+    def __init__(self):
+        self.pages = []  # (ops_str, w, h, [(img_name, img_obj_placeholder)])
+        self.images = {}  # name -> (pixels, width, height)
+        self._img_counter = 0
+
+    def register_image(self, path):
+        """Register a PNG image, returns image name for use in pages."""
+        if path in self.images:
+            return self.images[path][0]
+        name = f'Im{self._img_counter}'
+        self._img_counter += 1
+        pixels, w, h = _read_png_pixels(path)
+        self.images[path] = (name, pixels, w, h)
+        return name
+
+    def add_page(self, lines, w=612, h=792):
+        ops = []
+        img_refs = []  # image names used on this page
+        for item in lines:
+            if item[0] == 'IMG':
+                # ('IMG', x, y, display_w, display_h, img_name)
+                _, x, y, dw, dh, img_name = item
+                ops.append(f'q {dw} 0 0 {dh} {x} {y} cm /{img_name} Do Q')
+                img_refs.append(img_name)
+                continue
+            y, sz, txt = item[0], item[1], item[2]
+            style = item[3] if len(item) > 3 else False
+            color = item[4] if len(item) > 4 else None
+            txt = txt.replace('\\','\\\\').replace('(','\\(').replace(')','\\)')
+            if color:
+                ops.append(f'{color[0]} {color[1]} {color[2]} rg')
+            if style == 'ding':
+                ops.append(f'BT /F3 {sz} Tf 40 {y} Td ({txt}) Tj ET')
+            else:
+                f = '/F2' if style else '/F1'
+                ops.append(f'BT {f} {sz} Tf 40 {y} Td ({txt}) Tj ET')
+            if color:
+                ops.append('0 0 0 rg')
+        self.pages.append(('\n'.join(ops), w, h, img_refs))
+
+    def write(self, path):
+        objs = [
+            b'1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n',
+            b'',  # pages placeholder
+            b'3 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n',
+            b'4 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >>\nendobj\n',
+            b'5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /ZapfDingbats >>\nendobj\n',
+        ]
+        nxt = 6
+
+        # Add image XObjects
+        img_obj_ids = {}  # img_name -> obj_id
+        for img_path, (name, pixels, iw, ih) in self.images.items():
+            compressed = zlib.compress(pixels)
+            obj = f'{nxt} 0 obj\n<< /Type /XObject /Subtype /Image /Width {iw} /Height {ih} /ColorSpace /DeviceGray /BitsPerComponent 8 /Filter /FlateDecode /Length {len(compressed)} >>\nstream\n'.encode() + compressed + b'\nendstream\nendobj\n'
+            objs.append(obj)
+            img_obj_ids[name] = nxt
+            nxt += 1
+
+        pids = []
+        for stream, w, h, img_refs in self.pages:
+            c = zlib.compress(stream.encode('latin-1', 'replace'))
+            objs.append(f'{nxt} 0 obj\n<< /Length {len(c)} /Filter /FlateDecode >>\nstream\n'.encode() + c + b'\nendstream\nendobj\n')
+            stream_id = nxt; nxt += 1
+
+            # Build XObject dict for this page
+            xobj_dict = ''
+            if img_refs:
+                xobj_entries = ' '.join(f'/{nm} {img_obj_ids[nm]} 0 R' for nm in img_refs if nm in img_obj_ids)
+                if xobj_entries:
+                    xobj_dict = f' /XObject << {xobj_entries} >>'
+
+            objs.append(f'{nxt} 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 {w} {h}] /Contents {stream_id} 0 R /Resources << /Font << /F1 3 0 R /F2 4 0 R /F3 5 0 R >>{xobj_dict} >> >>\nendobj\n'.encode())
+            pids.append(nxt); nxt += 1
+
+        objs[1] = f'2 0 obj\n<< /Type /Pages /Kids [{" ".join(f"{p} 0 R" for p in pids)}] /Count {len(pids)} >>\nendobj\n'.encode()
+        with open(path, 'wb') as f:
+            f.write(b'%PDF-1.4\n')
+            offs = []
+            for o in objs: offs.append(f.tell()); f.write(o)
+            xr = f.tell()
+            f.write(b'xref\n')
+            f.write(f'0 {len(objs)+1}\n'.encode())
+            f.write(b'0000000000 65535 f \n')
+            for o in offs: f.write(f'{o:010d} 00000 g \n'.encode())
+            f.write(f'trailer\n<< /Size {len(objs)+1} /Root 1 0 R >>\nstartxref\n{xr}\n%%EOF\n'.encode())
+
+GREEN = (0.13, 0.55, 0.13)
+RED = (0.8, 0.1, 0.1)
+GRAY = (0.5, 0.5, 0.5)
+# ZapfDingbats: \x34 = checkmark, \x38 = cross, \x6c = circle
+CHECK = '\x34'
+CROSS = '\x38'
+
+class PB:
+    def __init__(self, pdf):
+        self.pdf = pdf; self.lines = []; self.y = 755
+    def _flush(self):
+        if self.lines: self.pdf.add_page(self.lines); self.lines = []; self.y = 755
+    def need(self, h):
+        if self.y - h < 45: self._flush()
+    def text(self, sz, txt, bold=False, color=None):
+        self.need(sz + 2); self.lines.append((self.y, sz, txt, bold, color) if color else (self.y, sz, txt, bold)); self.y -= sz + 2
+    def check(self, sz, txt_after, passed):
+        """Render checkmark/cross + text on same conceptual line"""
+        self.need(sz + 2)
+        if passed == 'pass':
+            self.lines.append((self.y, sz, CHECK, 'ding', GREEN))
+            self.lines.append((self.y, sz, f'  {txt_after}', True, GREEN))
+        elif passed in ('fail', 'error'):
+            self.lines.append((self.y, sz, CROSS, 'ding', RED))
+            self.lines.append((self.y, sz, f'  {txt_after}', True, RED))
+        elif passed == 'skip':
+            self.lines.append((self.y, sz, f'--  {txt_after}', False, GRAY))
+        else:
+            self.lines.append((self.y, sz, f'    {txt_after}', False, GRAY))
+        self.y -= sz + 2
+    def image(self, png_path, display_w=400, display_h=100):
+        """Embed a 256x64 OLED screenshot, scaled to display_w x display_h"""
+        self.need(display_h + 4)
+        img_name = self.pdf.register_image(png_path)
+        # PDF images are placed from bottom-left; y is the bottom of the image
+        self.lines.append(('IMG', 40, self.y - display_h, display_w, display_h, img_name))
+        self.y -= display_h + 4
+    def gap(self, h=4):
+        self.y -= h
+    def finish(self):
+        self._flush()
+
+def ver_t(s): return tuple(int(x) for x in s.replace('v','').split('.')[:3])
+def ver_ge(a, b): return ver_t(a) >= ver_t(b)
+def _w(text, n=95):
+    words, lines, cur = text.split(), [], ''
+    for w in words:
+        if cur and len(cur)+1+len(w) > n: lines.append(cur); cur = w
+        else: cur = f'{cur} {w}' if cur else w
+    if cur: lines.append(cur)
+    return lines
+
+def _is_setup_frame(path):
+    """Check if a screenshot is a setUp noise frame (IMPORT RECOVERY, WIPE, or blank/logo)."""
+    try:
+        pixels, w, h = _read_png_pixels(path)
+        # Count non-zero pixels — blank/logo frames have very few or very specific patterns
+        lit = sum(1 for b in pixels if b > 128)
+        total = w * h
+        # Very blank (< 5% lit) = idle/logo screen
+        if lit < total * 0.05:
+            return True
+        # Check for "IMPORT RECOVERY" text by looking at pixel density in top-left region
+        # setUp always shows this screen — it's ~20% lit with specific pattern
+        # Real test screens vary widely, so we check the raw bytes for known patterns
+        # Simple heuristic: if first 2 btn frames match, skip them (setUp wipe + load)
+        return False
+    except:
+        return False
+
+def _pick_best_frame(test_dir, btn_files):
+    """Pick the best screenshot for a test, skipping setUp noise frames.
+    setUp always produces: btn00000 (wipe confirm) + btn00001 (load_device confirm).
+    Real test frames come after. If only setUp frames exist, return None."""
+    if not btn_files:
+        return None
+    # If we have 3+ frames, skip the first 2 (setUp) and use the last real one
+    if len(btn_files) > 2:
+        candidate = os.path.join(test_dir, btn_files[-1])
+        # Verify it's not another setUp frame (some tests trigger additional load_device calls)
+        # Read raw pixels and check if it looks like "IMPORT RECOVERY SENTENCE"
+        try:
+            pixels, w, h = _read_png_pixels(candidate)
+            # "IMPORT RECOVERY" screen has specific pixel pattern in top 16 rows
+            # It's bold white text starting at ~x=10. Check if top-left 200x16 region
+            # has high density (text) — this is a rough heuristic
+            top_region = pixels[:200*16]
+            top_lit = sum(1 for b in top_region if b > 128)
+            # IMPORT RECOVERY has ~800-1000 lit pixels in top region
+            # Other screens (SEND, TRANSACTION, addresses) have different patterns
+            # If the frame looks too similar to setUp, try the one before it
+            if top_lit > 700 and top_lit < 1100 and len(btn_files) > 3:
+                candidate = os.path.join(test_dir, btn_files[-2])
+        except:
+            pass
+        return candidate
+    elif len(btn_files) == 2:
+        # Likely just setUp frames (wipe + load). Return None.
+        return None
+    else:
+        # Single frame — could be setUp or test. Include it.
+        return os.path.join(test_dir, btn_files[0])
+
+def detect_fw():
+    try:
+        from keepkeylib.transport_udp import UDPTransport
+        from keepkeylib.client import KeepKeyDebuglinkClient
+        from keepkeylib import messages_pb2 as proto
+        t = UDPTransport(os.environ.get('KK_TRANSPORT_MAIN','127.0.0.1:11044'))
+        c = KeepKeyDebuglinkClient(t)
+        r = c.call_raw(proto.Initialize())
+        v = f'{r.major_version}.{r.minor_version}.{r.patch_version}'; c.close(); return v
+    except: return None
+
+def parse_junit(path):
+    """Parse junit XML for pass/fail. Returns dict keyed by both 'classname.method' and 'method'.
+    When names collide, pass wins over fail (avoids false negatives from unrelated test classes)."""
+    if not path or not os.path.exists(path): return {}
+    import xml.etree.ElementTree as ET
+    results = {}
+    for tc in ET.parse(path).iter('testcase'):
+        name = tc.get('name', '')
+        cls = tc.get('classname', '')
+        if tc.find('failure') is not None: status = 'fail'
+        elif tc.find('error') is not None: status = 'error'
+        elif tc.find('skipped') is not None: status = 'skip'
+        else: status = 'pass'
+        # Key by classname.method (precise) and method-only (fallback)
+        if cls:
+            results[f'{cls}.{name}'] = status
+        # For method-only key, pass wins over fail (avoid collision false negatives)
+        if name not in results or status == 'pass':
+            results[name] = status
+    return results
+
+# ---------------------------------------------------------------
+# Test catalog with full context per test
+# ---------------------------------------------------------------
+# (id, module, method, title, context, [screenshots])
+# context = why this test exists, what it proves, what user sees
+
+SECTIONS = [
+    ('X', 'Device Specifications', '0.0.0',
+     'The KeepKey is an open-source hardware wallet built on an ARM Cortex-M3 (STM32F205, 120MHz) '
+     'with a 256x64 monochrome OLED, single confirmation button, and micro-USB interface. The '
+     'bootloader (v2.x) is flashed at manufacture and never updated - it is the immutable root of '
+     'trust. On every boot, the bootloader verifies the firmware signature using redundant F3 checks '
+     'before transferring control.',
+     [
+         'BOOT SEQUENCE:',
+         '1. USB connect -> bootloader executes (always first)',
+         '2. F3 signature check (redundant dual-path verify)',
+         '3. Valid -> KeepKey logo -> firmware runs',
+         '4. Invalid/missing -> "UPDATE FIRMWARE" screen',
+         '5. Firmware upload -> verify -> flash -> reboot -> re-verify',
+         '',
+         'HARDWARE:',
+         '- MCU: STM32F205RET6, 120MHz, 128KB bootloader + 896KB firmware',
+         '- Display: 256x64 OLED (SSD1306), monochrome, used for ALL confirmations',
+         '- Input: single capacitive button (confirm/reject)',
+         '- USB: micro-B, HID + WebUSB transports, HID fallback',
+         '- Storage: BIP-39 seed encrypted in isolated flash region',
+         '- Curves: secp256k1, ed25519, NIST P-256, Pallas (Zcash)',
+         '',
+         'SECURITY MODEL:',
+         '- All private key operations happen on-device, keys never leave',
+         '- Every transaction output displayed on OLED for user verification',
+         '- PIN grid randomized on each prompt (position-based, not digit-based)',
+         '- BIP-39 passphrase creates hidden wallets (plausible deniability)',
+     ], []),
+
+    ('C', 'Core - Device Lifecycle', '7.0.0',
+     'Fundamental device security operations. Every firmware version must pass these tests. '
+     'A failure here is an absolute release blocker - these protect seed generation, backup, '
+     'recovery, and access control.',
+     [
+         'WIPE: Erases all keys and settings, returns to factory state',
+         'RESET: Generates cryptographic entropy -> BIP-39 mnemonic displayed on OLED only',
+         'RECOVERY: Cipher-based entry (scrambled keyboard on OLED) prevents keyloggers',
+         'PIN: Randomized grid on OLED, user enters position not digit',
+         'PASSPHRASE: Additional BIP-39 word, empty string = default wallet',
+     ],
+     [
+         ('C1', 'test_msg_wipedevice', 'test_wipe_device',
+          'Wipe device',
+          'Erases all keys, PIN, settings. Device shows "WIPE DEVICE - Do you want to erase your '
+          'private keys and settings?" on OLED. User must press button to confirm. After wipe, '
+          'device is uninitialized - no operations work until a new seed is loaded or generated.',
+          ['Wipe confirmation screen']),
+         ('C2', 'test_msg_resetdevice', 'test_reset_device',
+          'Generate new seed',
+          'Device generates 256 bits of entropy from hardware RNG, converts to BIP-39 mnemonic, '
+          'and displays words on OLED one page at a time. Words are NEVER sent to the host. '
+          'User writes them down as their backup.',
+          ['Seed word display']),
+         ('C3', 'test_msg_resetdevice', 'test_reset_device_pin',
+          'Generate seed with PIN',
+          'Same as C2 but also sets a PIN. PIN is entered twice for confirmation via the '
+          'randomized 3x3 grid on OLED. Verifies PIN is stored and required for subsequent operations.',
+          ['PIN entry grid']),
+         ('C4', 'test_msg_resetdevice', 'test_failed_pin',
+          'PIN mismatch rejects setup',
+          'If the user enters different PINs during confirmation, the device rejects the setup. '
+          'This prevents accidentally setting a PIN the user cannot reproduce.',
+          ['PIN mismatch warning']),
+         ('C5', 'test_msg_resetdevice', 'test_already_initialized',
+          'Reject reset on initialized device',
+          'An already-initialized device must refuse reset without a wipe first. Prevents '
+          'accidental seed replacement which would strand funds on the old seed.',
+          []),
+         ('C6', 'test_msg_loaddevice', 'test_load_device_1',
+          'Load 12-word mnemonic (debug)',
+          'Debug-only operation: loads a known 12-word mnemonic for testing. In production, '
+          'seeds can only be generated on-device or recovered via cipher entry.',
+          []),
+         ('C7', 'test_msg_loaddevice', 'test_load_device_2',
+          'Load 18-word mnemonic (debug)',
+          'Tests 18-word BIP-39 mnemonic support (192 bits of entropy).',
+          []),
+         ('C8', 'test_msg_loaddevice', 'test_load_device_3',
+          'Load 24-word mnemonic (debug)',
+          'Tests 24-word BIP-39 mnemonic support (256 bits of entropy, maximum security).',
+          []),
+         ('C9', 'test_msg_loaddevice', 'test_load_device_utf',
+          'Load with UTF-8 device label',
+          'Verifies the device handles non-ASCII characters in labels without corruption.',
+          []),
+         ('C10', 'test_msg_recoverydevice_cipher', 'test_nopin_nopassphrase',
+          'Cipher recovery (no PIN)',
+          'Recovery via scrambled keyboard on OLED. The letter grid is randomized per-character, '
+          'so even a compromised host cannot determine which letters the user selected. After all '
+          'words are entered, device verifies BIP-39 checksum and reconstructs the seed.',
+          ['Cipher grid on OLED']),
+         ('C11', 'test_msg_recoverydevice_cipher', 'test_pin_passphrase',
+          'Cipher recovery with PIN + passphrase',
+          'Same recovery flow as C10 but also sets PIN and enables passphrase protection during '
+          'the recovery process.',
+          ['Cipher + PIN entry']),
+         ('C12', 'test_msg_recoverydevice_cipher', 'test_character_fail',
+          'Invalid character rejection',
+          'Verifies the cipher entry rejects characters that cannot form any BIP-39 word prefix.',
+          []),
+         ('C13', 'test_msg_recoverydevice_cipher', 'test_backspace',
+          'Backspace during cipher entry',
+          'User can correct mistakes during word entry without restarting recovery.',
+          []),
+         ('C14', 'test_msg_recoverydevice_cipher', 'test_reset_and_recover',
+          'Full reset then recover cycle',
+          'End-to-end test: generate seed -> write down words -> wipe -> recover from words -> '
+          'verify same addresses are derived. Proves the backup/restore cycle works.',
+          []),
+         ('C15', 'test_msg_recoverydevice_cipher', 'test_wrong_number_of_words',
+          'Wrong word count rejected',
+          'BIP-39 only allows 12, 18, or 24 words. Other counts are rejected immediately.',
+          []),
+         ('C16', 'test_msg_recoverydevice_cipher_dryrun', 'test_correct_same',
+          'Dry-run recovery matches',
+          'User can verify their backup without wiping the device. Dry-run recovers the seed '
+          'in memory and compares to the active seed. If they match, user knows their backup is valid.',
+          []),
+         ('C17', 'test_msg_recoverydevice_cipher_dryrun', 'test_correct_notsame',
+          'Dry-run detects wrong backup',
+          'If the entered words produce a different seed, the device warns the user. This catches '
+          'transcription errors in the backup before an emergency.',
+          []),
+         ('C18', 'test_msg_recoverydevice_cipher_dryrun', 'test_incorrect',
+          'Dry-run rejects bad entry',
+          'Invalid words or checksum failure during dry-run are reported to the user.',
+          []),
+         ('C19', 'test_msg_changepin', 'test_set_pin',
+          'Set new PIN',
+          'Transitions from no-PIN to PIN-protected. The randomized 3x3 grid prevents screen '
+          'recording attacks - the attacker sees button presses but not which digit they map to.',
+          ['PIN entry grid']),
+         ('C20', 'test_msg_changepin', 'test_change_pin',
+          'Change existing PIN',
+          'Requires entering the current PIN first (proving knowledge), then setting a new one.',
+          []),
+         ('C21', 'test_msg_changepin', 'test_remove_pin',
+          'Remove PIN protection',
+          'User can disable PIN if physical security is sufficient. Requires current PIN to remove.',
+          []),
+         ('C22', 'test_msg_applysettings', 'test_apply_settings',
+          'Change label and language',
+          'Device label appears on OLED during confirmation screens. Helps identify devices when '
+          'a user has multiple KeepKeys.',
+          ['Label change confirm']),
+         ('C23', 'test_msg_applysettings', 'test_apply_settings_passphrase',
+          'Toggle passphrase protection',
+          'Enables/disables BIP-39 passphrase. When enabled, every operation prompts for a '
+          'passphrase. Different passphrases derive completely different wallets from the same seed.',
+          ['Passphrase enable']),
+         ('C24', 'test_msg_clearsession', 'test_clearsession',
+          'Clear session state',
+          'Clears cached PIN, passphrase, and session data. Next operation requires re-authentication.',
+          []),
+         ('C25', 'test_msg_ping', 'test_ping',
+          'Ping with button confirmation',
+          'Basic connectivity test. Verifies the device processes messages and button confirmation works.',
+          []),
+         ('C26', 'test_msg_ping', 'test_ping_format_specifier_sanitize',
+          'Sanitize format specifiers',
+          'Security test: printf-style format specifiers in ping message must not cause crashes '
+          'or information leaks. Verifies input sanitization.',
+          []),
+         ('C27', 'test_msg_getentropy', 'test_entropy',
+          'Hardware RNG entropy',
+          'Reads random bytes from the hardware RNG. Used to verify the entropy source is functional.',
+          []),
+         ('C28', 'test_msg_cipherkeyvalue', 'test_encrypt',
+          'Symmetric key encryption',
+          'Derives a symmetric key from the HD tree and encrypts data. Used for password manager '
+          'integrations and encrypted communication.',
+          []),
+         ('C29', 'test_msg_cipherkeyvalue', 'test_decrypt',
+          'Symmetric key decryption',
+          'Reverse of C28. Verifies encrypt/decrypt round-trips correctly.',
+          []),
+         ('C30', 'test_msg_signidentity', 'test_sign',
+          'Sign identity challenge (SSH/GPG)',
+          'Signs an identity challenge for SSH login or GPG key derivation. Derives a key from '
+          'the identity URI and signs the challenge.',
+          []),
+     ]),
+
+    ('B', 'Bitcoin', '7.0.0',
+     'Bitcoin is the primary chain and most extensively tested. Covers legacy P2PKH, P2SH-wrapped '
+     'SegWit, native SegWit (bech32), and Taproot (P2TR). Transaction signing validates that the '
+     'device correctly displays every output address and amount, calculates fees, detects change '
+     'outputs, and resists output substitution attacks. Also covers UTXO forks sharing BTC signing code.',
+     [
+         'ADDRESS: Derive key from BIP-32 path -> display on OLED with QR code -> user verifies against host',
+         'SIGN TX: Device shows each output (full address + amount) -> shows fee -> user confirms -> signs',
+         'MESSAGE: Show text on OLED -> user confirms -> signs with address-specific key (EIP-191 equivalent)',
+     ],
+     [
+         ('B1', 'test_msg_getaddress', 'test_btc',
+          'Derive BTC legacy address',
+          'Derives a P2PKH (1...) address from standard BIP-44 path m/44\'/0\'/0\'/0/0. '
+          'Verifies the address matches the expected value from the test mnemonic.',
+          []),
+         ('B2', 'test_msg_getaddress', 'test_ltc',
+          'Derive Litecoin address',
+          'LTC uses the same derivation as BTC with coin_type=2. Verifies L... address format.',
+          []),
+         ('B3', 'test_msg_getaddress', 'test_tbtc',
+          'Derive testnet address',
+          'Testnet addresses use different version bytes (m/n prefix). Important for development testing.',
+          []),
+         ('B4', 'test_msg_getaddress_show', 'test_show',
+          'Show BTC address on OLED',
+          'Address displayed on OLED with QR code for visual verification. User compares the address '
+          'shown on the trusted device display against the host application. This is the primary defense '
+          'against address substitution attacks by compromised hosts.',
+          ['BTC address + QR code']),
+         ('B5', 'test_msg_getaddress_show', 'test_show_multisig_3',
+          'Show 3-of-3 multisig address',
+          'Multisig addresses require all co-signer xpubs. Device displays the P2SH multisig address '
+          'derived from all provided public keys.',
+          ['Multisig address']),
+         ('B6', 'test_msg_getaddress_segwit', 'test_show_segwit',
+          'Show SegWit P2SH address',
+          'P2SH-wrapped SegWit (3... prefix). Backwards compatible with legacy wallets while '
+          'getting SegWit fee savings.',
+          ['SegWit address']),
+         ('B7', 'test_msg_getaddress_segwit_native', 'test_show_segwit',
+          'Show native SegWit bech32',
+          'Native SegWit (bc1q... prefix). Lowest fees, modern address format. Verifies bech32 encoding.',
+          ['bech32 address']),
+         ('B8', 'test_msg_getpublickey', 'test_btc',
+          'Get BTC xpub',
+          'Exports the extended public key for a derivation path. Used by wallet software to '
+          'derive addresses and monitor balances without the device connected.',
+          []),
+         ('B9', 'test_msg_signtx', 'test_one_one_fee',
+          'Sign basic BTC transaction',
+          'Simplest case: one input, one output. Device displays "Send X BTC to [address]" with '
+          'the full recipient address (no truncation), then shows the fee. Verifies the signed '
+          'transaction is valid.',
+          ['Send amount + address', 'Fee confirmation']),
+         ('B10', 'test_msg_signtx', 'test_one_two_fee',
+          'Sign BTC tx with change',
+          'One input, two outputs (payment + change). Device must identify the change output '
+          '(same xpub tree) and only display the payment output to the user.',
+          ['Output confirmation']),
+         ('B11', 'test_msg_signtx', 'test_two_two',
+          'Sign multi-input BTC tx',
+          'Two inputs, two outputs. Verifies correct fee calculation across multiple inputs.',
+          []),
+         ('B12', 'test_msg_signtx', 'test_spend_coinbase',
+          'Sign coinbase spend',
+          'Spending a coinbase (mining reward) output. Coinbase outputs have special maturity rules.',
+          []),
+         ('B13', 'test_msg_signtx', 'test_lots_of_outputs',
+          'Sign tx with many outputs',
+          'Stress test with many recipients. Each output is displayed individually on the OLED.',
+          []),
+         ('B14', 'test_msg_signtx', 'test_fee_too_high',
+          'Reject excessive fee',
+          'If the fee exceeds a safety threshold, the device shows a prominent warning. Protects '
+          'against fat-finger errors or malicious fee manipulation.',
+          ['High fee warning']),
+         ('B15', 'test_msg_signtx', 'test_not_enough_funds',
+          'Reject insufficient funds',
+          'If inputs don\'t cover outputs + fee, the device refuses to sign.',
+          []),
+         ('B16', 'test_msg_signtx', 'test_p2sh',
+          'Sign P2SH transaction',
+          'Pay-to-Script-Hash output. Used for multisig and complex scripts.',
+          []),
+         ('B17', 'test_msg_signtx', 'test_attack_change_outputs',
+          'Detect output substitution',
+          'Security test: the host attempts to substitute the change output address between '
+          'the first and second signing pass. Device must detect the mismatch and refuse.',
+          []),
+         ('B18', 'test_msg_signtx_segwit', 'test_send_p2sh',
+          'Sign SegWit P2SH tx',
+          'SegWit transaction with P2SH-wrapped inputs. Different signing algorithm (BIP-143).',
+          []),
+         ('B19', 'test_msg_signtx_segwit', 'test_send_mixed',
+          'Sign mixed legacy+SegWit tx',
+          'Transaction with both legacy and SegWit inputs in the same transaction.',
+          []),
+         ('B20', 'test_msg_signtx_p2tr', 'test_send_p2tr_only',
+          'Sign Taproot P2TR tx',
+          'Taproot (BIP-341/342) with Schnorr signatures. Newest address type with improved '
+          'privacy and efficiency.',
+          ['Taproot confirmation']),
+         ('B21', 'test_msg_signmessage', 'test_sign',
+          'Sign message with BTC key',
+          'Signs arbitrary text with a BTC address key. Used for proof-of-ownership and login.',
+          ['Sign message on OLED']),
+         ('B22', 'test_msg_signmessage_segwit', 'test_sign',
+          'Sign message with SegWit key', 'Message signing with P2SH-SegWit address key.', []),
+         ('B23', 'test_msg_signmessage_segwit_native', 'test_sign',
+          'Sign message with bech32 key', 'Message signing with native SegWit address key.', []),
+         ('B24', 'test_msg_verifymessage', 'test_message_verify',
+          'Verify signed message', 'Device verifies a message signature against a BTC address.', []),
+         ('B25', 'test_msg_signtx_bgold', 'test_send_bitcoin_gold_nochange',
+          'Sign Bitcoin Gold tx', 'BTG fork uses same signing code with different chain parameters.', []),
+         ('B26', 'test_msg_signtx_dash', 'test_send_dash',
+          'Sign Dash transaction', 'Dash special transaction types (InstantSend-compatible).', []),
+         ('B27', 'test_msg_signtx_grs', 'test_one_one_fee',
+          'Sign Groestlcoin tx', 'GRS uses Groestl hash instead of SHA-256d for tx hashing.', []),
+         ('B28', 'test_msg_signtx_zcash', 'test_transparent_one_one',
+          'Sign Zcash transparent tx',
+          'Zcash transparent transactions use Overwinter/Sapling serialization format with '
+          'version group IDs and expiry height.',
+          ['Zcash tx confirm']),
+     ]),
+
+    ('E', 'Ethereum', '7.0.0',
+     'Ethereum covers native ETH transfers, ERC-20 tokens, EIP-1559 gas, personal message signing '
+     '(EIP-191), and contract interactions. The device displays checksummed addresses (EIP-55), '
+     'values in ETH with 18-decimal precision, and gas parameters.',
+     [
+         'ETH TRANSFER: Show "Send X ETH to 0x..." -> show gas -> confirm -> sign with secp256k1',
+         'ERC-20: Decode transfer(to,amount) from contract data -> show token name + amount',
+         'EIP-1559: Show maxFeePerGas + maxPriorityFeePerGas (not legacy gasPrice)',
+         'MESSAGE: EIP-191 prefix -> show text on OLED -> sign with ETH key',
+     ],
+     [
+         ('E1', 'test_msg_ethereum_getaddress', 'test_ethereum_getaddress',
+          'Derive ETH address', 'Standard m/44\'/60\'/0\'/0/0 derivation. EIP-55 checksum address.', ['ETH address']),
+         ('E2', 'test_msg_ethereum_signtx', 'test_ethereum_signtx_nodata',
+          'Sign ETH transfer',
+          'Simple value transfer with no contract data. Device shows recipient + amount + gas.',
+          ['ETH send confirmation']),
+         ('E3', 'test_msg_ethereum_signtx', 'test_ethereum_signtx_data',
+          'Sign ETH tx with contract data',
+          'Transaction with data field (contract call). Device shows data as hex since it cannot '
+          'decode arbitrary ABI without metadata.',
+          ['Contract data hex']),
+         ('E4', 'test_msg_ethereum_signtx', 'test_ethereum_signtx_nodata_eip155',
+          'Sign ETH with EIP-155 replay protection',
+          'Chain ID embedded in signature v value to prevent cross-chain replay attacks.', []),
+         ('E5', 'test_msg_ethereum_signtx', 'test_ethereum_eip_1559',
+          'Sign EIP-1559 transaction',
+          'Type 2 transaction with base fee + priority fee. Device shows both gas parameters.',
+          ['EIP-1559 gas display']),
+         ('E6', 'test_msg_ethereum_signtx', 'test_ethereum_signtx_knownerc20_eip_1559',
+          'Sign known ERC-20 (EIP-1559)',
+          'Known token (in firmware token list) via EIP-1559. Shows human-readable token name + amount.',
+          ['Token transfer display']),
+         ('E7', 'test_msg_ethereum_message', 'test_ethereum_sign_message',
+          'Sign personal message',
+          'EIP-191 personal_sign. Device shows the message text on OLED for user to verify before signing.',
+          ['Sign message screen']),
+         ('E8', 'test_msg_ethereum_message', 'test_ethereum_sign_bytes',
+          'Sign raw bytes', 'Signs arbitrary bytes (displayed as hex on OLED).', []),
+         ('E9', 'test_msg_ethereum_message', 'test_ethereum_verify_message',
+          'Verify ETH signed message', 'Device-side verification of EIP-191 signed messages.', []),
+         ('E10', 'test_msg_signtx_ethereum_erc20', 'test_approve_some',
+          'ERC-20 approve specific amount',
+          'Token approval for a specific amount. Device shows spender address + approved amount.',
+          ['Approval screen']),
+         ('E11', 'test_msg_signtx_ethereum_erc20', 'test_approve_all',
+          'ERC-20 approve unlimited',
+          'MAX_UINT256 approval. Device shows "UNLIMITED" warning since this grants infinite spending.',
+          ['Unlimited approval warning']),
+         ('E12', 'test_msg_ethereum_makerdao', 'test_generate',
+          'MakerDAO generate DAI', 'Complex DeFi contract interaction (MakerDAO CDP).', []),
+         ('E13', 'test_msg_ethereum_sablier', 'test_sign_salarywithdrawal',
+          'Sablier salary withdrawal', 'Streaming payment protocol contract call.', []),
+         ('E14', 'test_msg_ethereum_erc20_0x_signtx', 'test_sign_0x_swap_ETH_to_ERC20',
+          '0x swap ETH to ERC-20', 'DEX aggregator swap via 0x protocol.', []),
+         ('E15', 'test_msg_ethereum_cfunc', 'test_sign_execTx',
+          'Contract function call', 'Generic contract call signing.', []),
+     ]),
+
+    ('R', 'Ripple (XRP)', '7.0.0',
+     'XRP Ledger support for the third-largest cryptocurrency by market cap. XRP uses a unique '
+     'account-based model (not UTXO) with 20 XRP minimum reserve. Amounts are denominated in '
+     'drops (1 XRP = 1,000,000 drops). Destination tags are required for exchange deposits to '
+     'route funds to the correct account. The device displays the full rAddress (34 chars starting '
+     'with r) and converts drop amounts to human-readable XRP values.',
+     [
+         'ADDRESS: Derive from m/44\'/144\'/0\'/0/0 -> display full rAddress + QR on OLED',
+         'SIGN: Host sends Payment tx (destination, amount, fee, destination_tag) -> device shows XRP amount + recipient',
+         'FEE: XRP requires a minimum fee (currently 10 drops). Device validates fee is within bounds.',
+     ],
+     [
+         ('R1', 'test_msg_ripple_get_address', 'test_ripple_get_address',
+          'Derive XRP address', 'Standard m/44\'/144\'/0\'/0/0 derivation.', ['XRP address']),
+         ('R2', 'test_msg_ripple_sign_tx', 'test_sign',
+          'Sign XRP payment', 'Payment with amount in drops (1 XRP = 1,000,000 drops).', ['XRP send']),
+         ('R3', 'test_msg_ripple_sign_tx', 'test_ripple_sign_invalid_fee',
+          'Reject invalid fee', 'Fee outside acceptable range is rejected.', []),
+     ]),
+
+    ('A', 'Cosmos (ATOM)', '7.0.0',
+     'Cosmos Hub is the anchor chain for the Cosmos IBC ecosystem. Transactions use amino encoding '
+     '(legacy Cosmos SDK format). The device supports MsgSend (transfers), MsgDelegate (staking to '
+     'validators), and MsgWithdrawDelegatorReward (claiming staking rewards). Addresses use bech32 '
+     'encoding with the cosmos1 prefix. Memo field is critical for exchange deposits and IBC transfers - '
+     'the device displays it in full on the OLED for user verification.',
+     [
+         'ADDRESS: Derive from m/44\'/118\'/0\'/0/0 -> display cosmos1... bech32 address',
+         'SEND: Show recipient address + ATOM amount + memo on OLED -> user confirms',
+         'MEMO: Displayed in full - required for exchange deposits (e.g. numeric account ID)',
+     ],
+     [
+         ('A1', 'test_msg_cosmos_getaddress', 'test_standard',
+          'Derive Cosmos address', 'Bech32 cosmos1... address from m/44\'/118\'/0\'/0/0.', ['ATOM address']),
+         ('A2', 'test_msg_cosmos_signtx', 'test_cosmos_sign_tx',
+          'Sign Cosmos send', 'MsgSend with amount + recipient display.', ['ATOM send']),
+         ('A3', 'test_msg_cosmos_signtx', 'test_cosmos_sign_tx_memo',
+          'Sign Cosmos with memo', 'Memo field displayed for exchange deposit tags.', []),
+     ]),
+
+    ('H', 'THORChain', '7.0.0',
+     'THORChain is a decentralized cross-chain liquidity protocol. Native RUNE transactions use amino '
+     'encoding with thor1... bech32 addresses. The memo field is the critical security element - it '
+     'encodes the entire swap/LP instruction (e.g. "SWAP:BTC.BTC:bc1q..." or "=:ETH.ETH:0x..."). A '
+     'compromised host could substitute the memo destination address to steal funds. The device '
+     'displays the full memo text on OLED so users can verify the swap destination, pool, and '
+     'parameters before signing. THORChain also supports LP add/remove operations and deposits.',
+     [
+         'ADDRESS: Derive from m/44\'/931\'/0\'/0/0 -> display thor1... bech32 address',
+         'SEND: Show RUNE amount + recipient + full memo text on OLED',
+         'SWAP MEMO: "SWAP:BTC.BTC:bc1q..." - user verifies destination chain, asset, and receiving address',
+         'LP MEMO: "ADD:BTC.BTC:thor1..." or "WITHDRAW:BTC.BTC:10000" - user verifies pool and basis points',
+     ],
+     [
+         ('H1', 'test_msg_thorchain_getaddress', 'test_thorchain_get_address',
+          'Derive THORChain address', 'Bech32 thor1... address.', []),
+         ('H2', 'test_msg_thorchain_signtx', 'test_thorchain_sign_tx',
+          'Sign THORChain tx', 'Native RUNE transfer with memo.', ['Memo display']),
+         ('H3', 'test_msg_thorchain_signtx', 'test_sign_btc_eth_swap',
+          'Sign BTC->ETH swap', 'Cross-chain swap via THORChain memo routing.', ['Swap memo']),
+         ('H4', 'test_msg_2thorchain_signtx', 'test_thorchain_sign_tx_deposit',
+          'Sign THORChain deposit', 'LP deposit transaction.', []),
+     ]),
+
+    ('M', 'Maya Protocol', '7.0.0',
+     'Maya Protocol is a THORChain fork providing cross-chain liquidity with its native CACAO token. '
+     'Uses identical amino transaction format and memo-based routing as THORChain but with maya1... '
+     'bech32 addresses. Maya bridges assets between Bitcoin, Ethereum, THORChain, Dash, and Kujira. '
+     'The same memo security considerations apply - the device must display the full memo for swap '
+     'destination verification.',
+     [
+         'ADDRESS: Derive from m/44\'/931\'/0\'/0/0 -> display maya1... bech32 address',
+         'SEND: Show CACAO amount + recipient + full memo on OLED',
+         'SWAP: Same memo format as THORChain with Maya-specific pool routing',
+     ],
+     [
+         ('M1', 'test_msg_mayachain_getaddress', 'test_mayachain_get_address',
+          'Derive Maya address', 'Bech32 maya1... address.', []),
+         ('M2', 'test_msg_mayachain_signtx', 'test_sign_btc_eth_swap',
+          'Sign BTC-ETH swap via Maya', 'Cross-chain swap via Maya memo routing.', []),
+         ('M3', 'test_msg_mayachain_signtx', 'test_sign_eth_add_liquidity',
+          'Sign swap via Maya', 'Cross-chain swap via Maya memo routing.', []),
+     ]),
+
+    # Binance Chain (BNB) - REMOVED: chain deprecated, beacon chain shut down 2024.
+    # Tests remain in python-keepkey but excluded from report.
+
+    ('O', 'EOS', '7.0.0',
+     'EOS chain support with action-based transaction model. Unlike UTXO or account-based chains, EOS '
+     'transactions contain a list of actions, each targeting a specific smart contract. The device '
+     'displays each action individually for user review. Covers the core eosio system actions: token '
+     'transfers, CPU/NET bandwidth delegation, block producer voting, and account authority management '
+     '(updateauth, linkauth, newaccount). EOS uses a unique account name system (12-char names) instead '
+     'of addresses.',
+     [
+         'PUBKEY: Derive EOS public key from m/44\'/194\'/0\'/0/0 (EOS format with EOS prefix)',
+         'SIGN TX: Host sends action list -> device displays each action with contract + data -> signs',
+         'STAKING: delegatebw/undelegatebw for CPU/NET resource management',
+         'GOVERNANCE: voteproducer to select block producers',
+     ],
+     [
+         ('O1', 'test_msg_eos_getpublickey', 'test_trezor',
+          'Derive EOS public key', 'EOS public key from m/44\'/194\'/0\'/0/0.', []),
+         ('O2', 'test_msg_eos_signtx', 'test_transfer',
+          'Sign EOS transfer', 'eosio.token::transfer action.', []),
+         ('O3', 'test_msg_eos_signtx', 'test_delegatebw',
+          'Delegate bandwidth', 'CPU/NET resource staking.', []),
+         ('O4', 'test_msg_eos_signtx', 'test_voteproducer',
+          'Vote for producer', 'Block producer voting.', []),
+     ]),
+
+    ('W', 'Nano', '7.0.0',
+     'Nano uses a unique block-lattice architecture where each account has its own blockchain. '
+     'Transactions are feeless and near-instant. The device validates balance encoding for Nano state '
+     'blocks, which represent the entire account state (balance, representative, link) in a single block. '
+     'Balance values use 128-bit raw amounts (1 Nano = 10^30 raw).',
+     [
+         'ENCODE: Validate 128-bit balance representation for state block construction',
+         'STATE BLOCK: account + previous + representative + balance + link -> hash -> sign',
+     ],
+     [('W1', 'test_msg_nano_signtx', 'test_encode_balance',
+       'Encode Nano balance',
+       'Validates the 128-bit balance encoding used in Nano state blocks. Incorrect encoding would '
+       'cause fund loss or invalid transactions on the block-lattice.',
+       [])]),
+
+    # ===== 7.14 NEW FEATURES =====
+    ('V', 'EVM Clear-Signing', '7.14.0',
+     'NEW: Verified transaction metadata for EVM contracts. Host sends a signed blob with contract '
+     'name, function, and decoded parameters. Device verifies blob signature against trusted key, '
+     'then shows human-readable details with VERIFIED icon. AdvancedMode policy gates blind-signing '
+     '(disabled by default = blind signing blocked).',
+     [
+         'CLEAR-SIGN: Signed metadata -> verify signature -> VERIFIED icon + method + decoded args',
+         'BLIND BLOCKED: No metadata + AdvancedMode off -> device refuses',
+         'BLIND ALLOWED: No metadata + AdvancedMode on -> warning -> sign',
+     ],
+     [
+         ('V1', 'test_msg_ethereum_clear_signing', 'test_valid_metadata_returns_verified',
+          'Valid metadata accepted',
+          'Correctly signed metadata blob is accepted. Device shows VERIFIED icon with decoded '
+          'method name and contract address.',
+          ['VERIFIED icon + method']),
+         ('V2', 'test_msg_ethereum_clear_signing', 'test_wrong_key_returns_malformed',
+          'Wrong signing key rejected', 'Metadata signed with wrong key is rejected as malformed.', []),
+         ('V3', 'test_msg_ethereum_clear_signing', 'test_tampered_method_returns_malformed',
+          'Tampered method rejected', 'Modified method name in blob fails signature check.', []),
+         ('V4', 'test_msg_ethereum_clear_signing', 'test_tampered_contract_returns_malformed',
+          'Tampered contract rejected', 'Modified contract address fails signature check.', []),
+         ('V5', 'test_msg_ethereum_clear_signing', 'test_no_metadata_then_sign_unchanged',
+          'No metadata = blind sign path',
+          'Without metadata, transaction goes through blind-sign path (gated by AdvancedMode).',
+          ['Blind sign warning']),
+         ('V6', 'test_msg_ethereum_clear_signing', 'test_signature_verification',
+          'Signature verification math', 'Unit test for the metadata blob signature algorithm.', []),
+         ('V7', 'test_msg_ethereum_clear_signing', 'test_tampered_blob_fails_verification',
+          'Tampered blob fails', 'Any byte change in the blob invalidates the signature.', []),
+     ]),
+
+    ('S', 'Solana', '7.14.0',
+     'NEW: Full Solana with Ed25519 (SLIP-10), base58 addresses, 37 instruction types across 7 '
+     'programs. Key security fix: full 44-character address display replaces old 8-char truncation '
+     'that was a spoofing vector.',
+     [
+         'ADDRESS: m/44\'/501\'/0\' Ed25519 -> full 44-char base58 on OLED',
+         'SIGN TX: Parse instructions -> per-instruction confirmation -> Ed25519 sign',
+         'SIGN MESSAGE: Arbitrary bytes -> hex display -> Ed25519 sign',
+     ],
+     [
+         ('S1', 'test_msg_solana_getaddress', 'test_solana_get_address',
+          'Derive Solana address', 'Full 44-character base58 address displayed on OLED.', ['Full 44-char address']),
+         ('S2', 'test_msg_solana_getaddress', 'test_solana_different_accounts',
+          'Different account indices', 'Verifies different accounts produce different addresses.', []),
+         ('S3', 'test_msg_solana_getaddress', 'test_solana_deterministic',
+          'Deterministic derivation', 'Same path always produces same address.', []),
+         ('S4', 'test_msg_solana_signtx', 'test_solana_sign_system_transfer',
+          'Sign SOL transfer', 'System::Transfer with full address + amount display.', ['SOL amount + address']),
+         ('S5', 'test_msg_solana_signtx', 'test_solana_sign_message',
+          'Sign Solana message', 'Arbitrary message signing with Ed25519 key.', ['Message screen']),
+         ('S6', 'test_msg_solana_signtx', 'test_solana_sign_empty_rejected',
+          'Empty tx rejected', 'Zero-length transaction data is refused.', []),
+         ('S7', 'test_msg_solana_signtx', 'test_solana_sign_deterministic',
+          'Deterministic signing', 'Same tx always produces same signature.', []),
+     ]),
+
+    ('T', 'TRON', '7.14.0',
+     'NEW: TRON with protobuf deserialization and reconstruct-then-sign. 13 hardcoded TRC-20 tokens. '
+     'Device reconstructs tx hash from parsed fields (not raw blob) for clear-sign path.',
+     [
+         'ADDRESS: m/44\'/195\'/0\'/0/0 -> full 34-char base58 TRON address',
+         'STRUCTURED: Parse fields -> reconstruct hash -> show amount + address -> sign',
+         'TRC-20: Decode transfer(to,amount) ABI -> show token name + decoded amount',
+         'LEGACY: Raw protobuf -> blind sign warning',
+     ],
+     [
+         ('T1', 'test_msg_tron_getaddress', 'test_tron_get_address',
+          'Derive TRON address', 'Full 34-character base58 address.', ['Full 34-char address']),
+         ('T2', 'test_msg_tron_getaddress', 'test_tron_different_accounts',
+          'Different accounts', 'Different indices produce different addresses.', []),
+         ('T3', 'test_msg_tron_getaddress', 'test_tron_deterministic',
+          'Deterministic derivation', 'Same path always produces same address.', []),
+         ('T4', 'test_msg_tron_signtx', 'test_tron_sign_transfer_structured',
+          'Sign TRX transfer', 'Structured clear-sign with full address display.', ['TRX send']),
+         ('T5', 'test_msg_tron_signtx', 'test_tron_sign_transfer_legacy_raw_data',
+          'Sign TRX legacy raw', 'Raw protobuf data triggers blind sign path.', ['Blind sign']),
+         ('T6', 'test_msg_tron_signtx', 'test_tron_sign_trc20_transfer',
+          'Sign TRC-20 token', 'Known token decoded from ABI data.', ['Token + amount']),
+         ('T7', 'test_msg_tron_signtx', 'test_tron_sign_missing_fields_rejected',
+          'Missing fields rejected', 'Incomplete transaction data is refused.', []),
+     ]),
+
+    ('N', 'TON', '7.14.0',
+     'NEW: TON v4r2 wallet contracts. Clear-sign reconstructs cell tree + SHA-256 hash verification. '
+     'Blind-sign for StateInit deploys or hash mismatch. Memo/comment support.',
+     [
+         'ADDRESS: m/44\'/607\'/0\' -> full 48-char base64url TON address',
+         'CLEAR-SIGN: Reconstruct v4r2 cell -> SHA-256 match -> show transfer details',
+         'BLIND-SIGN: Hash mismatch or deploy -> "BLIND SIGNATURE" warning',
+     ],
+     [
+         ('N1', 'test_msg_ton_getaddress', 'test_ton_get_address',
+          'Derive TON address', 'Full 48-character base64url address.', ['Full 48-char address']),
+         ('N2', 'test_msg_ton_getaddress', 'test_ton_different_accounts',
+          'Different accounts', 'Different indices produce different addresses.', []),
+         ('N3', 'test_msg_ton_getaddress', 'test_ton_address_format',
+          'Address format validation', 'Bounceable/non-bounceable format check.', []),
+         ('N4', 'test_msg_ton_signtx', 'test_ton_sign_structured',
+          'Sign TON clear-sign', 'Hash verification passes, shows "TON Transfer" with details.', ['TON Transfer']),
+         ('N5', 'test_msg_ton_signtx', 'test_ton_sign_with_comment',
+          'Sign TON with memo', 'Comment displayed before signing.', ['Memo display']),
+         ('N6', 'test_msg_ton_signtx', 'test_ton_sign_legacy_raw_tx',
+          'Sign TON blind', 'Raw tx without structured fields triggers blind sign.', ['Blind warning']),
+         ('N7', 'test_msg_ton_signtx', 'test_ton_sign_missing_fields_rejected',
+          'Missing fields rejected', 'Incomplete data refused.', []),
+     ]),
+
+    ('Z', 'Zcash Orchard', '7.14.0',
+     'NEW: Shielded transactions via PCZT streaming. Orchard hides sender, recipient, and amount '
+     'using ZK proofs. Raw seed access (ZIP-32 Orchard derivation uses BIP-39 seed + Pallas curve). '
+     'Full Viewing Key (FVK) export for watch-only wallets.',
+     [
+         'FVK: Derive ak, nk, rivk components via ZIP-32 Orchard path',
+         'PCZT: Stream header -> actions one at a time -> confirm each -> return signatures',
+         'HYBRID: Transparent inputs + Orchard outputs in same tx',
+     ],
+     [
+         ('Z1', 'test_msg_zcash_orchard', 'test_fvk_reference_vectors',
+          'FVK reference vectors', 'FVK output matches known test vectors.', ['FVK export']),
+         ('Z2', 'test_msg_zcash_orchard', 'test_fvk_field_ranges',
+          'FVK field ranges', 'ak, nk, rivk are within valid Pallas curve ranges.', []),
+         ('Z3', 'test_msg_zcash_orchard', 'test_fvk_consistency_across_calls',
+          'FVK deterministic', 'Same account always produces same FVK.', []),
+         ('Z4', 'test_msg_zcash_orchard', 'test_fvk_different_accounts',
+          'FVK different accounts', 'Different accounts produce different FVKs.', []),
+         ('Z5', 'test_msg_zcash_sign_pczt', 'test_single_action_legacy_sighash',
+          'Sign single Orchard action', 'One shielded action, device shows amount + fee.', ['Shielded confirm']),
+         ('Z6', 'test_msg_zcash_sign_pczt', 'test_multi_action_legacy_sighash',
+          'Sign multiple actions', 'Multiple Orchard actions in one transaction.', []),
+         ('Z7', 'test_msg_zcash_sign_pczt', 'test_signatures_are_64_bytes',
+          'Signature format', 'Orchard signatures must be exactly 64 bytes (RedPallas).', []),
+         ('Z8', 'test_msg_zcash_sign_pczt', 'test_transparent_shielding_single_input',
+          'Transparent to shielded', 'Transparent BTC-like input shielded into Orchard pool.', ['Hybrid shield']),
+         ('Z9', 'test_msg_zcash_sign_pczt', 'test_transparent_shielding_multiple_inputs',
+          'Multi-input shielding', 'Multiple transparent inputs shielded in one tx.', []),
+     ]),
+
+    ('D', 'BIP-85 Child Derivation', '7.14.0',
+     'NEW: Derives child BIP-39 mnemonic from master seed via HMAC-SHA512 (BIP-85). Display-only: '
+     'derived words appear on OLED, never transmitted over USB. Seed accessed in CONFIDENTIAL '
+     'buffer, memzero\'d after use.',
+     [
+         'DERIVE: word_count + language + index -> HMAC-SHA512 -> child entropy -> BIP-39 words',
+         'DISPLAY: Words shown on OLED only -> user writes down -> never sent to host',
+     ],
+     [
+         ('D1', 'test_msg_bip85', 'test_bip85_12word_flow',
+          'Derive 12-word child',
+          'Derives 128 bits of child entropy -> 12-word BIP-39 mnemonic displayed on OLED.',
+          ['Derivation params', 'Mnemonic on OLED']),
+         ('D2', 'test_msg_bip85', 'test_bip85_24word_flow',
+          'Derive 24-word child', '256 bits -> 24 words.', []),
+         ('D3', 'test_msg_bip85', 'test_bip85_18word_flow',
+          'Derive 18-word child', '192 bits -> 18 words.', []),
+         ('D4', 'test_msg_bip85', 'test_bip85_different_indices_different_flows',
+          'Different indices', 'Index 0 and index 1 must produce completely different mnemonics.', []),
+         ('D5', 'test_msg_bip85', 'test_bip85_deterministic_flow',
+          'Deterministic', 'Same seed + same index always produces same child mnemonic.', []),
+         ('D6', 'test_msg_bip85', 'test_bip85_invalid_word_count',
+          'Invalid count rejected', 'Word counts other than 12/18/24 are refused.', []),
+     ]),
+]
+
+# ---------------------------------------------------------------
+# Render
+# ---------------------------------------------------------------
+def render(output_path, fw_version, results, screenshot_dir=None):
+    pdf = PDF(); pb = PB(pdf)
+    ts = datetime.now().strftime('%Y-%m-%d %H:%M')
+    active = [(l,t,mf,bg,fl,tests) for l,t,mf,bg,fl,tests in SECTIONS if ver_ge(fw_version, mf)]
+    # Separate specs section (no tests) from test sections
+    specs = [s for s in active if not s[5]]
+    test_sections = [s for s in active if s[5]]
+    total = sum(len(s[5]) for s in test_sections)
+    passed = sum(1 for s in test_sections for t in s[5] if results.get(t[2]) == 'pass')
+    failed = sum(1 for s in test_sections for t in s[5] if results.get(t[2]) in ('fail','error'))
+    skipped = total - passed - failed
+
+    # Title
+    pb.text(20, 'KeepKey Firmware Test Report', bold=True)
+    pb.gap(2)
+    if passed == total and total > 0:
+        pb.text(11, f'Firmware {fw_version}  |  {ts}  |  ALL {total} TESTS PASSED', bold=True, color=GREEN)
+    elif failed > 0:
+        pb.text(11, f'Firmware {fw_version}  |  {ts}  |  {failed} FAILED of {total} tests', bold=True, color=RED)
+    else:
+        pb.text(10, f'Firmware {fw_version}  |  {ts}  |  {total} tests: {passed} passed, {skipped} pending')
+    pb.gap(6)
+    pb.text(12, 'Sections', bold=True)
+    for letter, title, mf, _, _, tests in test_sections:
+        tag = ' [NEW]' if ver_t(mf) > (7, 10, 0) else ''
+        p = sum(1 for t in tests if results.get(t[2]) == 'pass')
+        if p == len(tests) and len(tests) > 0:
+            pb.text(8, f'  {letter}  {title}{tag} -- {p}/{len(tests)} passed', color=GREEN)
+        elif p > 0:
+            pb.text(8, f'  {letter}  {title}{tag} -- {p}/{len(tests)} passed')
+        else:
+            pb.text(8, f'  {letter}  {title}{tag} -- {len(tests)} tests', color=GRAY)
+
+    # Render specs sections as informational (no test count in header)
+    for letter, title, mf, background, user_flow, tests in specs:
+        pb.gap(10); pb.need(80)
+        pb.text(14, f'{title}', bold=True)
+        pb.gap(2)
+        for line in _w(background, 95): pb.text(8, line)
+        pb.gap(3)
+        for line in user_flow: pb.text(7, line)
+
+    # Render test sections
+    for letter, title, mf, background, user_flow, tests in test_sections:
+        pb.gap(10); pb.need(80)
+        tag = ' [NEW]' if ver_t(mf) > (7, 10, 0) else ''
+        pb.text(14, f'{letter}. {title}{tag}', bold=True)
+        pb.gap(2)
+        for line in _w(background, 95): pb.text(8, line)
+        pb.gap(3)
+        pb.text(9, 'User Flow', bold=True)
+        for line in user_flow: pb.text(7, line)
+        if not tests: continue
+        pb.gap(3)
+        p = sum(1 for t in tests if results.get(t[2]) == 'pass')
+        f_count = sum(1 for t in tests if results.get(t[2]) in ('fail','error'))
+        if p == len(tests):
+            pb.text(9, f'Tests: {p}/{len(tests)} -- ALL PASSED', bold=True, color=GREEN)
+        elif f_count > 0:
+            pb.text(9, f'Tests: {p}/{len(tests)} passed, {f_count} FAILED', bold=True, color=RED)
+        else:
+            pb.text(9, f'Tests: {len(tests)}', bold=True)
+        pb.gap(2)
+        for tid, mod, meth, title, ctx, scr in tests:
+            pb.need(50)
+            r = results.get(meth, '')
+            pb.check(9, f'{tid} {meth}', r)
+            pb.text(7, f'{title}  ({mod}.py)')
+            for cline in _w(ctx, 95): pb.text(7, cline)
+            # Embed OLED screenshots (skip first 2 setUp frames, show all test frames)
+            if screenshot_dir:
+                test_dir = os.path.join(screenshot_dir, mod.replace('test_',''), meth)
+                btn_files = sorted(f for f in os.listdir(test_dir) if f.startswith('btn')) if os.path.isdir(test_dir) else []
+                # Skip first 2 btn frames (setUp: wipe + load_device confirmations)
+                test_frames = btn_files[2:] if len(btn_files) > 2 else btn_files[:1] if len(btn_files) == 1 else []
+                if test_frames:
+                    for frame in test_frames:
+                        try:
+                            pb.need(55)
+                            pb.image(os.path.join(test_dir, frame), display_w=384, display_h=96)
+                        except Exception:
+                            pass
+                elif scr:
+                    pb.text(7, f'OLED needed: {", ".join(scr)}', color=GRAY)
+            elif scr:
+                pb.text(7, f'OLED needed: {", ".join(scr)}', color=GRAY)
+            pb.gap(3)
+
+    pb.finish()
+    pdf.write(output_path)
+    print(f'{output_path}: fw={fw_version}, {len(active)} sections, {total} tests ({passed} passed, {failed} failed, {skipped} pending)')
+
+def main():
+    p = argparse.ArgumentParser(description='KeepKey Firmware Test Report')
+    p.add_argument('--output', default='test-report.pdf')
+    p.add_argument('--fw-version', default=None)
+    p.add_argument('--junit', default=None, help='JUnit XML for pass/fail results')
+    p.add_argument('--screenshots', default=None, help='Directory with per-test OLED screenshots')
+    args = p.parse_args()
+
+    fw = args.fw_version
+    if not fw:
+        print('Detecting firmware from emulator...')
+        fw = detect_fw()
+        if fw: print(f'Detected: {fw}')
+        else: print('No emulator, defaulting to 7.10.0'); fw = '7.10.0'
+
+    results = parse_junit(args.junit) if args.junit else {}
+    render(args.output, fw, results, args.screenshots)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- Adds BIP-39 wordlist validation check during cipher recovery word entry
- Invalid words that pass checksum but aren't in the BIP-39 wordlist are now rejected
- Fixes logic inversion in validation gate

## Test plan
- [ ] C12 test_character_fail — invalid character rejection still works
- [ ] C15 test_wrong_number_of_words — wrong word count still rejected
- [ ] OLED screenshot showing reject message for invalid word
- [ ] All 91 tests pass, no regressions