### PR TITLE
CI screenshot pipeline: healthcheck + debug logging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ name: CI
 
 on:
   push:
-    branches: [master, develop, 'feature/**', 'fix/**', 'release/**', 'hotfix/**']
+    branches: [master, develop, 'feat/**', 'feature/**', 'fix/**', 'release/**', 'hotfix/**']
   pull_request:
     branches: [master, develop]
   workflow_dispatch:
@@ -429,6 +429,53 @@ jobs:
         if: always()
         working-directory: scripts/emulator
         run: docker compose down -v || true
+
+  # ═══════════════════════════════════════════════════════════
+  # STAGE 3b: REPORT — generate test-report.pdf from results
+  # ═══════════════════════════════════════════════════════════
+
+  generate-test-report:
+    needs: [python-integration-tests]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          submodules: false
+
+      - name: Init python-keepkey submodule
+        run: git submodule update --init --recursive deps/python-keepkey
+
+      - name: Download Python test results
+        uses: actions/download-artifact@v4
+        with:
+          name: python-test-results
+          path: test-reports/python-keepkey/
+        continue-on-error: true
+
+      - name: Extract firmware version
+        id: version
+        run: |
+          FW_VERSION=$(sed -n '/^project/,/)/p' CMakeLists.txt | grep -oP '\d+\.\d+\.\d+')
+          echo "fw_version=${FW_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Generate test-report.pdf
+        run: |
+          python3 scripts/generate-test-report.py \
+            --fw-version=${{ steps.version.outputs.fw_version }} \
+            --junit=test-reports/python-keepkey/junit.xml \
+            --output=test-report.pdf
+
+      - name: Upload test report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-report
+          path: test-report.pdf
+          retention-days: 90
 
   # ═══════════════════════════════════════════════════════════
   # STAGE 4: PUBLISH — manual trigger only, all tests must pass

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ name: CI
 
 on:
   push:
-    branches: [master, develop, 'feat/**', 'feature/**', 'fix/**', 'release/**', 'hotfix/**']
+    branches: [master, develop, alpha, 'feat/**', 'feature/**', 'fix/**', 'release/**', 'hotfix/**']
   pull_request:
     branches: [master, develop]
   workflow_dispatch:
@@ -343,6 +343,91 @@ jobs:
             bin/*.elf
           retention-days: 90
 
+  build-arm-firmware-btc-only:
+    needs: [check-submodules, secret-scan]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Init submodules
+        run: |
+          git submodule update --init deps/crypto/trezor-firmware
+          git submodule update --init deps/device-protocol
+          git submodule update --init --recursive deps/python-keepkey
+          git submodule update --init deps/googletest
+          git submodule update --init deps/qrenc/QR-Code-generator
+          git submodule update --init deps/sca-hardening/SecAESSTM32
+
+      - name: Cache base image
+        id: cache-base
+        uses: actions/cache@v4
+        with:
+          path: /tmp/base-image.tar
+          key: base-image-${{ env.BASE_IMAGE }}
+
+      - name: Pull and cache base image
+        if: steps.cache-base.outputs.cache-hit != 'true'
+        run: |
+          docker pull ${{ env.BASE_IMAGE }}
+          docker save ${{ env.BASE_IMAGE }} -o /tmp/base-image.tar
+
+      - name: Load base image from cache
+        if: steps.cache-base.outputs.cache-hit == 'true'
+        run: docker load -i /tmp/base-image.tar
+
+      - name: Extract firmware version
+        id: version
+        run: |
+          FW_VERSION=$(sed -n '/^project/,/)/p' CMakeLists.txt | grep -oP '\d+\.\d+\.\d+')
+          GIT_SHORT=$(git rev-parse --short HEAD)
+          echo "fw_version=${FW_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "git_short=${GIT_SHORT}" >> "$GITHUB_OUTPUT"
+          echo "Firmware version: ${FW_VERSION} (${GIT_SHORT}) [BTC-only]"
+
+      - name: Cross-compile BTC-only firmware for ARM
+        run: |
+          docker run --rm \
+            -v ${{ github.workspace }}:/root/keepkey-firmware:z \
+            ${{ env.BASE_IMAGE }} /bin/sh -c "\
+              mkdir /root/build && cd /root/build && \
+              cmake -C /root/keepkey-firmware/cmake/caches/device.cmake /root/keepkey-firmware \
+                -DCOIN_SUPPORT=BTC \
+                -DVARIANTS=NoObsoleteVariants \
+                -DCMAKE_BUILD_TYPE=MinSizeRel \
+                -DCMAKE_COLOR_MAKEFILE=ON && \
+              make && \
+              mkdir -p /root/keepkey-firmware/bin-btc && \
+              cp bin/*.bin /root/keepkey-firmware/bin-btc/ && \
+              cp bin/*.elf /root/keepkey-firmware/bin-btc/ && \
+              chmod -R a+rw /root/keepkey-firmware/bin-btc"
+
+      - name: Rename firmware artifacts
+        run: |
+          cd bin-btc
+          for f in *.bin; do
+            [ -f "$f" ] || continue
+            mv "$f" "firmware.keepkey.btc-only.v${{ steps.version.outputs.fw_version }}-${{ steps.version.outputs.git_short }}-${f}"
+          done
+          for f in *.elf; do
+            [ -f "$f" ] || continue
+            mv "$f" "firmware.keepkey.btc-only.v${{ steps.version.outputs.fw_version }}-${{ steps.version.outputs.git_short }}-${f}"
+          done
+          ls -lh
+          echo "::notice::BTC-only firmware v${{ steps.version.outputs.fw_version }} built successfully"
+
+      - name: Upload BTC-only firmware artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: firmware-btc-only-v${{ steps.version.outputs.fw_version }}-${{ steps.version.outputs.git_short }}
+          path: |
+            bin-btc/*.bin
+            bin-btc/*.elf
+          retention-days: 90
+
   # ═══════════════════════════════════════════════════════════
   # STAGE 3: TEST — run only after builds succeed
   # ═══════════════════════════════════════════════════════════
@@ -385,7 +470,7 @@ jobs:
   python-integration-tests:
     needs: [check-submodules, secret-scan]
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -431,7 +516,8 @@ jobs:
         with:
           name: oled-screenshots
           path: test-reports/screenshots/
-          retention-days: 30
+          retention-days: 90
+          if-no-files-found: warn
 
       - name: Tear down
         if: always()
@@ -439,11 +525,11 @@ jobs:
         run: docker compose down -v || true
 
   # ═══════════════════════════════════════════════════════════
-  # STAGE 3b: REPORT — generate test-report.pdf from results
+  # STAGE 3b: TEST REPORT — generate PDF from test artifacts
   # ═══════════════════════════════════════════════════════════
 
   generate-test-report:
-    needs: [python-integration-tests]
+    needs: [unit-tests, python-integration-tests]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -452,38 +538,45 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          submodules: false
 
-      - name: Init python-keepkey submodule
-        run: git submodule update --init --recursive deps/python-keepkey
-
-      - name: Download Python test results
+      - name: Download unit test results
         uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: unit-test-results
+          path: test-reports/firmware-unit/
+
+      - name: Download python test results
+        uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           name: python-test-results
           path: test-reports/python-keepkey/
-        continue-on-error: true
 
       - name: Download OLED screenshots
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           name: oled-screenshots
           path: test-reports/screenshots/
-        continue-on-error: true
 
       - name: Extract firmware version
         id: version
         run: |
-          FW_VERSION=$(sed -n '/^project/,/)/p' CMakeLists.txt | grep -oP '\d+\.\d+\.\d+')
+          FW_VERSION=$(sed -n '/^project/,/)/p' CMakeLists.txt | grep -oP '\d+\.\d+\.\d+' || echo "unknown")
           echo "fw_version=${FW_VERSION}" >> "$GITHUB_OUTPUT"
 
-      - name: Generate test-report.pdf
-        run: |
-          python3 scripts/generate-test-report.py \
-            --fw-version=${{ steps.version.outputs.fw_version }} \
-            --junit=test-reports/python-keepkey/junit.xml \
-            --screenshots=test-reports/screenshots \
-            --output=test-report.pdf
+      - name: Install dependencies
+        run: pip install fpdf2
+
+      - name: Generate test report PDF
+        env:
+          BRANCH: ${{ github.head_ref || github.ref_name }}
+          COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          FW_VERSION: ${{ steps.version.outputs.fw_version }}
+          TEST_REPORTS_DIR: test-reports
+          OUTPUT_PDF: test-report.pdf
+        run: python3 scripts/generate-test-report.py
 
       - name: Upload test report
         uses: actions/upload-artifact@v4
@@ -498,7 +591,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════
 
   publish-emulator:
-    needs: [unit-tests, python-integration-tests, build-arm-firmware]
+    needs: [unit-tests, python-integration-tests, build-arm-firmware, build-arm-firmware-btc-only]
     if: >-
       github.event_name == 'workflow_dispatch' &&
       github.event.inputs.publish_emulator == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,6 +425,14 @@ jobs:
           path: test-reports/python-keepkey/
           retention-days: 30
 
+      - name: Upload OLED screenshots
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: oled-screenshots
+          path: test-reports/screenshots/
+          retention-days: 30
+
       - name: Tear down
         if: always()
         working-directory: scripts/emulator
@@ -456,6 +464,13 @@ jobs:
           path: test-reports/python-keepkey/
         continue-on-error: true
 
+      - name: Download OLED screenshots
+        uses: actions/download-artifact@v4
+        with:
+          name: oled-screenshots
+          path: test-reports/screenshots/
+        continue-on-error: true
+
       - name: Extract firmware version
         id: version
         run: |
@@ -467,6 +482,7 @@ jobs:
           python3 scripts/generate-test-report.py \
             --fw-version=${{ steps.version.outputs.fw_version }} \
             --junit=test-reports/python-keepkey/junit.xml \
+            --screenshots=test-reports/screenshots \
             --output=test-report.pdf
 
       - name: Upload test report

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,7 +13,7 @@ path = code-signing-keys
 url = https://github.com/keepkey/code-signing-keys.git
 [submodule "deps/python-keepkey"]
 path = deps/python-keepkey
-url = https://github.com/keepkey/python-keepkey.git
+	url = https://github.com/BitHighlander/python-keepkey.git
 branch = master
 [submodule "deps/qrenc/QR-Code-generator"]
 path = deps/qrenc/QR-Code-generator

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.7.2)
 
 project(
   KeepKeyFirmware
-  VERSION 7.10.0
+  VERSION 7.14.0
   LANGUAGES C CXX ASM)
 
 set(BOOTLOADER_MAJOR_VERSION 2)

--- a/scripts/emulator/bridge.py
+++ b/scripts/emulator/bridge.py
@@ -38,5 +38,9 @@ def exchange(kind):
 
     return Response('{}', status=404, mimetype='application/json')
 
+@app.route('/health')
+def health():
+    return Response('{"status":"ok"}', status=200, mimetype='application/json')
+
 if __name__ == '__main__':
     app.run(debug=True, host='0.0.0.0')

--- a/scripts/emulator/docker-compose.yml
+++ b/scripts/emulator/docker-compose.yml
@@ -11,6 +11,12 @@ services:
       - "127.0.0.1:11044:11044/udp"
       - "127.0.0.1:11045:11045/udp"
       - "127.0.0.1:5000:5000"
+    healthcheck:
+      test: ["CMD-SHELL", "python3 -c \"import urllib.request; urllib.request.urlopen('http://localhost:5000/health')\" || exit 1"]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+      start_period: 10s
   python-keepkey:
     build:
       context: '../../'
@@ -20,7 +26,8 @@ services:
     networks:
       - local-net
     depends_on:
-      - kkemu
+      kkemu:
+        condition: service_healthy
   firmware-unit:
     build:
       context: '../../'
@@ -31,7 +38,8 @@ services:
     networks:
       - local-net
     depends_on:
-      - kkemu
+      kkemu:
+        condition: service_healthy
 networks:
   local-net:
     external: false

--- a/scripts/emulator/python-keepkey-tests.sh
+++ b/scripts/emulator/python-keepkey-tests.sh
@@ -2,20 +2,67 @@
 
 mkdir -p /kkemu/test-reports/python-keepkey
 mkdir -p /kkemu/test-reports/screenshots
+LOGFILE=/kkemu/test-reports/python-keepkey/screenshot-debug.log
+
+# --- Wait for emulator to be ready on UDP ---
+echo "=== Waiting for emulator (kkemu:11044) ==="
+python3 -c "
+import socket, time, sys
+for i in range(30):
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.settimeout(3)
+        # Send Initialize message (msg_type=0, length=0)
+        s.sendto(b'##\x00\x00\x00\x00\x00\x00', ('kkemu', 11044))
+        data, _ = s.recvfrom(64)
+        s.close()
+        print('Emulator ready after %d attempts' % (i+1))
+        sys.exit(0)
+    except Exception as e:
+        print('  attempt %d/30: %s' % (i+1, e))
+        try: s.close()
+        except: pass
+        time.sleep(2)
+print('FATAL: emulator not ready after 60s')
+sys.exit(1)
+"
+EMU_READY=$?
+if [ "$EMU_READY" != "0" ]; then
+    echo "ERROR: Emulator never became ready" | tee "$LOGFILE"
+    echo "1" > /kkemu/test-reports/python-keepkey/status
+    exit 1
+fi
+
+# Debug link (port 11045) is tested implicitly by Phase 1 tests via DebugLink transport.
+# No explicit probe — python-keepkey's UDPTransport handles connection on demand.
+
 cd deps/python-keepkey/tests
 
-# Phase 1: screenshot capture (display tests only, broad filter, tests self-skip via requires_message)
-KEEPKEY_SCREENSHOT=1 \
-SCREENSHOT_DIR=/kkemu/test-reports/screenshots \
-KK_TRANSPORT_MAIN=kkemu:11044 \
-KK_TRANSPORT_DEBUG=kkemu:11045 \
-pytest -v -k "test_show or test_show_address or test_wipe_device or test_bip85 or test_apply_settings or test_ping" \
+# Phase 1: Targeted screenshot capture (fast — key address display tests only)
+echo "=== Screenshot capture (targeted tests) ==="
+export KEEPKEY_SCREENSHOT=1
+export SCREENSHOT_DIR=/kkemu/test-reports/screenshots
+export KK_TRANSPORT_MAIN=kkemu:11044
+export KK_TRANSPORT_DEBUG=kkemu:11045
+pytest -v -k "test_getaddress or test_get_address or test_wipedevice or test_bip85 or test_solana_get or test_tron_get or test_ton_get" \
   --junitxml=/kkemu/test-reports/python-keepkey/junit-screenshots.xml \
-  2>&1 || true
+  2>&1 | tee "$LOGFILE" || true
+echo "Phase 1 done"
 
-echo "Screenshot PNGs: $(find /kkemu/test-reports/screenshots -type f -name '*.png' 2>/dev/null | wc -l)"
+# Count screenshots
+SCREENSHOT_COUNT=$(find /kkemu/test-reports/screenshots -name '*.png' 2>/dev/null | wc -l)
+echo "=== Screenshots captured: $SCREENSHOT_COUNT ==="
+if [ "$SCREENSHOT_COUNT" -eq 0 ]; then
+    echo "WARNING: Zero screenshots captured!" | tee -a "$LOGFILE"
+    echo "Checking SCREENSHOT env and debug state..." | tee -a "$LOGFILE"
+    grep -i "screenshot" "$LOGFILE" || echo "  (no screenshot-related output found)" | tee -a "$LOGFILE"
+else
+    echo "Screenshot files:" | tee -a "$LOGFILE"
+    find /kkemu/test-reports/screenshots -name '*.png' -ls | tee -a "$LOGFILE"
+fi
 
-# Phase 2: full test suite (no screenshots, normal speed)
+# Phase 2: Full test suite (no screenshots — normal speed)
+echo "=== Full test suite ==="
 KK_TRANSPORT_MAIN=kkemu:11044 \
 KK_TRANSPORT_DEBUG=kkemu:11045 \
 pytest -v --junitxml=/kkemu/test-reports/python-keepkey/junit.xml

--- a/scripts/emulator/python-keepkey-tests.sh
+++ b/scripts/emulator/python-keepkey-tests.sh
@@ -1,6 +1,22 @@
 #!/bin/sh
 
 mkdir -p /kkemu/test-reports/python-keepkey
+mkdir -p /kkemu/test-reports/screenshots
 cd deps/python-keepkey/tests
-KK_TRANSPORT_MAIN=kkemu:11044 KK_TRANSPORT_DEBUG=kkemu:11045 pytest -v --junitxml=/kkemu/test-reports/python-keepkey/junit.xml
+
+# Phase 1: screenshot capture (display tests only, broad filter, tests self-skip via requires_message)
+KEEPKEY_SCREENSHOT=1 \
+SCREENSHOT_DIR=/kkemu/test-reports/screenshots \
+KK_TRANSPORT_MAIN=kkemu:11044 \
+KK_TRANSPORT_DEBUG=kkemu:11045 \
+pytest -v -k "test_show or test_show_address or test_wipe_device or test_bip85 or test_apply_settings or test_ping" \
+  --junitxml=/kkemu/test-reports/python-keepkey/junit-screenshots.xml \
+  --timeout=120 2>&1 || true
+
+echo "Screenshot PNGs: $(find /kkemu/test-reports/screenshots -type f -name '*.png' 2>/dev/null | wc -l)"
+
+# Phase 2: full test suite (no screenshots, normal speed)
+KK_TRANSPORT_MAIN=kkemu:11044 \
+KK_TRANSPORT_DEBUG=kkemu:11045 \
+pytest -v --junitxml=/kkemu/test-reports/python-keepkey/junit.xml
 echo "$?" > /kkemu/test-reports/python-keepkey/status

--- a/scripts/emulator/python-keepkey-tests.sh
+++ b/scripts/emulator/python-keepkey-tests.sh
@@ -11,7 +11,7 @@ KK_TRANSPORT_MAIN=kkemu:11044 \
 KK_TRANSPORT_DEBUG=kkemu:11045 \
 pytest -v -k "test_show or test_show_address or test_wipe_device or test_bip85 or test_apply_settings or test_ping" \
   --junitxml=/kkemu/test-reports/python-keepkey/junit-screenshots.xml \
-  --timeout=120 2>&1 || true
+  2>&1 || true
 
 echo "Screenshot PNGs: $(find /kkemu/test-reports/screenshots -type f -name '*.png' 2>/dev/null | wc -l)"
 

--- a/scripts/generate-test-report.py
+++ b/scripts/generate-test-report.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+"""Thin wrapper — delegates to python-keepkey's version-aware report generator."""
+import subprocess, sys, os
+
+script = os.path.join(
+    os.path.dirname(__file__), '..', 'deps', 'python-keepkey',
+    'scripts', 'generate-test-report.py'
+)
+
+if not os.path.exists(script):
+    print(f"ERROR: {script} not found. Is deps/python-keepkey checked out?", file=sys.stderr)
+    sys.exit(1)
+
+sys.exit(subprocess.call([sys.executable, script] + sys.argv[1:]))

--- a/scripts/generate-test-report.py
+++ b/scripts/generate-test-report.py
@@ -1,14 +1,314 @@
 #!/usr/bin/env python3
-"""Thin wrapper — delegates to python-keepkey's version-aware report generator."""
-import subprocess, sys, os
+"""
+Generate a test-report.pdf from CI artifacts.
 
-script = os.path.join(
-    os.path.dirname(__file__), '..', 'deps', 'python-keepkey',
-    'scripts', 'generate-test-report.py'
-)
+Reads:
+  - test-reports/firmware-unit/*.xml   (JUnit XML from GoogleTest)
+  - test-reports/python-keepkey/*.xml  (JUnit XML from python-keepkey)
+  - test-reports/screenshots/*.png     (OLED captures)
 
-if not os.path.exists(script):
-    print(f"ERROR: {script} not found. Is deps/python-keepkey checked out?", file=sys.stderr)
+Produces:
+  - test-report.pdf
+"""
+
+import glob
+import os
+import sys
+import xml.etree.ElementTree as ET
+from datetime import datetime, timezone
+
+# fpdf2 is installed in CI via pip
+try:
+    from fpdf import FPDF
+except ImportError:
+    print("ERROR: fpdf2 not installed. Run: pip install fpdf2", file=sys.stderr)
     sys.exit(1)
 
-sys.exit(subprocess.call([sys.executable, script] + sys.argv[1:]))
+
+def parse_junit_xml(xml_path):
+    """Parse a JUnit XML file and return test results."""
+    results = []
+    try:
+        tree = ET.parse(xml_path)
+        root = tree.getroot()
+
+        # Handle both <testsuites> and <testsuite> root elements
+        suites = root.findall(".//testsuite")
+        if not suites and root.tag == "testsuite":
+            suites = [root]
+
+        for suite in suites:
+            suite_name = suite.get("name", "unknown")
+            for tc in suite.findall("testcase"):
+                name = tc.get("name", "unknown")
+                classname = tc.get("classname", suite_name)
+                time_s = float(tc.get("time", "0"))
+
+                failure = tc.find("failure")
+                error = tc.find("error")
+                skipped = tc.find("skipped")
+
+                if failure is not None:
+                    status = "FAIL"
+                    message = failure.get("message", "")
+                elif error is not None:
+                    status = "ERROR"
+                    message = error.get("message", "")
+                elif skipped is not None:
+                    status = "SKIP"
+                    message = skipped.get("message", "")
+                else:
+                    status = "PASS"
+                    message = ""
+
+                results.append({
+                    "suite": classname,
+                    "name": name,
+                    "status": status,
+                    "time": time_s,
+                    "message": message[:120],  # truncate long messages
+                })
+    except ET.ParseError as e:
+        results.append({
+            "suite": os.path.basename(xml_path),
+            "name": "XML_PARSE_ERROR",
+            "status": "ERROR",
+            "time": 0,
+            "message": str(e)[:120],
+        })
+    return results
+
+
+def collect_results(base_dir):
+    """Collect all JUnit XML results from test-reports/."""
+    unit_results = []
+    python_results = []
+
+    for xml_file in sorted(glob.glob(os.path.join(base_dir, "firmware-unit", "*.xml"))):
+        unit_results.extend(parse_junit_xml(xml_file))
+
+    for xml_file in sorted(glob.glob(os.path.join(base_dir, "python-keepkey", "*.xml"))):
+        python_results.extend(parse_junit_xml(xml_file))
+
+    return unit_results, python_results
+
+
+def collect_screenshots(base_dir):
+    """Collect OLED screenshot paths."""
+    patterns = [
+        os.path.join(base_dir, "screenshots", "*.png"),
+        os.path.join(base_dir, "screenshots", "**", "*.png"),
+    ]
+    shots = []
+    for pat in patterns:
+        shots.extend(sorted(glob.glob(pat, recursive=True)))
+    return shots
+
+
+def count_status(results):
+    """Count pass/fail/skip/error."""
+    counts = {"PASS": 0, "FAIL": 0, "SKIP": 0, "ERROR": 0}
+    for r in results:
+        counts[r["status"]] = counts.get(r["status"], 0) + 1
+    return counts
+
+
+class TestReportPDF(FPDF):
+    def __init__(self, branch, commit, fw_version):
+        super().__init__()
+        self.branch = branch
+        self.commit = commit
+        self.fw_version = fw_version
+        self.timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+    def header(self):
+        self.set_font("Helvetica", "B", 14)
+        self.cell(0, 8, "KeepKey Firmware Test Report", new_x="LMARGIN", new_y="NEXT", align="C")
+        self.set_font("Helvetica", "", 8)
+        self.cell(0, 5,
+                  f"Branch: {self.branch}  |  Commit: {self.commit}  |  "
+                  f"Version: {self.fw_version}  |  {self.timestamp}",
+                  new_x="LMARGIN", new_y="NEXT", align="C")
+        self.ln(3)
+
+    def footer(self):
+        self.set_y(-15)
+        self.set_font("Helvetica", "I", 8)
+        self.cell(0, 10, f"Page {self.page_no()}/{{nb}}", align="C")
+
+    def add_summary(self, unit_counts, python_counts):
+        self.set_font("Helvetica", "B", 12)
+        self.cell(0, 8, "Summary", new_x="LMARGIN", new_y="NEXT")
+
+        total_pass = unit_counts["PASS"] + python_counts["PASS"]
+        total_fail = unit_counts["FAIL"] + python_counts["FAIL"]
+        total_error = unit_counts["ERROR"] + python_counts["ERROR"]
+        total_skip = unit_counts["SKIP"] + python_counts["SKIP"]
+        total = total_pass + total_fail + total_error + total_skip
+
+        # Overall verdict
+        if total_fail > 0 or total_error > 0:
+            verdict = "FAIL"
+            color = (220, 50, 50)
+        elif total == 0:
+            verdict = "NO TESTS"
+            color = (200, 150, 0)
+        else:
+            verdict = "PASS"
+            color = (50, 150, 50)
+
+        self.set_font("Helvetica", "B", 16)
+        self.set_text_color(*color)
+        self.cell(0, 10, f"Overall: {verdict}", new_x="LMARGIN", new_y="NEXT", align="C")
+        self.set_text_color(0, 0, 0)
+
+        # Counts table
+        self.set_font("Helvetica", "", 10)
+        self.ln(3)
+
+        col_w = [60, 30, 30, 30, 30]
+        headers = ["Category", "Pass", "Fail", "Error", "Skip"]
+        for i, h in enumerate(headers):
+            self.set_font("Helvetica", "B", 9)
+            self.cell(col_w[i], 7, h, border=1)
+        self.ln()
+
+        self.set_font("Helvetica", "", 9)
+        for label, counts in [("Unit Tests", unit_counts), ("Python Integration", python_counts)]:
+            self.cell(col_w[0], 7, label, border=1)
+            self.cell(col_w[1], 7, str(counts["PASS"]), border=1, align="C")
+
+            self.set_text_color(220, 50, 50) if counts["FAIL"] > 0 else self.set_text_color(0, 0, 0)
+            self.cell(col_w[2], 7, str(counts["FAIL"]), border=1, align="C")
+            self.set_text_color(0, 0, 0)
+
+            self.set_text_color(220, 50, 50) if counts["ERROR"] > 0 else self.set_text_color(0, 0, 0)
+            self.cell(col_w[3], 7, str(counts["ERROR"]), border=1, align="C")
+            self.set_text_color(0, 0, 0)
+
+            self.cell(col_w[4], 7, str(counts["SKIP"]), border=1, align="C")
+            self.ln()
+
+        # Totals
+        self.set_font("Helvetica", "B", 9)
+        self.cell(col_w[0], 7, "TOTAL", border=1)
+        self.cell(col_w[1], 7, str(total_pass), border=1, align="C")
+        self.set_text_color(220, 50, 50) if total_fail > 0 else self.set_text_color(0, 0, 0)
+        self.cell(col_w[2], 7, str(total_fail), border=1, align="C")
+        self.set_text_color(0, 0, 0)
+        self.set_text_color(220, 50, 50) if total_error > 0 else self.set_text_color(0, 0, 0)
+        self.cell(col_w[3], 7, str(total_error), border=1, align="C")
+        self.set_text_color(0, 0, 0)
+        self.cell(col_w[4], 7, str(total_skip), border=1, align="C")
+        self.ln(10)
+
+    def add_test_section(self, title, results):
+        self.set_font("Helvetica", "B", 11)
+        self.cell(0, 8, title, new_x="LMARGIN", new_y="NEXT")
+
+        if not results:
+            self.set_font("Helvetica", "I", 9)
+            self.cell(0, 6, "No test results found.", new_x="LMARGIN", new_y="NEXT")
+            self.ln(3)
+            return
+
+        col_w = [75, 15, 15, 85]
+        self.set_font("Helvetica", "B", 8)
+        for i, h in enumerate(["Test Name", "Status", "Time", "Details"]):
+            self.cell(col_w[i], 6, h, border=1)
+        self.ln()
+
+        self.set_font("Helvetica", "", 7)
+        for r in results:
+            # Truncate test name to fit
+            name = r["name"][:45]
+
+            # Status color
+            if r["status"] == "PASS":
+                self.set_text_color(0, 100, 0)
+            elif r["status"] in ("FAIL", "ERROR"):
+                self.set_text_color(220, 50, 50)
+            else:
+                self.set_text_color(150, 150, 0)
+
+            self.cell(col_w[0], 5, name, border=1)
+            self.cell(col_w[1], 5, r["status"], border=1, align="C")
+            self.set_text_color(0, 0, 0)
+            self.cell(col_w[2], 5, f"{r['time']:.2f}s", border=1, align="R")
+            self.cell(col_w[3], 5, r["message"][:50], border=1)
+            self.ln()
+
+            # Page break check
+            if self.get_y() > 270:
+                self.add_page()
+
+        self.ln(5)
+
+    def add_screenshots(self, screenshot_paths):
+        if not screenshot_paths:
+            return
+
+        self.add_page()
+        self.set_font("Helvetica", "B", 12)
+        self.cell(0, 8, "OLED Screenshots", new_x="LMARGIN", new_y="NEXT")
+
+        for i, path in enumerate(screenshot_paths):
+            if self.get_y() > 230:
+                self.add_page()
+
+            label = os.path.basename(path).replace(".png", "").replace("_", " ")
+            self.set_font("Helvetica", "", 8)
+            self.cell(0, 5, label, new_x="LMARGIN", new_y="NEXT")
+
+            try:
+                # OLED screenshots are typically 128x64, scale up 2x
+                self.image(path, w=60, h=30)
+            except Exception as e:
+                self.cell(0, 5, f"[Could not load: {e}]", new_x="LMARGIN", new_y="NEXT")
+
+            self.ln(3)
+
+
+def main():
+    # Read environment or args
+    branch = os.environ.get("BRANCH", os.popen("git rev-parse --abbrev-ref HEAD").read().strip())
+    commit = os.environ.get("COMMIT_SHA", os.popen("git rev-parse --short HEAD").read().strip())
+    fw_version = os.environ.get("FW_VERSION", "unknown")
+    base_dir = os.environ.get("TEST_REPORTS_DIR", "test-reports")
+    output = os.environ.get("OUTPUT_PDF", "test-report.pdf")
+
+    print(f"Generating test report for {branch} ({commit}), firmware {fw_version}")
+    print(f"Reading from: {base_dir}")
+
+    unit_results, python_results = collect_results(base_dir)
+    screenshots = collect_screenshots(base_dir)
+
+    print(f"  Unit tests: {len(unit_results)}")
+    print(f"  Python tests: {len(python_results)}")
+    print(f"  Screenshots: {len(screenshots)}")
+
+    unit_counts = count_status(unit_results)
+    python_counts = count_status(python_results)
+
+    pdf = TestReportPDF(branch, commit, fw_version)
+    pdf.alias_nb_pages()
+    pdf.add_page()
+    pdf.add_summary(unit_counts, python_counts)
+    pdf.add_test_section("Unit Tests (GoogleTest)", unit_results)
+    pdf.add_test_section("Python Integration Tests", python_results)
+    pdf.add_screenshots(screenshots)
+    pdf.output(output)
+
+    print(f"Report written to: {output}")
+
+    # Exit non-zero if any failures
+    total_fail = unit_counts["FAIL"] + python_counts["FAIL"]
+    total_error = unit_counts["ERROR"] + python_counts["ERROR"]
+    if total_fail > 0 or total_error > 0:
+        print(f"WARNING: {total_fail} failures, {total_error} errors")
+        # Don't exit non-zero — let the report be uploaded even with failures
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Docker healthcheck for emulator readiness (python3 urllib, not curl)
- `depends_on: service_healthy` so tests never start before emulator
- Pin python-keepkey to fork `fix/screenshot-debug` for `[SCREENSHOT]` stderr logging
- Zero upstream changes — only fork pinning

## What this proves
When CI runs, `screenshot-debug.log` artifact will show exactly why screenshots succeed or fail:
- `[SCREENSHOT] OK: path (N bytes layout)` — working
- `[SCREENSHOT] SKIP: no debug link` — DebugLink not attached
- `[SCREENSHOT] SKIP: layout too small` — proto/emulator issue
- `[SCREENSHOT] ERROR: exception` — with full traceback

## Test plan
- [ ] CI triggers on push to feat/** branch
- [ ] Emulator healthcheck passes (python3 urllib)
- [ ] python-keepkey-tests.sh logs emulator readiness
- [ ] Phase 1 screenshot tests run with KEEPKEY_SCREENSHOT=1
- [ ] screenshot-debug.log appears in python-test-results artifact
- [ ] oled-screenshots artifact contains PNGs (or warn if empty)