### PR TITLE
CI OLED screenshot pipeline + docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ name: CI
 
 on:
   push:
-    branches: [master, develop, 'feature/**', 'fix/**', 'release/**', 'hotfix/**']
+    branches: [master, develop, alpha, p0, 'feat/**', 'feature/**', 'fix/**', 'release/**', 'hotfix/**']
   pull_request:
     branches: [master, develop]
   workflow_dispatch:
@@ -384,8 +384,9 @@ jobs:
 
   python-integration-tests:
     needs: [check-submodules, secret-scan]
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -409,8 +410,22 @@ jobs:
           docker compose up --build python-keepkey
           set -e
           mkdir -p ${{ github.workspace }}/test-reports
-          docker cp "$(docker compose ps -a -q firmware-unit)":/kkemu/test-reports/. ${{ github.workspace }}/test-reports/ 2>/dev/null || true
-          docker cp "$(docker compose ps -a -q python-keepkey)":/kkemu/test-reports/. ${{ github.workspace }}/test-reports/ 2>/dev/null || true
+
+          echo "=== Extracting test reports from Docker ==="
+          PY_CONTAINER=$(docker compose ps -a -q python-keepkey)
+          FW_CONTAINER=$(docker compose ps -a -q firmware-unit)
+          echo "python-keepkey container: $PY_CONTAINER"
+          echo "firmware-unit container: $FW_CONTAINER"
+
+          docker cp "$FW_CONTAINER":/kkemu/test-reports/. ${{ github.workspace }}/test-reports/ || echo "WARN: firmware-unit docker cp failed"
+          docker cp "$PY_CONTAINER":/kkemu/test-reports/. ${{ github.workspace }}/test-reports/ || echo "WARN: python-keepkey docker cp failed"
+
+          echo "=== Extracted files ==="
+          find ${{ github.workspace }}/test-reports -type f | head -30
+          echo "=== Screenshot PNGs ==="
+          find ${{ github.workspace }}/test-reports/screenshots -name '*.png' 2>/dev/null | wc -l
+          echo "PNGs on host"
+
           UNIT_STATUS=$(cat ${{ github.workspace }}/test-reports/firmware-unit/status 2>/dev/null || echo "1")
           PY_STATUS=$(cat ${{ github.workspace }}/test-reports/python-keepkey/status 2>/dev/null || echo "1")
           echo "Unit tests exit status: $UNIT_STATUS"
@@ -424,6 +439,15 @@ jobs:
           name: python-test-results
           path: test-reports/python-keepkey/
           retention-days: 30
+
+      - name: Upload OLED screenshots
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: oled-screenshots
+          path: test-reports/screenshots/
+          retention-days: 90
+          if-no-files-found: warn
 
       - name: Tear down
         if: always()

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,7 +13,7 @@ path = code-signing-keys
 url = https://github.com/keepkey/code-signing-keys.git
 [submodule "deps/python-keepkey"]
 path = deps/python-keepkey
-url = https://github.com/keepkey/python-keepkey.git
+	url = https://github.com/BitHighlander/python-keepkey.git
 branch = master
 [submodule "deps/qrenc/QR-Code-generator"]
 path = deps/qrenc/QR-Code-generator

--- a/docs/CI-SCREENSHOT-HANDOFF.md
+++ b/docs/CI-SCREENSHOT-HANDOFF.md
@@ -1,0 +1,199 @@
+# CI Screenshot Pipeline — Agent Handoff Guide
+
+Status: WORKING on alpha (run 23673308446 produced 4 PNGs). Needs to be landed on p0/develop.
+
+## What Works (Proven)
+
+The complete pipeline runs end-to-end when these conditions are met:
+
+1. **Emulator builds with DEBUG_LINK=ON** (`cmake/caches/emulator.cmake` line 2)
+2. **python-keepkey has `_capture_oled()` with the PNG writer** (any version ≥ `4ed90c7`)
+3. **Test script sets `KEEPKEY_SCREENSHOT=1`** and `SCREENSHOT_DIR=...`
+4. **Tests trigger `callback_ButtonRequest`** which calls `_capture_oled()`
+5. **`test_wipe_device` is the proven smoke test** — always triggers 2 ButtonRequests
+
+## The 3 Things That Must Be True for Screenshots
+
+```
+1. python-integration-tests job must RUN    → if: ${{ !cancelled() }}
+2. Emulator must be READY before tests      → healthcheck or wait loop
+3. Test must trigger ButtonRequest          → -k "test_wipe_device"
+```
+
+If any of these fail, you get 0 PNGs with no error.
+
+## Current Branch State
+
+| Branch | .gitmodules python-keepkey URL | Pin | Has CI fixes | Screenshots work? |
+|--------|-------------------------------|-----|-------------|-------------------|
+| `alpha` | BitHighlander/python-keepkey | `4f34e35` (debug logging) | YES (all fixes) | YES (proven) |
+| `feat/ci-screenshot-docs` | BitHighlander/python-keepkey | `4f34e35` | YES (all fixes) | Should work (not tested) |
+| `p0` | keepkey/python-keepkey | `4ed90c7` (upstream) | NO | NO (missing CI fixes) |
+| `develop` | keepkey/python-keepkey | varies | NO | NO (missing CI fixes) |
+| `upstream/master` | keepkey/python-keepkey | `f1dd2b6` | NO | NO |
+
+## What p0 Needs (Minimum Viable)
+
+Apply these changes to p0 (PR #180 `feat/ci-screenshot-docs → p0` already has them):
+
+### 1. ci.yml — 3 changes
+
+```yaml
+# A. Add !cancelled() guard (line ~386)
+python-integration-tests:
+  needs: [check-submodules, secret-scan]
+  if: ${{ !cancelled() }}  # <-- ADD THIS
+
+# B. Add screenshot upload step (after "Upload Python test results")
+- name: Upload OLED screenshots
+  uses: actions/upload-artifact@v4
+  if: always()
+  with:
+    name: oled-screenshots
+    path: test-reports/screenshots/
+    retention-days: 90
+    if-no-files-found: warn
+
+# C. Replace silent docker cp with visible extraction
+# REMOVE:  docker cp "$(docker compose ps -a -q python-keepkey)":/kkemu/test-reports/. ... 2>/dev/null || true
+# ADD:
+PY_CONTAINER=$(docker compose ps -a -q python-keepkey)
+echo "python-keepkey container: $PY_CONTAINER"
+docker cp "$PY_CONTAINER":/kkemu/test-reports/. ${{ github.workspace }}/test-reports/ || echo "WARN: docker cp failed"
+find ${{ github.workspace }}/test-reports/screenshots -name '*.png' 2>/dev/null | wc -l
+```
+
+### 2. python-keepkey-tests.sh — Replace entire file
+
+The working version uses:
+- Emulator wait loop (nc UDP probe OR python3 socket probe)
+- Phase 1: `KEEPKEY_SCREENSHOT=1 pytest -v -x -k "test_wipe_device"`
+- Screenshot count reporting
+- Phase 2: full suite without screenshots
+
+**Critical**: Must be `/bin/sh` compatible. NO bash-isms:
+- NO `${PIPESTATUS[0]}`
+- NO `{ cmd; } | tee`
+- NO `#!/bin/bash`
+
+### 3. docker-compose.yml — Add healthcheck (OPTIONAL but recommended)
+
+```yaml
+kkemu:
+  healthcheck:
+    test: ["CMD-SHELL", "python3 -c \"import urllib.request; urllib.request.urlopen('http://localhost:5000/health')\" || exit 1"]
+    interval: 3s
+    timeout: 3s
+    retries: 20
+    start_period: 10s
+python-keepkey:
+  depends_on:
+    kkemu:
+      condition: service_healthy
+```
+
+Requires `/health` endpoint in `bridge.py`:
+```python
+@app.route('/health')
+def health():
+    return Response('{"status":"ok"}', status=200, mimetype='application/json')
+```
+
+**TRAP**: `curl` is NOT in `kktech/firmware:v15`. Must use `python3 urllib`.
+
+### 4. python-keepkey fork pin (OPTIONAL but recommended for debugging)
+
+To get `[SCREENSHOT] OK/SKIP/ERROR` diagnostic output:
+```
+.gitmodules: url = https://github.com/BitHighlander/python-keepkey.git
+submodule pin: 4f34e35 (fix/screenshot-debug branch)
+```
+
+The upstream code at `4ed90c7` ALSO works for screenshots — it just has `except Exception: pass` so failures are silent.
+
+## The 10 Traps (Ordered by Pain Caused)
+
+### 1. `if: ${{ !cancelled() }}` missing → job cancelled by ARM failures
+ARM builds fail on alpha (Zcash protos, const qualifiers). Without `!cancelled()`, python tests get cancelled. You see "cancelled" status with zero artifacts. **Fix: always add the guard.**
+
+### 2. `-k` filter selects tests that SKIP on BTC-only emulator → 0 ButtonRequests
+BIP85, Solana, Tron, TON tests all SKIP because the emulator is BTC-only. Only `test_wipe_device` and basic BTC tests run. If your `-k` filter only matches multi-chain tests, you get 0 screenshots. **Fix: always include `test_wipe_device`.**
+
+### 3. `except Exception: pass` in `_capture_oled()` → silent failure
+If `debug.read_layout()` returns empty bytes, or PNG write fails, or any exception — swallowed. Zero output. Tests still pass. **Fix: use fork pin for debug logging, or accept upstream and rely on screenshot count check.**
+
+### 4. `curl` not in Docker image → healthcheck fails → "unhealthy" → tests never start
+`kktech/firmware:v15` has Python but NOT curl. **Fix: `python3 -c "import urllib.request; urllib.request.urlopen(...)"`**
+
+### 5. `/bin/sh` not bash → script syntax errors
+`python-keepkey.Dockerfile` uses `/bin/sh`. `PIPESTATUS`, brace groups, bashisms all fail. **Fix: test your script with `dash` or `busybox sh`.**
+
+### 6. `--timeout=120` → pytest-timeout not installed
+**Fix: don't use it. CI job timeout (30 min) is the safety net.**
+
+### 7. `docker cp ... 2>/dev/null || true` → extraction failures invisible
+**Fix: log container ID, remove stderr suppression, count files after.**
+
+### 8. Debug link UDP port (11045) doesn't respond to raw probes
+Sending raw `DebugLinkGetState` bytes to UDP 11045 times out. The emulator expects proper protobuf framing through the transport layer. **Fix: don't probe port 11045 directly. Test it implicitly via pytest.**
+
+### 9. `layout too small (0 bytes)` → emulator display not initialized
+If the test runs before any screen is rendered (before `layoutHome()`), the canvas is empty. The wipe test avoids this because `setUp()` calls `wipe_device()` which renders a confirmation screen.
+
+### 10. Branch triggers missing → CI doesn't run on push
+Develop's `ci.yml` didn't have `alpha`, `p0`, or `feat/**` in the branch list. **Fix: add them.**
+
+## Debugging When Screenshots Are 0
+
+```
+Step 1: Was python-integration-tests cancelled?
+  → Check job status. If cancelled, add if: !cancelled()
+
+Step 2: Did the emulator Docker image build?
+  → Look for "make -j" success or "ERROR" in build logs
+
+Step 3: Did tests actually run?
+  → Look for "PASSED" or "FAILED" in Phase 1 output
+  → If all SKIPPED, fix the -k filter
+
+Step 4: Did _capture_oled() run?
+  → If using fork pin: look for [SCREENSHOT] lines in stderr
+  → If using upstream: no way to tell (silent pass)
+
+Step 5: Were files extracted from Docker?
+  → Look for container ID logging and file count
+  → "Screenshot PNGs: N" should be > 0
+
+Step 6: Was the artifact uploaded?
+  → Look for "Artifact oled-screenshots has been successfully uploaded"
+  → If "Warning: No files were found", the path was empty
+```
+
+## Local Docker Test (Fastest Verification)
+
+```bash
+cd /path/to/keepkey-firmware
+cd scripts/emulator
+docker compose up --build python-keepkey
+# Wait for it to finish, then:
+docker cp "$(docker compose ps -a -q python-keepkey)":/kkemu/test-reports/screenshots/. /tmp/screenshots/
+find /tmp/screenshots -name '*.png' -ls
+```
+
+If this produces PNGs locally but not in CI, the issue is in ci.yml (job cancellation, docker cp, artifact upload).
+
+## File Reference
+
+| File | What to check |
+|------|--------------|
+| `.github/workflows/ci.yml:~386` | `if: !cancelled()` on python-integration-tests |
+| `.github/workflows/ci.yml:~412` | docker cp with logging (no `2>/dev/null || true`) |
+| `.github/workflows/ci.yml:~428` | Upload OLED screenshots step exists |
+| `scripts/emulator/python-keepkey-tests.sh` | `/bin/sh` shebang, `-k "test_wipe_device"`, `KEEPKEY_SCREENSHOT=1` |
+| `scripts/emulator/docker-compose.yml` | healthcheck on kkemu, `service_healthy` condition |
+| `scripts/emulator/bridge.py` | `/health` endpoint exists |
+| `scripts/emulator/python-keepkey.Dockerfile` | `/bin/sh` entrypoint (NOT bash) |
+| `deps/python-keepkey/keepkeylib/client.py:~463` | `_capture_oled()` method |
+| `deps/python-keepkey/tests/conftest.py:~11` | `KEEPKEY_SCREENSHOT` check |
+| `include/keepkey/transport/messages.options:112` | `DebugLinkState.layout max_size:2048` |
+| `cmake/caches/emulator.cmake:2` | `KK_DEBUG_LINK ON` |

--- a/docs/CI-Screenshots.md
+++ b/docs/CI-Screenshots.md
@@ -1,0 +1,275 @@
+# CI OLED Screenshot Pipeline
+
+Captures KeepKey OLED display screenshots from the emulator during CI test runs and uploads them as artifacts.
+
+**Status**: Working as of 2026-03-27 (run 23673308446 on BitHighlander/keepkey-firmware alpha)
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  GitHub Actions Runner (ubuntu-latest)                      │
+│                                                             │
+│  ┌─────────────────────────────────────────────────────┐    │
+│  │  Docker Compose (scripts/emulator/docker-compose.yml)│    │
+│  │                                                     │    │
+│  │  ┌──────────┐  healthcheck   ┌──────────────────┐   │    │
+│  │  │  kkemu   │◄──────────────│  python-keepkey   │   │    │
+│  │  │          │  depends_on:   │                  │   │    │
+│  │  │ emulator │  service_      │ pytest + capture │   │    │
+│  │  │ binary   │  healthy       │                  │   │    │
+│  │  │          │                │ writes PNGs to   │   │    │
+│  │  │ UDP:11044│◄──main────────│ /kkemu/test-     │   │    │
+│  │  │ UDP:11045│◄──debug───────│  reports/         │   │    │
+│  │  │ TCP:5000 │  (DebugLink)  │  screenshots/    │   │    │
+│  │  │ (bridge) │                │                  │   │    │
+│  │  └──────────┘                └──────────────────┘   │    │
+│  │                                    │                │    │
+│  │                              shared volume:         │    │
+│  │                              test-reports           │    │
+│  └─────────────────────────────────────────────────────┘    │
+│           │                                                 │
+│     docker cp                                               │
+│           │                                                 │
+│           ▼                                                 │
+│  test-reports/screenshots/*.png                             │
+│           │                                                 │
+│     upload-artifact@v4                                      │
+│           │                                                 │
+│           ▼                                                 │
+│  Artifact: oled-screenshots (90 day retention)              │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## How Screenshots Are Captured
+
+### Firmware Side (C)
+
+**File**: `lib/firmware/fsm_msg_debug.h`
+
+`fsm_msgDebugLinkGetState()` handles `DebugLinkGetState` messages:
+
+1. Calls `force_animation_start()` + `animate()` + `display_refresh()` to ensure pending animations render
+2. Gets the 256x64 grayscale canvas via `display_canvas()`
+3. Packs it into 1bpp layout (2048 bytes): each byte holds 8 vertical pixels, LSB = top
+4. Sets `resp->layout.size = 2048` and sends `DebugLinkState` response
+
+**Proto constraint**: `messages.options` line 112: `DebugLinkState.layout max_size:2048`
+
+### Python Side (keepkeylib)
+
+**File**: `deps/python-keepkey/keepkeylib/client.py`
+
+`_capture_oled()` is called from `callback_ButtonRequest()` BEFORE pressing the button:
+
+1. Checks `KEEPKEY_SCREENSHOT` env var == `'1'`
+2. Checks `self.debug` link exists
+3. Calls `self.debug.read_layout()` → sends `DebugLinkGetState` over debug transport (UDP:11045)
+4. If layout >= 1024 bytes, converts 1bpp → 8bpp grayscale rows
+5. Writes 256x64 PNG to `screenshot_dir/btn%05d.png`
+
+### Test Framework
+
+**File**: `deps/python-keepkey/tests/conftest.py`
+
+Patches `KeepKeyTest.setUp()` to create per-test screenshot directories:
+```
+screenshots/{module}/{test_name}/btn00000.png
+screenshots/{module}/{test_name}/btn00001.png
+```
+
+## Critical Files
+
+| File | Role |
+|------|------|
+| `.github/workflows/ci.yml` | CI orchestration, docker compose, artifact upload |
+| `scripts/emulator/docker-compose.yml` | Container orchestration with healthcheck |
+| `scripts/emulator/Dockerfile` | Builds emulator binary (cmake + clang) |
+| `scripts/emulator/python-keepkey.Dockerfile` | Test runner container |
+| `scripts/emulator/python-keepkey-tests.sh` | Test execution script (Phase 1 screenshots, Phase 2 full suite) |
+| `scripts/emulator/bridge.py` | Flask HTTP→UDP proxy with `/health` endpoint |
+| `scripts/emulator/run.sh` | Starts bridge.py (background) + emulator binary |
+| `deps/python-keepkey/keepkeylib/client.py` | `_capture_oled()` screenshot capture |
+| `deps/python-keepkey/tests/conftest.py` | Per-test screenshot directory setup |
+| `deps/python-keepkey/tests/config.py` | Transport config (UDP for emulator) |
+| `include/keepkey/transport/messages.options` | nanopb constraints (`max_size:2048`) |
+| `lib/firmware/fsm_msg_debug.h` | Firmware DebugLinkGetState handler |
+
+## Fragile Points (Lessons Learned)
+
+These were discovered over 50+ CI runs. Each one silently breaks screenshots with zero error output unless you know what to look for.
+
+### 1. Docker Healthcheck (CRITICAL)
+
+**Problem**: `depends_on: kkemu` only ensures container start ORDER, not service READINESS. Tests start before the emulator binary is listening on UDP.
+
+**Symptom**: Tests timeout or fail with no screenshot output at all. `_capture_oled()` is never called because no `ButtonRequest` is ever received.
+
+**Fix**: `docker-compose.yml` must have a healthcheck on `kkemu` and `depends_on: condition: service_healthy`.
+
+**Trap**: `curl` is NOT installed in `kktech/firmware:v15`. Use `python3 urllib`:
+```yaml
+healthcheck:
+  test: ["CMD-SHELL", "python3 -c \"import urllib.request; urllib.request.urlopen('http://localhost:5000/health')\" || exit 1"]
+```
+
+Requires `/health` endpoint in `bridge.py`.
+
+### 2. Shell Compatibility (CRITICAL)
+
+**Problem**: `python-keepkey.Dockerfile` uses `ENTRYPOINT ["/bin/sh", ...]`. The test script MUST be `/bin/sh` compatible.
+
+**Will break**:
+- `${PIPESTATUS[0]}` — bash-only, causes `syntax error: bad substitution`
+- `{ cmd; } | tee` — causes `syntax error: unexpected "}"`
+- `#!/bin/bash` — may not exist in the image
+
+**Safe patterns**:
+```sh
+# Capture exit code without PIPESTATUS:
+cmd 2>&1 | tee logfile || true
+
+# Export env vars separately (not inline with complex pipes):
+export KEEPKEY_SCREENSHOT=1
+export SCREENSHOT_DIR=/path
+pytest ...
+```
+
+### 3. pytest-timeout Not Installed
+
+**Problem**: `--timeout=120` causes `pytest: error: unrecognized arguments`.
+
+**Fix**: Don't use `--timeout`. The emulator tests are fast (~1s each). If something hangs, the CI job timeout (30 min) will catch it.
+
+### 4. Phase 1 Test Selection (CRITICAL)
+
+**Problem**: The `-k` filter must match tests that actually EXIST and RUN on a BTC-only emulator.
+
+**Will NOT work** (all SKIPPED on BTC-only build):
+- `test_bip85` — requires `GetFeatures.capabilities` check
+- `test_solana_get` — Solana not compiled in
+- `test_tron_get` — Tron not compiled in
+- `test_ton_get` — TON not compiled in
+
+**Will work** (triggers `ButtonRequest` → `_capture_oled()`):
+- `test_wipe_device` — always works, 2 button prompts = 2 screenshots
+- `test_get_address` (from `test_protection_levels`) — works but no `ButtonRequest`
+
+**Best smoke test**: `-k "test_wipe_device"` — fast, reliable, proves the entire pipeline.
+
+### 5. `_capture_oled()` Silent Exception Swallowing
+
+**Problem**: Upstream `keepkeylib/client.py` has `except Exception: pass` in `_capture_oled()`. If screenshots fail, you get ZERO diagnostic output.
+
+**Fix**: Pin to fork branch `fix/screenshot-debug` on `BitHighlander/python-keepkey` which adds:
+```
+[SCREENSHOT] OK: /path/btn00000.png (2048 bytes layout)
+[SCREENSHOT] SKIP: no debug link
+[SCREENSHOT] SKIP: layout too small (0 bytes)
+[SCREENSHOT] ERROR: <exception with traceback>
+```
+
+**To switch back to upstream later**: Change `.gitmodules` URL back to `keepkey/python-keepkey` and update submodule pin.
+
+### 6. `if: ${{ !cancelled() }}` on python-integration-tests Job (CRITICAL)
+
+**Problem**: ARM firmware builds (build-arm-firmware, build-arm-firmware-btc-only) share the `needs` chain. If ARM builds fail, GitHub Actions CANCELS the python-integration-tests job by default.
+
+**Symptom**: Python tests show as "cancelled" even though they have nothing to do with ARM compilation. No screenshots, no test results.
+
+**Fix**: Add `if: ${{ !cancelled() }}` to the python-integration-tests job so it runs regardless of ARM build failures.
+
+### 7. docker cp Extraction
+
+**Problem**: Original code used `2>/dev/null || true` which silently swallows extraction failures.
+
+**Symptom**: Screenshot upload succeeds with an empty artifact (no warning).
+
+**Fix**: Log the container IDs, remove stderr suppression, add file listing:
+```yaml
+PY_CONTAINER=$(docker compose ps -a -q python-keepkey)
+echo "python-keepkey container: $PY_CONTAINER"
+docker cp "$PY_CONTAINER":/kkemu/test-reports/. ./test-reports/ || echo "WARN: docker cp failed"
+find ./test-reports/screenshots -name '*.png' | wc -l
+```
+
+### 8. Layout Size 0 Bytes
+
+**Problem**: `_capture_oled()` gets `layout` with 0 bytes from `DebugLinkGetState`.
+
+**Root causes**:
+- `display_canvas()` returns canvas with null buffer (display not initialized)
+- Firmware compiled without `DEBUG_LINK` — `fsm_msgDebugLinkGetState` not registered
+- Test ran before any screen was rendered (no `layoutHome()` called yet)
+
+**Diagnosis**: Look for `[SCREENSHOT] SKIP: layout too small (0 bytes)` in stderr (requires fork pin).
+
+### 9. conftest.py Module Name Detection
+
+**Problem**: `conftest.py` derives the screenshot subdirectory from the test ID. If it can't parse the module name, it uses `unknown/`.
+
+**Symptom**: Screenshots appear in `screenshots/unknown/test_name/` instead of `screenshots/module/test_name/`. Not a functional issue but messy.
+
+### 10. Emulator Debug Port (UDP 11045)
+
+**Problem**: The debug transport (port 11045) does NOT respond to raw UDP probes. Sending `DebugLinkGetState` as raw bytes to the port times out — the emulator expects the full protobuf wire format through its transport layer.
+
+**Symptom**: A "verify debug link" probe wastes 60s and always fails.
+
+**Fix**: Don't probe port 11045 directly. The debug transport is tested implicitly when `_capture_oled()` calls `self.debug.read_layout()` through the proper python transport stack.
+
+## Environment Variables
+
+| Variable | Set In | Value | Purpose |
+|----------|--------|-------|---------|
+| `KEEPKEY_SCREENSHOT` | test script | `1` | Enables `_capture_oled()` in client.py |
+| `SCREENSHOT_DIR` | test script | `/kkemu/test-reports/screenshots` | Base directory for PNG output |
+| `KK_TRANSPORT_MAIN` | test script | `kkemu:11044` | Emulator main UDP (docker hostname) |
+| `KK_TRANSPORT_DEBUG` | test script | `kkemu:11045` | Emulator debug UDP (docker hostname) |
+
+## Debugging Checklist
+
+When screenshots don't appear in CI artifacts:
+
+1. **Check if python-integration-tests was cancelled** — look for `if: ${{ !cancelled() }}` on the job
+2. **Check if emulator built** — look for `make -j` success in docker build logs
+3. **Check if healthcheck passed** — look for `healthy` in container logs, or `unhealthy` → fix healthcheck
+4. **Check if emulator responded** — look for `Emulator ready` in test output
+5. **Check Phase 1 test results** — look for PASSED vs SKIPPED. All SKIPPED = wrong `-k` filter
+6. **Check `[SCREENSHOT]` lines** — requires fork pin. Look in captured stderr or `screenshot-debug.log`
+7. **Check docker cp** — look for container IDs and file count in extraction step
+8. **Check artifact upload** — `if-no-files-found: warn` will flag empty uploads
+
+## Local Testing
+
+```bash
+# Build emulator locally (macOS ARM64)
+cd /path/to/keepkey-firmware
+eval "$(pyenv init -)"
+pyenv shell 3.10.15
+cmake -C cmake/caches/emulator.cmake . -DCMAKE_BUILD_TYPE=Debug
+make -j
+
+# Run emulator
+./bin/kkemu &
+
+# Run screenshot test
+cd deps/python-keepkey/tests
+KEEPKEY_SCREENSHOT=1 \
+SCREENSHOT_DIR=/tmp/screenshots \
+pytest -v -x -k "test_wipe_device" 2>&1
+
+# Check results
+find /tmp/screenshots -name '*.png' -ls
+```
+
+## Version History
+
+| Date | Change | CI Runs |
+|------|--------|---------|
+| 2026-03-27 | Initial working pipeline | ~50 runs to diagnose |
+| Key fix | `if: !cancelled()` prevents ARM failures from killing python tests | |
+| Key fix | `python3 urllib` healthcheck (curl not in image) | |
+| Key fix | sh-compatible script (no bash-isms) | |
+| Key fix | `-k "test_wipe_device"` (BTC-only compatible) | |
+| Key fix | Fork pin for `[SCREENSHOT]` debug logging | |

--- a/scripts/emulator/bridge.py
+++ b/scripts/emulator/bridge.py
@@ -38,5 +38,9 @@ def exchange(kind):
 
     return Response('{}', status=404, mimetype='application/json')
 
+@app.route('/health')
+def health():
+    return Response('{"status":"ok"}', status=200, mimetype='application/json')
+
 if __name__ == '__main__':
     app.run(debug=True, host='0.0.0.0')

--- a/scripts/emulator/docker-compose.yml
+++ b/scripts/emulator/docker-compose.yml
@@ -11,6 +11,12 @@ services:
       - "127.0.0.1:11044:11044/udp"
       - "127.0.0.1:11045:11045/udp"
       - "127.0.0.1:5000:5000"
+    healthcheck:
+      test: ["CMD-SHELL", "python3 -c \"import urllib.request; urllib.request.urlopen('http://localhost:5000/health')\" || exit 1"]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+      start_period: 10s
   python-keepkey:
     build:
       context: '../../'
@@ -20,7 +26,8 @@ services:
     networks:
       - local-net
     depends_on:
-      - kkemu
+      kkemu:
+        condition: service_healthy
   firmware-unit:
     build:
       context: '../../'
@@ -31,7 +38,8 @@ services:
     networks:
       - local-net
     depends_on:
-      - kkemu
+      kkemu:
+        condition: service_healthy
 networks:
   local-net:
     external: false

--- a/scripts/emulator/python-keepkey-tests.sh
+++ b/scripts/emulator/python-keepkey-tests.sh
@@ -1,6 +1,41 @@
 #!/bin/sh
+set -e
 
 mkdir -p /kkemu/test-reports/python-keepkey
+mkdir -p /kkemu/test-reports/screenshots
+
+# Wait for emulator
+echo "=== Waiting for emulator ==="
+for i in $(seq 1 20); do
+  if echo -n "PINGPING" | nc -u -w1 kkemu 11044 2>/dev/null | grep -q PONG; then
+    echo "Emulator ready (attempt $i)"
+    break
+  fi
+  echo "  attempt $i/20..."
+  sleep 2
+done
+
 cd deps/python-keepkey/tests
-KK_TRANSPORT_MAIN=kkemu:11044 KK_TRANSPORT_DEBUG=kkemu:11045 pytest -v --junitxml=/kkemu/test-reports/python-keepkey/junit.xml
+
+# Smoke test: ONE test with screenshots to prove the pipeline works
+echo "=== Screenshot smoke test (test_wipe_device) ==="
+KEEPKEY_SCREENSHOT=1 \
+SCREENSHOT_DIR=/kkemu/test-reports/screenshots \
+KK_TRANSPORT_MAIN=kkemu:11044 \
+KK_TRANSPORT_DEBUG=kkemu:11045 \
+pytest -v -x -k "test_wipe_device" \
+  --junitxml=/kkemu/test-reports/python-keepkey/junit-screenshots.xml \
+  2>&1
+
+# Report what we got
+echo "=== Screenshot results ==="
+find /kkemu/test-reports/screenshots -name '*.png' -ls 2>/dev/null || echo "NO SCREENSHOTS"
+SCREENSHOT_COUNT=$(find /kkemu/test-reports/screenshots -name '*.png' 2>/dev/null | wc -l)
+echo "Total PNGs: $SCREENSHOT_COUNT"
+
+# Full suite (no screenshots)
+echo "=== Full test suite ==="
+KK_TRANSPORT_MAIN=kkemu:11044 \
+KK_TRANSPORT_DEBUG=kkemu:11045 \
+pytest -v --junitxml=/kkemu/test-reports/python-keepkey/junit.xml
 echo "$?" > /kkemu/test-reports/python-keepkey/status


### PR DESCRIPTION
## Summary
- Complete working CI pipeline for capturing KeepKey emulator OLED screenshots
- Comprehensive documentation of the entire pipeline and all 10 fragile points
- Proven working: run 23673308446 produced real OLED screenshots as artifacts

## What changed

### CI Pipeline (`ci.yml`)
- `if: !cancelled()` on python-integration-tests (ARM failures no longer kill it)
- Visible docker cp extraction with container ID logging and file counting
- Screenshot upload artifact (90 day retention, `if-no-files-found: warn`)
- Branch triggers: added `alpha`, `p0`, `feat/**`

### Docker (`docker-compose.yml` + `bridge.py`)
- Healthcheck using `python3 urllib` (curl not in image)
- `depends_on: condition: service_healthy` gate
- `/health` endpoint on Flask bridge

### Test Runner (`python-keepkey-tests.sh`)
- Emulator readiness wait (nc UDP probe, 20 retries)
- Smoke test: `test_wipe_device` (BTC-only compatible, triggers ButtonRequest)
- Screenshot count reporting after Phase 1
- All sh-compatible (no bash-isms)

### Debug Logging (`python-keepkey` fork pin)
- Pin to `BitHighlander/python-keepkey` branch `fix/screenshot-debug`
- `_capture_oled()` logs `[SCREENSHOT] OK/SKIP/ERROR` to stderr
- Full tracebacks instead of silent `except: pass`
- Upstream untouched

### Documentation (`docs/CI-Screenshots.md`)
- Architecture diagram
- All 10 fragile points documented with symptoms and fixes
- Debugging checklist
- Local testing instructions
- Environment variable reference

## Why this took 50+ CI runs
Each fragile point silently broke the pipeline with zero error output. See docs/CI-Screenshots.md for the full list.

## Test plan
- [x] CI produces oled-screenshots artifact with real PNGs (run 23673308446)
- [x] test_wipe_device captures 2 screenshots (wipe confirmation screen)
- [ ] PR CI run on p0 branch triggers and passes