### PR TITLE
PR #1: nanopb oneof memory leak fix (backport 4fe23595)

### DIFF
--- a/lib/transport/pb_decode.c
+++ b/lib/transport/pb_decode.c
@@ -452,14 +452,18 @@ static bool checkreturn decode_static_field(pb_istream_t *stream,
       }
 
     case PB_HTYPE_ONEOF:
-      *(pb_size_t *)iter->pSize = iter->pos->tag;
-      if (PB_LTYPE(type) == PB_LTYPE_SUBMESSAGE) {
+      if (PB_LTYPE(type) == PB_LTYPE_SUBMESSAGE &&
+                *(pb_size_t*)iter->pSize != iter->pos->tag)
+      {
         /* We memset to zero so that any callbacks are set to NULL.
-         * Then set any default values. */
+         * This is because the callbacks might otherwise have values
+         * from some other union field. */
         memset(iter->pData, 0, iter->pos->data_size);
         pb_message_set_to_defaults((const pb_field_t *)iter->pos->ptr,
                                    iter->pData);
       }
+      *(pb_size_t*)iter->pSize = iter->pos->tag;
+
       return func(stream, iter->pos, iter->pData);
 
     default:


### PR DESCRIPTION
## Summary

Backport of upstream nanopb fix (trezor/trezor-firmware@4fe23595) for oneof field memory leak.

**Bug**: When decoding a oneof submessage, the tag was set *before* zeroing the data area. If the same oneof was decoded twice with different types, the second decode would memset a potentially larger region using stale tag state, leaking or corrupting adjacent memory.

**Fix**: Move the tag assignment (`*(pb_size_t*)iter->pSize = iter->pos->tag`) *after* the conditional memset+defaults, so the size field reflects the new type before any callback runs.

## Files Changed

| File | Change |
|------|--------|
| `lib/transport/pb_decode.c` | Reorder tag write after memset in `decode_static_field` oneof case |

## Test Plan

- [ ] CI green (all 93 existing tests pass)
- [ ] test-report.pdf artifact generated
- [ ] No regression in Core/BTC/ETH/XRP/Cosmos/THORChain/Maya/EOS/Nano sections