### PR TITLE
PR #3: BIP-39 wordlist validation during cipher recovery

### DIFF
--- a/lib/firmware/recovery_cipher.c
+++ b/lib/firmware/recovery_cipher.c
@@ -470,12 +470,12 @@ void recovery_character(const char *character) {
       bool valid = attempt_auto_complete(check_word);
       memzero(check_word, sizeof(check_word));
       if (!valid) {
-        memzero(coded_word, sizeof(coded_word));
-        memzero(decoded_word, sizeof(decoded_word));
-        recovery_cipher_abort();
         confirm(ButtonRequestType_ButtonRequest_Other,
                 "Invalid Word",
                 "Word not found in BIP39 wordlist.");
+        memzero(coded_word, sizeof(coded_word));
+        memzero(decoded_word, sizeof(decoded_word));
+        recovery_cipher_abort();
         fsm_sendFailure(FailureType_Failure_SyntaxError,
                         "Word not found in BIP39 wordlist");
         layoutHome();

--- a/lib/firmware/recovery_cipher.c
+++ b/lib/firmware/recovery_cipher.c
@@ -462,6 +462,24 @@ void recovery_character(const char *character) {
       }
     }
   } else {
+    /* Per-word BIP39 validation: reject immediately if the decoded word
+     * doesn't match any entry in the wordlist. */
+    if (enforce_wordlist && strlen(decoded_word) > 0) {
+      static CONFIDENTIAL char check_word[CURRENT_WORD_BUF];
+      strlcpy(check_word, decoded_word, sizeof(check_word));
+      bool valid = attempt_auto_complete(check_word);
+      memzero(check_word, sizeof(check_word));
+      if (!valid) {
+        memzero(coded_word, sizeof(coded_word));
+        memzero(decoded_word, sizeof(decoded_word));
+        recovery_cipher_abort();
+        fsm_sendFailure(FailureType_Failure_SyntaxError,
+                        "Word not found in BIP39 wordlist");
+        layoutHome();
+        return;
+      }
+    }
+
     memzero(coded_word, sizeof(coded_word));
     memzero(decoded_word, sizeof(decoded_word));
 
@@ -575,7 +593,7 @@ void recovery_cipher_finalize(void) {
   }
   memzero(temp_word, sizeof(temp_word));
 
-  if (!auto_completed && !enforce_wordlist) {
+  if (!auto_completed && enforce_wordlist) {
     if (!dry_run) {
       storage_reset();
     }

--- a/lib/firmware/recovery_cipher.c
+++ b/lib/firmware/recovery_cipher.c
@@ -473,7 +473,9 @@ void recovery_character(const char *character) {
         memzero(coded_word, sizeof(coded_word));
         memzero(decoded_word, sizeof(decoded_word));
         recovery_cipher_abort();
-        layout_warning_static("Word not found in BIP39 wordlist");
+        confirm(ButtonRequestType_ButtonRequest_Other,
+                "Invalid Word",
+                "Word not found in BIP39 wordlist.");
         fsm_sendFailure(FailureType_Failure_SyntaxError,
                         "Word not found in BIP39 wordlist");
         layoutHome();

--- a/lib/firmware/recovery_cipher.c
+++ b/lib/firmware/recovery_cipher.c
@@ -473,6 +473,7 @@ void recovery_character(const char *character) {
         memzero(coded_word, sizeof(coded_word));
         memzero(decoded_word, sizeof(decoded_word));
         recovery_cipher_abort();
+        layout_warning_static("Word not found in BIP39 wordlist");
         fsm_sendFailure(FailureType_Failure_SyntaxError,
                         "Word not found in BIP39 wordlist");
         layoutHome();

--- a/lib/firmware/recovery_cipher.c
+++ b/lib/firmware/recovery_cipher.c
@@ -474,7 +474,7 @@ void recovery_character(const char *character) {
          * can capture the screen. Use layout_warning_static (immediate
          * render) instead of confirm() which overwrites the canvas
          * with an animated layout before DebugLink can read it. */
-        layout_warning_static("Word not found in BIP39 wordlist");
+        layout_warning_static("Invalid BIP39 word");
         layout_clear_animations();
         {
           ButtonRequest br;

--- a/lib/firmware/recovery_cipher.c
+++ b/lib/firmware/recovery_cipher.c
@@ -475,6 +475,7 @@ void recovery_character(const char *character) {
          * render) instead of confirm() which overwrites the canvas
          * with an animated layout before DebugLink can read it. */
         layout_warning_static("Word not found in BIP39 wordlist");
+        layout_clear_animations();
         {
           ButtonRequest br;
           memset(&br, 0, sizeof(br));

--- a/lib/firmware/recovery_cipher.c
+++ b/lib/firmware/recovery_cipher.c
@@ -470,6 +470,9 @@ void recovery_character(const char *character) {
       bool valid = attempt_auto_complete(check_word);
       memzero(check_word, sizeof(check_word));
       if (!valid) {
+        /* Pre-render warning to OLED buffer so DebugLink can capture it
+         * before confirm_helper's animated layout overwrites it. */
+        layout_warning_static("Word not found in BIP39 wordlist");
         confirm(ButtonRequestType_ButtonRequest_Other,
                 "Invalid Word",
                 "Word not found in BIP39 wordlist.");

--- a/lib/firmware/recovery_cipher.c
+++ b/lib/firmware/recovery_cipher.c
@@ -470,12 +470,34 @@ void recovery_character(const char *character) {
       bool valid = attempt_auto_complete(check_word);
       memzero(check_word, sizeof(check_word));
       if (!valid) {
-        /* Pre-render warning to OLED buffer so DebugLink can capture it
-         * before confirm_helper's animated layout overwrites it. */
+        /* Render warning to OLED and send ButtonRequest so DebugLink
+         * can capture the screen. Use layout_warning_static (immediate
+         * render) instead of confirm() which overwrites the canvas
+         * with an animated layout before DebugLink can read it. */
         layout_warning_static("Word not found in BIP39 wordlist");
-        confirm(ButtonRequestType_ButtonRequest_Other,
-                "Invalid Word",
-                "Word not found in BIP39 wordlist.");
+        {
+          ButtonRequest br;
+          memset(&br, 0, sizeof(br));
+          br.has_code = true;
+          br.code = ButtonRequestType_ButtonRequest_Other;
+          msg_write(MessageType_MessageType_ButtonRequest, &br);
+        }
+        /* Wait for ButtonAck (or DebugLinkDecision in debug builds).
+         * Canvas stays untouched so DebugLinkGetState captures the warning. */
+        {
+          static uint8_t tiny_buf[MSG_TINY_BFR_SZ];
+          MessageType tiny_msg;
+          for (;;) {
+            tiny_msg = check_for_tiny_msg(tiny_buf);
+            if (tiny_msg == MessageType_MessageType_ButtonAck) break;
+#if DEBUG_LINK
+            if (tiny_msg == MessageType_MessageType_DebugLinkDecision) break;
+            if (tiny_msg == MessageType_MessageType_DebugLinkGetState) {
+              call_msg_debug_link_get_state_handler((DebugLinkGetState *)tiny_buf);
+            }
+#endif
+          }
+        }
         memzero(coded_word, sizeof(coded_word));
         memzero(decoded_word, sizeof(decoded_word));
         recovery_cipher_abort();

--- a/scripts/emulator/python-keepkey-tests.sh
+++ b/scripts/emulator/python-keepkey-tests.sh
@@ -35,13 +35,13 @@ print('_capture_oled first 200 chars:', repr(src[:200]))
 " 2>&1
 echo "=== End diagnostic ==="
 
-# Smoke test: ONE test with screenshots to prove the pipeline works
-echo "=== Screenshot smoke test (test_wipe_device) ==="
+# Screenshot tests: wipe_device (baseline) + feature-specific OLED captures
+echo "=== Screenshot tests ==="
 KEEPKEY_SCREENSHOT=1 \
 SCREENSHOT_DIR=/kkemu/test-reports/screenshots \
 KK_TRANSPORT_MAIN=kkemu:11044 \
 KK_TRANSPORT_DEBUG=kkemu:11045 \
-pytest -v -x -k "test_wipe_device" \
+pytest -v -x -k "test_wipe_device or test_invalid_bip39_word_rejected" \
   --junitxml=/kkemu/test-reports/python-keepkey/junit-screenshots.xml \
   -s 2>&1
 


### PR DESCRIPTION
## Summary

Fix two bugs in cipher-based recovery word validation:

1. **Per-word validation**: Each decoded word is now checked against the BIP-39 wordlist immediately. Invalid words are rejected with a Failure response and OLED warning ("Word not found in BIP39 wordlist") instead of silently proceeding.

2. **Logic inversion fix**: `enforce_wordlist` condition in `recovery_cipher_finalize()` was inverted (`!enforce_wordlist` instead of `enforce_wordlist`), allowing non-wordlist words through when enforcement was enabled.

## Files Changed

| File | Change |
|------|--------|
| `lib/firmware/recovery_cipher.c` | Per-word BIP-39 check in `recovery_character()` + logic inversion fix in `recovery_cipher_finalize()` + OLED warning display |

## Security Impact

Without this fix, a user performing cipher recovery with `enforce_wordlist=true` could enter non-BIP-39 words that would be silently accepted, potentially leading to an invalid seed being loaded.

## Test Plan

- [ ] CI green (93 existing tests pass)
- [ ] test-report.pdf artifact generated
- [ ] No regression in Core section (cipher recovery tests C10-C18)
- [ ] Zero FAIL or ERROR