### PR TITLE
PR #3: BIP-39 wordlist validation during cipher recovery

### DIFF
--- a/lib/firmware/recovery_cipher.c
+++ b/lib/firmware/recovery_cipher.c
@@ -462,6 +462,24 @@ void recovery_character(const char *character) {
       }
     }
   } else {
+    /* Per-word BIP39 validation: reject immediately if the decoded word
+     * doesn't match any entry in the wordlist. */
+    if (enforce_wordlist && strlen(decoded_word) > 0) {
+      static CONFIDENTIAL char check_word[CURRENT_WORD_BUF];
+      strlcpy(check_word, decoded_word, sizeof(check_word));
+      bool valid = attempt_auto_complete(check_word);
+      memzero(check_word, sizeof(check_word));
+      if (!valid) {
+        memzero(coded_word, sizeof(coded_word));
+        memzero(decoded_word, sizeof(decoded_word));
+        recovery_cipher_abort();
+        fsm_sendFailure(FailureType_Failure_SyntaxError,
+                        "Word not found in BIP39 wordlist");
+        layoutHome();
+        return;
+      }
+    }
+
     memzero(coded_word, sizeof(coded_word));
     memzero(decoded_word, sizeof(decoded_word));
 
@@ -575,7 +593,7 @@ void recovery_cipher_finalize(void) {
   }
   memzero(temp_word, sizeof(temp_word));
 
-  if (!auto_completed && !enforce_wordlist) {
+  if (!auto_completed && enforce_wordlist) {
     if (!dry_run) {
       storage_reset();
     }

--- a/lib/firmware/recovery_cipher.c
+++ b/lib/firmware/recovery_cipher.c
@@ -473,7 +473,7 @@ void recovery_character(const char *character) {
         memzero(coded_word, sizeof(coded_word));
         memzero(decoded_word, sizeof(decoded_word));
         recovery_cipher_abort();
-        layout_warning_static("Word not found in BIP39 wordlist");
+        layout_warning_static("Word not in wordlist");
         fsm_sendFailure(FailureType_Failure_SyntaxError,
                         "Word not found in BIP39 wordlist");
         layoutHome();

--- a/lib/firmware/recovery_cipher.c
+++ b/lib/firmware/recovery_cipher.c
@@ -473,10 +473,9 @@ void recovery_character(const char *character) {
         memzero(coded_word, sizeof(coded_word));
         memzero(decoded_word, sizeof(decoded_word));
         recovery_cipher_abort();
-        layout_warning_static("Word not in wordlist");
         fsm_sendFailure(FailureType_Failure_SyntaxError,
                         "Word not found in BIP39 wordlist");
-        layoutHome();
+        layout_warning_static("Word not in wordlist");
         return;
       }
     }

--- a/lib/firmware/recovery_cipher.c
+++ b/lib/firmware/recovery_cipher.c
@@ -473,6 +473,7 @@ void recovery_character(const char *character) {
         memzero(coded_word, sizeof(coded_word));
         memzero(decoded_word, sizeof(decoded_word));
         recovery_cipher_abort();
+        layout_warning_static("Word not found in BIP39 wordlist");
         fsm_sendFailure(FailureType_Failure_SyntaxError,
                         "Word not found in BIP39 wordlist");
         layoutHome();

--- a/scripts/emulator/python-keepkey-tests.sh
+++ b/scripts/emulator/python-keepkey-tests.sh
@@ -35,19 +35,20 @@ print('_capture_oled first 200 chars:', repr(src[:200]))
 " 2>&1
 echo "=== End diagnostic ==="
 
-# Phase 1: 5 targeted screenshots — security-critical OLED content only
+# Phase 1: 6 targeted screenshots — security-critical OLED content only
 # 1. Wipe confirm — "erase your private keys?" (security gate)
 # 2. BTC sign — output address + amount + fee (anti-tampering proof)
 # 3. ETH sign — recipient + gas (different chain flow)
 # 4. THORChain swap — memo with routing (most complex confirmation)
 # 5. Reset device — seed words on OLED (proves words never leave device)
-echo "=== Phase 1: Targeted screenshot capture (5 tests) ==="
+# 6. BIP-39 rejection — "Word not in wordlist" (invalid word error screen)
+echo "=== Phase 1: Targeted screenshot capture (6 tests) ==="
 KEEPKEY_SCREENSHOT=1 \
 SCREENSHOT_DIR=/kkemu/test-reports/screenshots \
 KK_TRANSPORT_MAIN=kkemu:11044 \
 KK_TRANSPORT_DEBUG=kkemu:11045 \
 pytest -v --tb=short \
-  -k "(test_wipe_device and wipedevice) or (test_one_one_fee and msg_signtx and not raw and not grs) or (test_ethereum_signtx_nodata and not eip) or (test_sign_btc_eth_swap and thorchain) or (test_reset_device and resetdevice and not pin)" \
+  -k "(test_wipe_device and wipedevice) or (test_one_one_fee and msg_signtx and not raw and not grs) or (test_ethereum_signtx_nodata and not eip) or (test_sign_btc_eth_swap and thorchain) or (test_reset_device and resetdevice and not pin) or test_invalid_bip39_word_rejected" \
   --junitxml=/kkemu/test-reports/python-keepkey/junit-screenshots.xml \
   -s 2>&1
 


### PR DESCRIPTION
## Summary

Two security fixes in cipher-based recovery word validation:

1. **Per-word validation**: Each decoded word checked against BIP-39 wordlist immediately. Invalid words rejected with Failure + OLED warning.
2. **Logic inversion fix**: `!enforce_wordlist` → `enforce_wordlist` in `recovery_cipher_finalize()`.

## Files Changed

| File | Change |
|------|--------|
| `lib/firmware/recovery_cipher.c` | Per-word BIP-39 check + logic inversion fix + OLED warning |
| `deps/python-keepkey` | Pin updated — C31 test + report entry restored |

## Test Plan

- [ ] CI green — 93+1 existing tests pass (C31 new)
- [ ] test-report.pdf: 135 tests, 31/31 Core (C31 PASSED)
- [ ] No regression in any chain section