### PR TITLE
PR #7-prep: EVM blind-sign hard gate

### DIFF
--- a/lib/firmware/ethereum.c
+++ b/lib/firmware/ethereum.c
@@ -734,16 +734,20 @@ void ethereum_signing_init(EthereumSignTx *msg, const HDNode *node,
 
   memset(confirm_body_message, 0, sizeof(confirm_body_message));
   if (token == NULL && data_total > 0 && data_needs_confirm) {
-    // KeepKey custom: warn the user that they're trying to do something
-    // that is potentially dangerous. People (generally) aren't great at
-    // parsing raw transaction data, and we can't effectively show them
-    // what they're about to do in the general case.
+    // Blind-sign gate: when AdvancedMode is OFF (default), BLOCK the tx.
+    // When ON, warn prominently but allow.
     if (!storage_isPolicyEnabled("AdvancedMode")) {
-      (void)review(
-          ButtonRequestType_ButtonRequest_Other, "Warning",
-          "Signing of arbitrary ETH contract data is recommended only for "
-          "experienced users. Enable 'AdvancedMode' policy to dismiss.");
+      (void)review(ButtonRequestType_ButtonRequest_Other, "BLOCKED",
+                   "Blind signing is disabled. "
+                   "Enable AdvancedMode policy to allow.");
+      fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                      "Blind signing disabled by policy");
+      ethereum_signing_abort();
+      return;
     }
+    (void)review(ButtonRequestType_ButtonRequest_Other, "BLIND SIGNATURE",
+                 "You are signing raw contract data. "
+                 "The device cannot verify the contents.");
 
     layoutEthereumData(msg->data_initial_chunk.bytes,
                        msg->data_initial_chunk.size, data_total,


### PR DESCRIPTION
## Summary
- AdvancedMode OFF (default): blind-signing BLOCKED with abort
- AdvancedMode ON: BLIND SIGNATURE warning, user confirms

## What changed
One file: `lib/firmware/ethereum.c` (+12/-8 lines)

Old: `(void)review()` showed warning but signed regardless — return value discarded.
New: `fsm_sendFailure` + `ethereum_signing_abort()` + `return` when AdvancedMode OFF.

## Test plan
- [ ] `test_ethereum_blind_sign_blocked` — BLOCKED screen, tx refused
- [ ] `test_ethereum_blind_sign_allowed` — BLIND SIGNATURE warning, tx proceeds
- [ ] No regression on existing ETH signing tests