### PR TITLE
PR #7b: TRON — protobuf, reconstruct-then-sign, 13 TRC-20 tokens

### DIFF
--- a/include/keepkey/firmware/fsm.h
+++ b/include/keepkey/firmware/fsm.h
@@ -135,4 +135,7 @@ void fsm_msgSolanaGetAddress(const SolanaGetAddress *msg);
 void fsm_msgSolanaSignTx(const SolanaSignTx *msg);
 void fsm_msgSolanaSignMessage(const SolanaSignMessage *msg);
 
+void fsm_msgTronGetAddress(const TronGetAddress *msg);
+void fsm_msgTronSignTx(TronSignTx *msg);
+
 #endif

--- a/include/keepkey/firmware/tron.h
+++ b/include/keepkey/firmware/tron.h
@@ -1,0 +1,117 @@
+/*
+ * This file is part of the KeepKey project.
+ *
+ * Copyright (C) 2024 KeepKey
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPKEY_FIRMWARE_TRON_H
+#define KEEPKEY_FIRMWARE_TRON_H
+
+#include "trezor/crypto/bip32.h"
+
+#include "messages-tron.pb.h"
+
+// TRON address length (Base58Check, typically 34 chars starting with 'T')
+#define TRON_ADDRESS_MAX_LEN 64
+
+// TRON address raw size (1 prefix + 20 hash)
+#define TRON_ADDRESS_SIZE 21
+
+// TRON max encoded address size
+#define MAX_TRON_ADDR_SIZE 35
+
+// TRON mainnet address prefix
+#define TRON_MAINNET_PREFIX 0x41
+
+// TRON decimals (1 TRX = 1,000,000 SUN)
+#define TRON_DECIMALS 6
+
+// TRON signature size (r + s + recovery_id)
+#define TRON_SIGNATURE_SIZE 65
+
+// TRC-20 transfer(address,uint256) function selector
+#define TRC20_TRANSFER_SELECTOR 0xa9059cbb
+
+/**
+ * Generate TRON address from secp256k1 public key
+ */
+bool tron_getAddress(const uint8_t public_key[33], char *address,
+                     size_t address_len);
+
+/**
+ * Decode a Base58Check TRON address to raw 21-byte form
+ * @param address  Base58Check encoded "T..." address
+ * @param raw_address  Output buffer (21 bytes: 0x41 prefix + 20 hash)
+ * @return true on success, false if decode fails or prefix is wrong
+ */
+bool tron_decodeAddress(const char *address,
+                        uint8_t raw_address[TRON_ADDRESS_SIZE]);
+
+/**
+ * Validate a Base58Check TRON address
+ */
+bool tron_validateAddress(const char *address);
+
+/**
+ * Format TRON amount (SUN) for display
+ */
+void tron_formatAmount(char *buf, size_t len, uint64_t amount);
+
+/**
+ * Format a token amount with given decimals for display
+ * @param buf       Output buffer
+ * @param buf_len   Buffer size
+ * @param amount_be 32-byte big-endian amount
+ * @param decimals  Token decimal places
+ * @param symbol    Token symbol (e.g., "USDT")
+ */
+void tron_formatTokenAmount(char *buf, size_t buf_len,
+                            const uint8_t amount_be[32],
+                            uint8_t decimals, const char *symbol);
+
+/**
+ * Decode TRC-20 transfer(address,uint256) ABI call data
+ * @param data       ABI-encoded call data (>= 68 bytes)
+ * @param data_len   Length of call data
+ * @param to_raw     Output: 21-byte TRON address (0x41 + 20-byte EVM addr)
+ * @param amount_bytes Output: 32-byte big-endian amount
+ * @return true if data matches transfer(address,uint256) selector
+ */
+bool tron_decodeTRC20Transfer(const uint8_t *data, size_t data_len,
+                              uint8_t to_raw[TRON_ADDRESS_SIZE],
+                              uint8_t amount_bytes[32]);
+
+/**
+ * Reconstruct Transaction.raw protobuf from structured fields
+ * @param msg        TronSignTx with structured fields
+ * @param owner_raw  21-byte raw address of the signer
+ * @param out        Output buffer for serialized protobuf
+ * @param out_len    In: max capacity; Out: bytes written
+ * @param max_len    Maximum buffer size
+ * @return true on success
+ */
+bool tron_serializeRawTransaction(const TronSignTx *msg,
+                                  const uint8_t *owner_raw,
+                                  uint8_t *out, size_t *out_len,
+                                  size_t max_len);
+
+/**
+ * Sign a TRON transaction (supports both structured and legacy modes)
+ */
+bool tron_signTx(const HDNode *node, const TronSignTx *msg,
+                 TronSignedTx *resp);
+
+#endif

--- a/include/keepkey/transport/interface.h
+++ b/include/keepkey/transport/interface.h
@@ -36,6 +36,7 @@
 #include "messages-thorchain.pb.h"
 #include "messages-mayachain.pb.h"
 #include "messages-solana.pb.h"
+#include "messages-tron.pb.h"
 
 #include "types.pb.h"
 #include "trezor_transport.h"

--- a/lib/firmware/CMakeLists.txt
+++ b/lib/firmware/CMakeLists.txt
@@ -38,6 +38,7 @@ set(sources
     storage.c
     tendermint.c
     thorchain.c
+    tron.c
     tiny-json.c
     transaction.c
     txin_check.c

--- a/lib/firmware/fsm.c
+++ b/lib/firmware/fsm.c
@@ -288,3 +288,5 @@ void fsm_msgClearSession(ClearSession *msg) {
 #include "fsm_msg_mayachain.h"
 #include "fsm_msg_bip85.h"
 #include "fsm_msg_solana.h"
+#include "keepkey/firmware/tron.h"
+#include "fsm_msg_tron.h"

--- a/lib/firmware/fsm_msg_tron.h
+++ b/lib/firmware/fsm_msg_tron.h
@@ -1,0 +1,347 @@
+/*
+ * This file is part of the KeepKey project.
+ *
+ * Copyright (C) 2024 KeepKey
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "tron_tokens.h"
+
+void fsm_msgTronGetAddress(const TronGetAddress *msg) {
+  RESP_INIT(TronAddress);
+
+  CHECK_INITIALIZED
+
+  CHECK_PIN
+
+  // Validate path: m/44'/195'/...
+  if (msg->address_n_count < 3 ||
+      msg->address_n[0] != (0x80000000 | 44) ||
+      msg->address_n[1] != (0x80000000 | 195)) {
+    fsm_sendFailure(FailureType_Failure_Other,
+                    _("Invalid TRON path (expected m/44'/195'/...)"));
+    layoutHome();
+    return;
+  }
+
+  HDNode *node = fsm_getDerivedNode(SECP256K1_NAME, msg->address_n,
+                                    msg->address_n_count, NULL);
+  if (!node) return;
+  hdnode_fill_public_key(node);
+
+  char address[MAX_ADDR_SIZE];
+  if (!tron_getAddress(node->public_key, address, sizeof(address))) {
+    memzero(node, sizeof(*node));
+    fsm_sendFailure(FailureType_Failure_Other, _("Address derivation failed"));
+    layoutHome();
+    return;
+  }
+
+  resp->has_address = true;
+  strlcpy(resp->address, address, sizeof(resp->address));
+
+  if (msg->has_show_display && msg->show_display) {
+    char node_str[NODE_STRING_LENGTH];
+    if (!bip32_path_to_string(node_str, sizeof(node_str), msg->address_n,
+                              msg->address_n_count)) {
+      memset(node_str, 0, sizeof(node_str));
+    }
+
+    if (!confirm_ethereum_address(node_str, resp->address)) {
+      memzero(node, sizeof(*node));
+      fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                      _("Show address cancelled"));
+      layoutHome();
+      return;
+    }
+  }
+
+  memzero(node, sizeof(*node));
+  msg_write(MessageType_MessageType_TronAddress, resp);
+  layoutHome();
+}
+
+void fsm_msgTronSignTx(TronSignTx *msg) {
+  RESP_INIT(TronSignedTx);
+
+  CHECK_INITIALIZED
+
+  CHECK_PIN
+
+  // Validate path: m/44'/195'/...
+  if (msg->address_n_count < 3 ||
+      msg->address_n[0] != (0x80000000 | 44) ||
+      msg->address_n[1] != (0x80000000 | 195)) {
+    fsm_sendFailure(FailureType_Failure_Other,
+                    _("Invalid TRON path (expected m/44'/195'/...)"));
+    layoutHome();
+    return;
+  }
+
+  HDNode *node = fsm_getDerivedNode(SECP256K1_NAME, msg->address_n,
+                                    msg->address_n_count, NULL);
+  if (!node) return;
+  hdnode_fill_public_key(node);
+
+  bool is_structured = msg->has_transfer || msg->has_trigger_smart;
+  bool is_legacy = msg->has_raw_data && msg->raw_data.size > 0;
+
+  if (!is_structured && !is_legacy) {
+    memzero(node, sizeof(*node));
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Must provide transfer, trigger_smart, or raw_data"));
+    layoutHome();
+    return;
+  }
+
+  /* Reject if both contract types are present — exactly one required */
+  if (msg->has_transfer && msg->has_trigger_smart) {
+    memzero(node, sizeof(*node));
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Cannot set both transfer and trigger_smart"));
+    layoutHome();
+    return;
+  }
+
+  /* ---- Structured reconstruct-then-sign path ---- */
+  if (is_structured) {
+    /* Validate required header fields */
+    if (!msg->has_ref_block_bytes || msg->ref_block_bytes.size != 2) {
+      memzero(node, sizeof(*node));
+      fsm_sendFailure(FailureType_Failure_SyntaxError,
+                      _("ref_block_bytes must be exactly 2 bytes"));
+      layoutHome();
+      return;
+    }
+    if (!msg->has_ref_block_hash || msg->ref_block_hash.size != 8) {
+      memzero(node, sizeof(*node));
+      fsm_sendFailure(FailureType_Failure_SyntaxError,
+                      _("ref_block_hash must be exactly 8 bytes"));
+      layoutHome();
+      return;
+    }
+    if (!msg->has_expiration) {
+      memzero(node, sizeof(*node));
+      fsm_sendFailure(FailureType_Failure_SyntaxError,
+                      _("expiration is required"));
+      layoutHome();
+      return;
+    }
+
+    /* Show memo if present */
+    if (msg->has_data && msg->data.size > 0) {
+      char memo_hex[65];
+      size_t show = msg->data.size < 32 ? msg->data.size : 32;
+      for (size_t i = 0; i < show; i++) {
+        snprintf(memo_hex + i * 2, 3, "%02x", msg->data.bytes[i]);
+      }
+      if (msg->data.size > 32) {
+        strlcat(memo_hex, "...", sizeof(memo_hex));
+      }
+      if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
+                   "Memo", "Transaction memo:\n%s", memo_hex)) {
+        memzero(node, sizeof(*node));
+        fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                        _("Signing cancelled"));
+        layoutHome();
+        return;
+      }
+    }
+
+    /* ---- TransferContract path ---- */
+    if (msg->has_transfer) {
+      /* Validate to_address BEFORE display */
+      if (!tron_validateAddress(msg->transfer.to_address)) {
+        memzero(node, sizeof(*node));
+        fsm_sendFailure(FailureType_Failure_SyntaxError,
+                        _("Invalid to_address in transfer"));
+        layoutHome();
+        return;
+      }
+
+      char amount_str[64];
+      tron_formatAmount(amount_str, sizeof(amount_str), msg->transfer.amount);
+
+      if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
+                   "Send TRX", "Send %s to\n%s?",
+                   amount_str, msg->transfer.to_address)) {
+        memzero(node, sizeof(*node));
+        fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                        _("Signing cancelled"));
+        layoutHome();
+        return;
+      }
+    }
+
+    /* ---- TriggerSmartContract path ---- */
+    if (msg->has_trigger_smart) {
+      /* Validate contract_address BEFORE any display */
+      if (!tron_validateAddress(msg->trigger_smart.contract_address)) {
+        memzero(node, sizeof(*node));
+        fsm_sendFailure(FailureType_Failure_SyntaxError,
+                        _("Invalid contract_address"));
+        layoutHome();
+        return;
+      }
+
+      /* Attempt TRC-20 transfer(address,uint256) decode */
+      uint8_t trc20_to[TRON_ADDRESS_SIZE];
+      uint8_t trc20_amount[32];
+      bool is_trc20 = msg->trigger_smart.has_data &&
+                      msg->trigger_smart.data.size >= 68 &&
+                      tron_decodeTRC20Transfer(msg->trigger_smart.data.bytes,
+                                               msg->trigger_smart.data.size,
+                                               trc20_to, trc20_amount);
+
+      if (is_trc20) {
+        /* Look up known token by contract address */
+        const TronToken *token =
+            tron_token_by_address(msg->trigger_smart.contract_address);
+
+        char to_addr[MAX_TRON_ADDR_SIZE];
+        if (!base58_encode_check(trc20_to, 21, HASHER_SHA2D, to_addr,
+                                 sizeof(to_addr))) {
+          memzero(node, sizeof(*node));
+          fsm_sendFailure(FailureType_Failure_Other,
+                          _("Failed to encode recipient address"));
+          layoutHome();
+          return;
+        }
+
+        if (token) {
+          char amt_str[64];
+          tron_formatTokenAmount(amt_str, sizeof(amt_str), trc20_amount,
+                                 token->decimals, token->symbol);
+          if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
+                       "Send Token", "Send %s to\n%s?",
+                       amt_str, to_addr)) {
+            memzero(node, sizeof(*node));
+            fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                            _("Signing cancelled"));
+            layoutHome();
+            return;
+          }
+        } else {
+          /* Unknown TRC-20 token */
+          if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
+                       "Unknown Token",
+                       "Transfer unknown token at\n%s\nto %s?",
+                       msg->trigger_smart.contract_address, to_addr)) {
+            memzero(node, sizeof(*node));
+            fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                            _("Signing cancelled"));
+            layoutHome();
+            return;
+          }
+        }
+      } else {
+        /* Not a TRC-20 transfer — generic smart contract call */
+        if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
+                     "Contract Call",
+                     "Call contract\n%s?\nCannot verify call data.",
+                     msg->trigger_smart.contract_address)) {
+          memzero(node, sizeof(*node));
+          fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                          _("Signing cancelled"));
+          layoutHome();
+          return;
+        }
+      }
+
+      /* Show call_value if sending TRX along with the smart contract call */
+      if (msg->trigger_smart.has_call_value &&
+          msg->trigger_smart.call_value > 0) {
+        char call_str[64];
+        tron_formatAmount(call_str, sizeof(call_str),
+                          msg->trigger_smart.call_value);
+        if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
+                     "Call Value",
+                     "Also sending %s with call?", call_str)) {
+          memzero(node, sizeof(*node));
+          fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                          _("Signing cancelled"));
+          layoutHome();
+          return;
+        }
+      }
+    }
+
+    /* Show fee limit if present */
+    if (msg->has_fee_limit && msg->fee_limit > 0) {
+      char fee_str[64];
+      tron_formatAmount(fee_str, sizeof(fee_str), msg->fee_limit);
+      if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
+                   "Fee Limit", "Maximum fee:\n%s?", fee_str)) {
+        memzero(node, sizeof(*node));
+        fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                        _("Signing cancelled"));
+        layoutHome();
+        return;
+      }
+    }
+
+    /* Final confirmation */
+    if (!confirm(ButtonRequestType_ButtonRequest_SignTx, "Sign",
+                 "Sign this TRON transaction?")) {
+      memzero(node, sizeof(*node));
+      fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                      _("Signing cancelled"));
+      layoutHome();
+      return;
+    }
+  }
+
+  /* ---- Legacy blind-sign path ---- */
+  if (!is_structured) {
+    /* Blind-sign warning: user must understand this is unverified */
+    if (!confirm(ButtonRequestType_ButtonRequest_SignTx,
+                 "Blind Sign",
+                 "Sign unverified TRON\ntransaction?\n"
+                 "Data cannot be verified\non-device.")) {
+      memzero(node, sizeof(*node));
+      fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                      _("Signing cancelled"));
+      layoutHome();
+      return;
+    }
+
+    /* Show optional unverified hints from host */
+    if (msg->has_to_address && msg->has_amount) {
+      char amount_str[64];
+      tron_formatAmount(amount_str, sizeof(amount_str), msg->amount);
+      if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
+                   "Unverified", "Send %s to\n%s?\n(UNVERIFIED)",
+                   amount_str, msg->to_address)) {
+        memzero(node, sizeof(*node));
+        fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                        _("Signing cancelled"));
+        layoutHome();
+        return;
+      }
+    }
+  }
+
+  /* Sign the transaction */
+  if (!tron_signTx(node, msg, resp)) {
+    memzero(node, sizeof(*node));
+    fsm_sendFailure(FailureType_Failure_Other, _("TRON signing failed"));
+    layoutHome();
+    return;
+  }
+
+  memzero(node, sizeof(*node));
+  msg_write(MessageType_MessageType_TronSignedTx, resp);
+  layoutHome();
+}

--- a/lib/firmware/messagemap.def
+++ b/lib/firmware/messagemap.def
@@ -77,6 +77,9 @@
     MSG_IN(MessageType_MessageType_SolanaSignTx,                   SolanaSignTx,                fsm_msgSolanaSignTx)
     MSG_IN(MessageType_MessageType_SolanaSignMessage,              SolanaSignMessage,           fsm_msgSolanaSignMessage)
 
+    MSG_IN(MessageType_MessageType_TronGetAddress,                  TronGetAddress,              fsm_msgTronGetAddress)
+    MSG_IN(MessageType_MessageType_TronSignTx,                      TronSignTx,                  fsm_msgTronSignTx)
+
     /* Normal Out Messages */
     MSG_OUT(MessageType_MessageType_Success,                        Success,                     NO_PROCESS_FUNC)
     MSG_OUT(MessageType_MessageType_Failure,                        Failure,                     NO_PROCESS_FUNC)
@@ -139,6 +142,9 @@
     MSG_OUT(MessageType_MessageType_SolanaAddress,                  SolanaAddress,               NO_PROCESS_FUNC)
     MSG_OUT(MessageType_MessageType_SolanaSignedTx,                 SolanaSignedTx,              NO_PROCESS_FUNC)
     MSG_OUT(MessageType_MessageType_SolanaMessageSignature,         SolanaMessageSignature,      NO_PROCESS_FUNC)
+
+    MSG_OUT(MessageType_MessageType_TronAddress,                     TronAddress,                 NO_PROCESS_FUNC)
+    MSG_OUT(MessageType_MessageType_TronSignedTx,                    TronSignedTx,                NO_PROCESS_FUNC)
 
 #if DEBUG_LINK
     /* Debug Messages */

--- a/lib/firmware/tron.c
+++ b/lib/firmware/tron.c
@@ -1,0 +1,446 @@
+/*
+ * This file is part of the KeepKey project.
+ *
+ * Copyright (C) 2024 KeepKey
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "keepkey/firmware/tron.h"
+
+#include "keepkey/crypto/curves.h"
+#include "trezor/crypto/base58.h"
+#include "trezor/crypto/ecdsa.h"
+#include "trezor/crypto/memzero.h"
+#include "trezor/crypto/secp256k1.h"
+#include "trezor/crypto/sha2.h"
+#include "trezor/crypto/sha3.h"
+
+#include <stdio.h>
+#include <string.h>
+
+/* ------------------------------------------------------------------ */
+/*  Bounded protobuf encoding helpers                                  */
+/* ------------------------------------------------------------------ */
+
+/* How many bytes a varint takes. */
+static size_t pb_varint_size(uint64_t v) {
+  size_t n = 1;
+  while (v >= 0x80) { v >>= 7; n++; }
+  return n;
+}
+
+/* Encode a varint, checking remaining capacity. */
+static bool pb_encode_varint_safe(uint8_t *buf, size_t *pos, size_t cap,
+                                  uint64_t v) {
+  size_t need = pb_varint_size(v);
+  if (*pos + need > cap) return false;
+  while (v >= 0x80) {
+    buf[(*pos)++] = (uint8_t)(v & 0x7F) | 0x80;
+    v >>= 7;
+  }
+  buf[(*pos)++] = (uint8_t)v;
+  return true;
+}
+
+/* Write a protobuf tag (field_num << 3 | wire_type). */
+static bool pb_write_tag_safe(uint8_t *buf, size_t *pos, size_t cap,
+                              unsigned field, unsigned wire) {
+  return pb_encode_varint_safe(buf, pos, cap,
+                               ((uint64_t)field << 3) | wire);
+}
+
+/* Write a length-delimited field (wire type 2). */
+static bool pb_write_bytes_safe(uint8_t *buf, size_t *pos, size_t cap,
+                                unsigned field,
+                                const uint8_t *data, size_t data_len) {
+  if (!pb_write_tag_safe(buf, pos, cap, field, 2)) return false;
+  if (!pb_encode_varint_safe(buf, pos, cap, data_len)) return false;
+  if (*pos + data_len > cap) return false;
+  memcpy(buf + *pos, data, data_len);
+  *pos += data_len;
+  return true;
+}
+
+/* Write a varint field (wire type 0). */
+static bool pb_write_varint_field_safe(uint8_t *buf, size_t *pos, size_t cap,
+                                       unsigned field, uint64_t val) {
+  if (!pb_write_tag_safe(buf, pos, cap, field, 0)) return false;
+  return pb_encode_varint_safe(buf, pos, cap, val);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Address functions                                                  */
+/* ------------------------------------------------------------------ */
+
+bool tron_getAddress(const uint8_t public_key[33], char *address,
+                     size_t address_len) {
+  if (address_len < TRON_ADDRESS_MAX_LEN) {
+    return false;
+  }
+
+  uint8_t uncompressed_pubkey[65];
+  uint8_t hash[32];
+  uint8_t addr_bytes[21];
+
+  if (!ecdsa_uncompress_pubkey(&secp256k1, public_key, uncompressed_pubkey)) {
+    return false;
+  }
+
+  keccak_256(uncompressed_pubkey + 1, 64, hash);
+
+  addr_bytes[0] = TRON_MAINNET_PREFIX;
+  memcpy(addr_bytes + 1, hash + 12, 20);
+
+  if (!base58_encode_check(addr_bytes, 21, HASHER_SHA2D, address,
+                           address_len)) {
+    memzero(uncompressed_pubkey, sizeof(uncompressed_pubkey));
+    memzero(hash, sizeof(hash));
+    return false;
+  }
+
+  memzero(uncompressed_pubkey, sizeof(uncompressed_pubkey));
+  memzero(hash, sizeof(hash));
+  return true;
+}
+
+bool tron_decodeAddress(const char *address,
+                        uint8_t raw_address[TRON_ADDRESS_SIZE]) {
+  if (!address || strlen(address) < 25 || strlen(address) > 36) {
+    return false;
+  }
+  uint8_t decoded[25];  /* 21-byte payload + 4-byte checksum */
+  int len = base58_decode_check(address, HASHER_SHA2D, decoded,
+                                sizeof(decoded));
+  if (len != 21) return false;
+  if (decoded[0] != TRON_MAINNET_PREFIX) return false;
+  memcpy(raw_address, decoded, 21);
+  return true;
+}
+
+bool tron_validateAddress(const char *address) {
+  uint8_t raw[TRON_ADDRESS_SIZE];
+  return tron_decodeAddress(address, raw);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Formatting                                                         */
+/* ------------------------------------------------------------------ */
+
+void tron_formatAmount(char *buf, size_t len, uint64_t amount) {
+  bignum256 val;
+  bn_read_uint64(amount, &val);
+  bn_format(&val, NULL, " TRX", TRON_DECIMALS, 0, false, buf, len);
+}
+
+void tron_formatTokenAmount(char *buf, size_t buf_len,
+                            const uint8_t amount_be[32],
+                            uint8_t decimals, const char *symbol) {
+  /* Check if amount fits in uint64 (first 24 bytes must be zero). */
+  bool fits_u64 = true;
+  for (int i = 0; i < 24; i++) {
+    if (amount_be[i] != 0) { fits_u64 = false; break; }
+  }
+
+  if (fits_u64) {
+    uint64_t val64 = 0;
+    for (int i = 24; i < 32; i++) {
+      val64 = (val64 << 8) | amount_be[i];
+    }
+    bignum256 bn;
+    bn_read_uint64(val64, &bn);
+    char suffix[20];
+    snprintf(suffix, sizeof(suffix), " %s", symbol);
+    bn_format(&bn, NULL, suffix, decimals, 0, false, buf, buf_len);
+  } else {
+    snprintf(buf, buf_len, "(raw) %s", symbol);
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/*  TRC-20 ABI decoding                                                */
+/* ------------------------------------------------------------------ */
+
+bool tron_decodeTRC20Transfer(const uint8_t *data, size_t data_len,
+                              uint8_t to_raw[TRON_ADDRESS_SIZE],
+                              uint8_t amount_bytes[32]) {
+  if (data_len < 68) return false;
+
+  /* Check 4-byte function selector: transfer(address,uint256) = 0xa9059cbb */
+  if (data[0] != 0xa9 || data[1] != 0x05 ||
+      data[2] != 0x9c || data[3] != 0xbb) {
+    return false;
+  }
+
+  /* Bytes 4..35: ABI-encoded address (12 zero bytes + 20-byte EVM address).
+   * TRON ABI uses standard Solidity encoding — no 0x41 prefix in the ABI.
+   * We verify the 12 leading bytes are zero, then prepend 0x41 ourselves. */
+  for (int i = 4; i < 16; i++) {
+    if (data[i] != 0) return false;
+  }
+  to_raw[0] = TRON_MAINNET_PREFIX;
+  memcpy(to_raw + 1, data + 16, 20);
+
+  /* Bytes 36..67: uint256 amount (big-endian) */
+  memcpy(amount_bytes, data + 36, 32);
+  return true;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Protobuf serialization (reconstruct-then-sign)                     */
+/* ------------------------------------------------------------------ */
+
+/* Serialize a TransferContract into a contract entry (field 11 of raw). */
+static bool tron_serializeTransferContract(uint8_t *buf, size_t *pos,
+                                           size_t cap,
+                                           const TronTransferContract *tc,
+                                           const uint8_t *owner_raw) {
+  /* Build inner TransferContract protobuf:
+   *   field 1 (bytes): owner_address (21 bytes)
+   *   field 2 (bytes): to_address    (21 bytes)
+   *   field 3 (varint): amount
+   */
+  uint8_t inner[128];
+  size_t ip = 0;
+
+  /* owner_address */
+  if (!pb_write_bytes_safe(inner, &ip, sizeof(inner), 1, owner_raw, 21))
+    return false;
+
+  /* to_address — decode from Base58 */
+  uint8_t to_raw[TRON_ADDRESS_SIZE];
+  if (!tron_decodeAddress(tc->to_address, to_raw)) return false;
+  if (!pb_write_bytes_safe(inner, &ip, sizeof(inner), 2, to_raw, 21))
+    return false;
+
+  /* amount */
+  if (!pb_write_varint_field_safe(inner, &ip, sizeof(inner), 3, tc->amount))
+    return false;
+
+  /* Build contract wrapper:
+   *   field 1 (varint): type = 1 (TransferContract)
+   *   field 2 (bytes): google.protobuf.Any {
+   *     field 1 (bytes): type_url
+   *     field 2 (bytes): value = inner
+   *   }
+   */
+  static const char type_url[] =
+      "type.googleapis.com/protocol.TransferContract";
+  uint8_t any[256];
+  size_t ap = 0;
+  if (!pb_write_bytes_safe(any, &ap, sizeof(any), 1,
+                           (const uint8_t *)type_url, strlen(type_url)))
+    return false;
+  if (!pb_write_bytes_safe(any, &ap, sizeof(any), 2, inner, ip))
+    return false;
+
+  uint8_t contract[300];
+  size_t cp = 0;
+  if (!pb_write_varint_field_safe(contract, &cp, sizeof(contract), 1, 1))
+    return false;
+  if (!pb_write_bytes_safe(contract, &cp, sizeof(contract), 2, any, ap))
+    return false;
+
+  /* Write as field 11 of the outer transaction.raw */
+  return pb_write_bytes_safe(buf, pos, cap, 11, contract, cp);
+}
+
+/* Serialize a TriggerSmartContract into a contract entry. */
+static bool tron_serializeTriggerSmartContract(
+    uint8_t *buf, size_t *pos, size_t cap,
+    const TronTriggerSmartContract *tsc, const uint8_t *owner_raw) {
+  /* Inner TriggerSmartContract:
+   *   field 1 (bytes): owner_address (21)
+   *   field 2 (bytes): contract_address (21)
+   *   field 3 (bytes): data (ABI call data)
+   *   field 4 (varint): call_value
+   */
+  uint8_t inner[700];
+  size_t ip = 0;
+
+  if (!pb_write_bytes_safe(inner, &ip, sizeof(inner), 1, owner_raw, 21))
+    return false;
+
+  uint8_t contract_raw[TRON_ADDRESS_SIZE];
+  if (!tron_decodeAddress(tsc->contract_address, contract_raw)) return false;
+  if (!pb_write_bytes_safe(inner, &ip, sizeof(inner), 2, contract_raw, 21))
+    return false;
+
+  if (tsc->has_data && tsc->data.size > 0) {
+    if (!pb_write_bytes_safe(inner, &ip, sizeof(inner), 3,
+                             tsc->data.bytes, tsc->data.size))
+      return false;
+  }
+
+  if (tsc->has_call_value && tsc->call_value > 0) {
+    if (!pb_write_varint_field_safe(inner, &ip, sizeof(inner), 4,
+                                    tsc->call_value))
+      return false;
+  }
+
+  /* Wrap in Any with type_url for TriggerSmartContract */
+  static const char type_url[] =
+      "type.googleapis.com/protocol.TriggerSmartContract";
+  uint8_t any[768];
+  size_t ap = 0;
+  if (!pb_write_bytes_safe(any, &ap, sizeof(any), 1,
+                           (const uint8_t *)type_url, strlen(type_url)))
+    return false;
+  if (!pb_write_bytes_safe(any, &ap, sizeof(any), 2, inner, ip))
+    return false;
+
+  /* contract type = 31 for TriggerSmartContract */
+  uint8_t contract[900];
+  size_t cpp = 0;
+  if (!pb_write_varint_field_safe(contract, &cpp, sizeof(contract), 1, 31))
+    return false;
+  if (!pb_write_bytes_safe(contract, &cpp, sizeof(contract), 2, any, ap))
+    return false;
+
+  return pb_write_bytes_safe(buf, pos, cap, 11, contract, cpp);
+}
+
+bool tron_serializeRawTransaction(const TronSignTx *msg,
+                                  const uint8_t *owner_raw,
+                                  uint8_t *out, size_t *out_len,
+                                  size_t max_len) {
+  size_t pos = 0;
+
+  /* Field 1: ref_block_bytes (2 bytes required) */
+  if (!msg->has_ref_block_bytes || msg->ref_block_bytes.size != 2)
+    return false;
+  if (!pb_write_bytes_safe(out, &pos, max_len, 1,
+                           msg->ref_block_bytes.bytes, 2))
+    return false;
+
+  /* Field 4: ref_block_hash (8 bytes required) */
+  if (!msg->has_ref_block_hash || msg->ref_block_hash.size != 8)
+    return false;
+  if (!pb_write_bytes_safe(out, &pos, max_len, 4,
+                           msg->ref_block_hash.bytes, 8))
+    return false;
+
+  /* Field 8: expiration */
+  if (!msg->has_expiration) return false;
+  if (!pb_write_varint_field_safe(out, &pos, max_len, 8, msg->expiration))
+    return false;
+
+  /* Field 10: data/memo (optional, max 256 bytes) */
+  if (msg->has_data && msg->data.size > 0) {
+    if (msg->data.size > 256) return false;
+    if (!pb_write_bytes_safe(out, &pos, max_len, 10,
+                             msg->data.bytes, msg->data.size))
+      return false;
+  }
+
+  /* Field 11: contract (exactly one) */
+  if (msg->has_transfer) {
+    if (!tron_serializeTransferContract(out, &pos, max_len,
+                                        &msg->transfer, owner_raw))
+      return false;
+  } else if (msg->has_trigger_smart) {
+    if (!tron_serializeTriggerSmartContract(out, &pos, max_len,
+                                            &msg->trigger_smart, owner_raw))
+      return false;
+  } else {
+    return false;  /* Must have exactly one contract */
+  }
+
+  /* Field 14: timestamp (optional) */
+  if (msg->has_timestamp) {
+    if (!pb_write_varint_field_safe(out, &pos, max_len, 14, msg->timestamp))
+      return false;
+  }
+
+  /* Field 18: fee_limit (optional) */
+  if (msg->has_fee_limit && msg->fee_limit > 0) {
+    if (!pb_write_varint_field_safe(out, &pos, max_len, 18, msg->fee_limit))
+      return false;
+  }
+
+  *out_len = pos;
+  return true;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Transaction signing                                                */
+/* ------------------------------------------------------------------ */
+
+bool tron_signTx(const HDNode *node, const TronSignTx *msg,
+                 TronSignedTx *resp) {
+  if (!node || !msg || !resp) return false;
+
+  const curve_info *curve = get_curve_by_name(SECP256K1_NAME);
+  if (!curve) return false;
+
+  uint8_t hash[32];
+  bool is_structured = msg->has_transfer || msg->has_trigger_smart;
+
+  if (is_structured) {
+    /* Derive owner address from public key */
+    uint8_t owner_raw[TRON_ADDRESS_SIZE];
+    {
+      uint8_t uncompressed[65];
+      uint8_t keccak[32];
+      if (!ecdsa_uncompress_pubkey(&secp256k1, node->public_key, uncompressed))
+        return false;
+      keccak_256(uncompressed + 1, 64, keccak);
+      owner_raw[0] = TRON_MAINNET_PREFIX;
+      memcpy(owner_raw + 1, keccak + 12, 20);
+      memzero(uncompressed, sizeof(uncompressed));
+      memzero(keccak, sizeof(keccak));
+    }
+
+    /* Reconstruct the raw transaction */
+    uint8_t raw_buf[1024];
+    size_t raw_len = sizeof(raw_buf);
+    if (!tron_serializeRawTransaction(msg, owner_raw, raw_buf, &raw_len,
+                                      sizeof(raw_buf))) {
+      memzero(owner_raw, sizeof(owner_raw));
+      return false;
+    }
+    memzero(owner_raw, sizeof(owner_raw));
+
+    /* Return the serialized bytes for host verification */
+    resp->has_serialized_tx = true;
+    resp->serialized_tx.size = raw_len;
+    memcpy(resp->serialized_tx.bytes, raw_buf, raw_len);
+
+    sha256_Raw(raw_buf, raw_len, hash);
+    memzero(raw_buf, sizeof(raw_buf));
+  } else if (msg->has_raw_data && msg->raw_data.size > 0) {
+    /* Legacy: hash the client-provided raw_data */
+    sha256_Raw(msg->raw_data.bytes, msg->raw_data.size, hash);
+  } else {
+    return false;
+  }
+
+  /* Sign with secp256k1 */
+  uint8_t sig[65];
+  uint8_t pby;
+  if (ecdsa_sign_digest(&secp256k1, node->private_key, hash, sig, &pby,
+                        NULL) != 0) {
+    memzero(hash, sizeof(hash));
+    return false;
+  }
+  sig[64] = pby;
+
+  resp->has_signature = true;
+  resp->signature.size = 65;
+  memcpy(resp->signature.bytes, sig, 65);
+
+  memzero(hash, sizeof(hash));
+  memzero(sig, sizeof(sig));
+  return true;
+}

--- a/lib/firmware/tron_tokens.h
+++ b/lib/firmware/tron_tokens.h
@@ -1,0 +1,45 @@
+/*
+ * Hardcoded TRC-20 token definitions for on-device display.
+ * Only high-volume tokens are included; unknown tokens show as raw amounts.
+ */
+
+#ifndef KEEPKEY_FIRMWARE_TRON_TOKENS_H
+#define KEEPKEY_FIRMWARE_TRON_TOKENS_H
+
+#include <stddef.h>
+#include <string.h>
+
+typedef struct {
+  const char *address;   // Base58Check contract address
+  const char *symbol;    // Token ticker
+  uint8_t decimals;      // Token decimal places
+} TronToken;
+
+static const TronToken tron_tokens[] = {
+    {"TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t", "USDT",  6},
+    {"TPYmHEhy5n8TCEfYGqW2rPxsghSfzghPDn", "USDD",  18},
+    {"TSSMHYeV2uE9qYH95DqyoCuNCzEL1NvU3S", "SUN",   18},
+    {"TCFLL5dx5ZJdKnWuesXxi1VPwjLVmWZZy9", "JST",   18},
+    {"TAFjULxiVgT4qWk6UZwjqwZXTSaGaqnVp4", "BTT",   18},
+    {"TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7", "WIN",    6},
+    {"TXpw8XeWYeTUd4quDskoUqeQPowRh4jY65", "WBTC",   8},
+    {"THb4CqiFdwNHsWsQCs4JhzwjMWys4aqCbF", "ETH",   18},
+    {"TDPJwSHLPDqvDeX1JLkP2z1szHEhLLVBFq", "USD1",   6},
+    {"TUPM7K8REVzD2UdV4R5fe5M8XbnR2DdoJ6", "HTX",   18},
+    {"TUpMhErZL2fhh4sVNULAbNKLokS4GjC1F4", "TUSD",  18},
+    {"TEkxiTehnzSmSe2XqrBj4w32RUN966rdz8", "USDC",   6},
+};
+
+#define TRON_TOKEN_COUNT (sizeof(tron_tokens) / sizeof(tron_tokens[0]))
+
+static inline const TronToken *tron_token_by_address(
+    const char *contract_address) {
+  for (size_t i = 0; i < TRON_TOKEN_COUNT; i++) {
+    if (strcmp(tron_tokens[i].address, contract_address) == 0) {
+      return &tron_tokens[i];
+    }
+  }
+  return NULL;
+}
+
+#endif

--- a/unittests/firmware/tron.cpp
+++ b/unittests/firmware/tron.cpp
@@ -1,0 +1,128 @@
+extern "C" {
+#include "keepkey/firmware/tron.h"
+#include "messages-tron.pb.h"
+#include <string.h>
+}
+
+#include "gtest/gtest.h"
+
+/* ------------------------------------------------------------------ */
+/*  Address encoding / decoding tests                                  */
+/* ------------------------------------------------------------------ */
+
+TEST(Tron, DecodeValidAddress) {
+  // TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t  (USDT contract)
+  uint8_t raw[TRON_ADDRESS_SIZE];
+  ASSERT_TRUE(tron_decodeAddress("TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t", raw));
+  EXPECT_EQ(raw[0], 0x41);
+}
+
+TEST(Tron, DecodeInvalidAddress) {
+  uint8_t raw[TRON_ADDRESS_SIZE];
+  // Too short
+  EXPECT_FALSE(tron_decodeAddress("T", raw));
+  // Bad checksum
+  EXPECT_FALSE(tron_decodeAddress("TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6X", raw));
+  // NULL
+  EXPECT_FALSE(tron_decodeAddress(NULL, raw));
+}
+
+TEST(Tron, ValidateAddress) {
+  EXPECT_TRUE(tron_validateAddress("TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t"));
+  EXPECT_FALSE(tron_validateAddress("TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6X"));
+  EXPECT_FALSE(tron_validateAddress(NULL));
+}
+
+/* ------------------------------------------------------------------ */
+/*  TRC-20 ABI decoding tests                                          */
+/* ------------------------------------------------------------------ */
+
+TEST(Tron, DecodeTRC20Transfer) {
+  // Real TRC-20 transfer(address,uint256) ABI encoding:
+  // selector: a9059cbb
+  // to: 000000000000000000000000 + 20-byte EVM address
+  // amount: 32-byte big-endian
+  uint8_t data[68];
+  memset(data, 0, sizeof(data));
+
+  // selector
+  data[0] = 0xa9; data[1] = 0x05; data[2] = 0x9c; data[3] = 0xbb;
+  // EVM address at bytes 16..35 (12 zero pad + 20 addr)
+  data[16] = 0xDE; data[17] = 0xAD; data[35] = 0xBE;
+  // Amount: 1000000 (0xF4240) at last 3 bytes
+  data[65] = 0x0F; data[66] = 0x42; data[67] = 0x40;
+
+  uint8_t to_raw[TRON_ADDRESS_SIZE];
+  uint8_t amount[32];
+  ASSERT_TRUE(tron_decodeTRC20Transfer(data, sizeof(data), to_raw, amount));
+
+  // Must prepend 0x41 TRON prefix
+  EXPECT_EQ(to_raw[0], 0x41);
+  EXPECT_EQ(to_raw[1], 0xDE);
+  EXPECT_EQ(to_raw[2], 0xAD);
+
+  // Amount check
+  EXPECT_EQ(amount[29], 0x0F);
+  EXPECT_EQ(amount[30], 0x42);
+  EXPECT_EQ(amount[31], 0x40);
+}
+
+TEST(Tron, DecodeTRC20WrongSelector) {
+  uint8_t data[68];
+  memset(data, 0, sizeof(data));
+  data[0] = 0x12; data[1] = 0x34; data[2] = 0x56; data[3] = 0x78;
+
+  uint8_t to_raw[TRON_ADDRESS_SIZE];
+  uint8_t amount[32];
+  EXPECT_FALSE(tron_decodeTRC20Transfer(data, sizeof(data), to_raw, amount));
+}
+
+TEST(Tron, DecodeTRC20TooShort) {
+  uint8_t data[60];
+  memset(data, 0, sizeof(data));
+  data[0] = 0xa9; data[1] = 0x05; data[2] = 0x9c; data[3] = 0xbb;
+
+  uint8_t to_raw[TRON_ADDRESS_SIZE];
+  uint8_t amount[32];
+  EXPECT_FALSE(tron_decodeTRC20Transfer(data, sizeof(data), to_raw, amount));
+}
+
+TEST(Tron, DecodeTRC20NonZeroPadding) {
+  // If the 12 leading pad bytes aren't all zero, reject
+  uint8_t data[68];
+  memset(data, 0, sizeof(data));
+  data[0] = 0xa9; data[1] = 0x05; data[2] = 0x9c; data[3] = 0xbb;
+  data[4] = 0x01;  // non-zero in padding area
+
+  uint8_t to_raw[TRON_ADDRESS_SIZE];
+  uint8_t amount[32];
+  EXPECT_FALSE(tron_decodeTRC20Transfer(data, sizeof(data), to_raw, amount));
+}
+
+/* ------------------------------------------------------------------ */
+/*  Formatting tests                                                   */
+/* ------------------------------------------------------------------ */
+
+TEST(Tron, FormatAmount) {
+  char buf[64];
+
+  tron_formatAmount(buf, sizeof(buf), 1000000);  // 1 TRX
+  EXPECT_STREQ(buf, "1 TRX");
+
+  tron_formatAmount(buf, sizeof(buf), 500000);  // 0.5 TRX
+  EXPECT_STREQ(buf, "0.5 TRX");
+
+  tron_formatAmount(buf, sizeof(buf), 0);
+  EXPECT_STREQ(buf, "0 TRX");
+}
+
+TEST(Tron, FormatTokenAmount) {
+  char buf[64];
+
+  // 1 USDT (6 decimals) = 1000000
+  uint8_t amount1[32];
+  memset(amount1, 0, 32);
+  amount1[29] = 0x0F; amount1[30] = 0x42; amount1[31] = 0x40;  // 1000000
+  tron_formatTokenAmount(buf, sizeof(buf), amount1, 6, "USDT");
+  EXPECT_STREQ(buf, "1 USDT");
+}


### PR DESCRIPTION
## Summary
TRON with protobuf deserialization and reconstruct-then-sign. 13 hardcoded TRC-20 tokens. Device reconstructs tx hash from parsed fields for clear-sign path.

## Files
- `tron.h` / `tron.c` — Base58Check, protobuf parser, tx reconstruction
- `fsm_msg_tron.h` — GetAddress, SignTx handlers
- `tron_tokens.h` — 13 TRC-20 token definitions
- `tron.cpp` — Unit tests
- Wiring: fsm.h, fsm.c, messagemap.def, CMakeLists.txt, messages-tron.options

## Test plan
- [ ] T1-T7 TRON tests pass
- [ ] OLED: full 34-char base58 TRON address displayed
- [ ] No regression on existing chains