### PR TITLE
feat: Zcash Orchard shielded transactions + transparent shielding

### DIFF
--- a/.cppcheck-suppressions
+++ b/.cppcheck-suppressions
@@ -6,6 +6,7 @@ returnDanglingLifetime:lib/firmware/tiny-json.c
 memleakOnRealloc:lib/transport/pb_decode.c
 uninitvar:lib/board/messages.c
 bufferAccessOutOfBounds:lib/firmware/storage.c
+identicalInnerCondition:lib/firmware/storage.c
 subtractPointers:tools/blupdater/main.c
 comparePointers:tools/blupdater/main.c
 ctunullpointer

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "deps/device-protocol"]
 path = deps/device-protocol
-url = https://github.com/keepkey/device-protocol.git
+url = https://github.com/BitHighlander/device-protocol.git
 branch = master
 [submodule "deps/trezor-firmware"]
 path = deps/crypto/trezor-firmware
@@ -13,7 +13,7 @@ path = code-signing-keys
 url = https://github.com/keepkey/code-signing-keys.git
 [submodule "deps/python-keepkey"]
 path = deps/python-keepkey
-url = https://github.com/keepkey/python-keepkey.git
+url = https://github.com/BitHighlander/python-keepkey.git
 branch = master
 [submodule "deps/qrenc/QR-Code-generator"]
 path = deps/qrenc/QR-Code-generator

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "deps/device-protocol"]
 path = deps/device-protocol
-url = https://github.com/BitHighlander/device-protocol.git
+url = https://github.com/keepkey/device-protocol.git
 branch = master
 [submodule "deps/trezor-firmware"]
 path = deps/crypto/trezor-firmware
@@ -14,7 +14,7 @@ url = https://github.com/keepkey/code-signing-keys.git
 [submodule "deps/python-keepkey"]
 path = deps/python-keepkey
 url = https://github.com/BitHighlander/python-keepkey.git
-branch = master
+branch = features/7.15-dev
 [submodule "deps/qrenc/QR-Code-generator"]
 path = deps/qrenc/QR-Code-generator
 url = https://github.com/keepkey/QR-Code-generator.git

--- a/deps/crypto/CMakeLists.txt
+++ b/deps/crypto/CMakeLists.txt
@@ -55,7 +55,9 @@ set(sources
     trezor-firmware/crypto/aes/aescrypt.c
     trezor-firmware/crypto/aes/aes_modes.c
     #trezor-firmware/crypto/aes/aestst.c
-    trezor-firmware/crypto/aes/aestab.c)
+    trezor-firmware/crypto/aes/aestab.c
+    trezor-firmware/crypto/pallas.c
+    trezor-firmware/crypto/redpallas.c)
 
     # Clang 5.0 in the docker image (kktech/firmware:v7) is missing
     # <xmmintrin.h>, which breaks these. Until they're needed, we'll just elide

--- a/include/keepkey/firmware/fsm.h
+++ b/include/keepkey/firmware/fsm.h
@@ -129,4 +129,10 @@ void fsm_msgFlashWrite(FlashWrite* msg);
 void fsm_msgFlashHash(FlashHash* msg);
 void fsm_msgSoftReset(SoftReset* msg);
 
+
+void fsm_msgZcashSignPczt(const ZcashSignPCZT *msg);
+void fsm_msgZcashPcztAction(const ZcashPCZTAction *msg);
+void fsm_msgZcashGetOrchardFvk(const ZcashGetOrchardFVK *msg);
+void fsm_msgZcashTransparentInput(const ZcashTransparentInput *msg);
+
 #endif

--- a/include/keepkey/firmware/fsm.h
+++ b/include/keepkey/firmware/fsm.h
@@ -129,10 +129,4 @@ void fsm_msgFlashWrite(FlashWrite* msg);
 void fsm_msgFlashHash(FlashHash* msg);
 void fsm_msgSoftReset(SoftReset* msg);
 
-
-void fsm_msgZcashSignPCZT(const ZcashSignPCZT *msg);
-void fsm_msgZcashPCZTAction(const ZcashPCZTAction *msg);
-void fsm_msgZcashGetOrchardFVK(const ZcashGetOrchardFVK *msg);
-void fsm_msgZcashTransparentInput(const ZcashTransparentInput *msg);
-
 #endif

--- a/include/keepkey/firmware/fsm.h
+++ b/include/keepkey/firmware/fsm.h
@@ -130,9 +130,9 @@ void fsm_msgFlashHash(FlashHash* msg);
 void fsm_msgSoftReset(SoftReset* msg);
 
 
-void fsm_msgZcashSignPczt(const ZcashSignPCZT *msg);
-void fsm_msgZcashPcztAction(const ZcashPCZTAction *msg);
-void fsm_msgZcashGetOrchardFvk(const ZcashGetOrchardFVK *msg);
+void fsm_msgZcashSignPCZT(const ZcashSignPCZT *msg);
+void fsm_msgZcashPCZTAction(const ZcashPCZTAction *msg);
+void fsm_msgZcashGetOrchardFVK(const ZcashGetOrchardFVK *msg);
 void fsm_msgZcashTransparentInput(const ZcashTransparentInput *msg);
 
 #endif

--- a/include/keepkey/firmware/storage.h
+++ b/include/keepkey/firmware/storage.h
@@ -174,16 +174,16 @@ bool storage_hasMnemonic(void);
 /// \returns true iff the active storage has a HDNode.
 bool storage_hasNode(void);
 
-const char *storage_getPin(void);
-const char *storage_getMnemonic(void);
-HDNode *storage_getNode(void);
-void storage_dumpNode(HDNodeType *dst, const HDNode *src);
+const char* storage_getPin(void);
+const char* storage_getMnemonic(void);
+HDNode* storage_getNode(void);
+void storage_dumpNode(HDNodeType* dst, const HDNode* src);
 
 /// Return the 64-byte BIP-39 seed (PBKDF2 output).
 /// Needed by ZIP-32 Orchard which derives keys from the raw seed,
 /// not from a BIP-32 root node.  The returned pointer is to a
 /// CONFIDENTIAL session buffer — it MUST NOT be serialized to USB.
-const uint8_t *storage_getRawSeed(bool usePassphrase);
+const uint8_t* storage_getRawSeed(bool usePassphrase);
 #endif
 
 #endif

--- a/include/keepkey/firmware/storage.h
+++ b/include/keepkey/firmware/storage.h
@@ -174,10 +174,16 @@ bool storage_hasMnemonic(void);
 /// \returns true iff the active storage has a HDNode.
 bool storage_hasNode(void);
 
-const char* storage_getPin(void);
-const char* storage_getMnemonic(void);
-HDNode* storage_getNode(void);
-void storage_dumpNode(HDNodeType* dst, const HDNode* src);
+const char *storage_getPin(void);
+const char *storage_getMnemonic(void);
+HDNode *storage_getNode(void);
+void storage_dumpNode(HDNodeType *dst, const HDNode *src);
+
+/// Return the 64-byte BIP-39 seed (PBKDF2 output).
+/// Needed by ZIP-32 Orchard which derives keys from the raw seed,
+/// not from a BIP-32 root node.  The returned pointer is to a
+/// CONFIDENTIAL session buffer — it MUST NOT be serialized to USB.
+const uint8_t *storage_getRawSeed(bool usePassphrase);
 #endif
 
 #endif

--- a/include/keepkey/firmware/zcash.h
+++ b/include/keepkey/firmware/zcash.h
@@ -1,0 +1,70 @@
+/*
+ * This file is part of the KeepKey project.
+ *
+ * Copyright (C) 2025 KeepKey
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPKEY_FIRMWARE_ZCASH_H
+#define KEEPKEY_FIRMWARE_ZCASH_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/* Orchard spending keys derived via ZIP-32 */
+typedef struct {
+  uint8_t sk[32];    /* Spending key (master secret at this level) */
+  uint8_t ask[32];   /* Spend authorizing key (scalar) */
+  uint8_t nk[32];    /* Nullifier deriving key */
+  uint8_t rivk[32];  /* Commitment randomness key */
+} ZcashOrchardKeys;
+
+/**
+ * Derive Orchard spending keys from the device seed via ZIP-32.
+ * Path: m_orchard / 32' / 133' / account'
+ *
+ * Uses BLAKE2b with personalization "ZcashIP32Orchard" for key derivation.
+ *
+ * @param seed       BIP-39 master seed
+ * @param seed_len   Seed length (typically 64 bytes)
+ * @param account    Account index (0-based, will be hardened)
+ * @param keys       Output: derived Orchard keys
+ * @return true on success
+ */
+bool zcash_derive_orchard_keys(const uint8_t *seed, uint32_t seed_len,
+                               uint32_t account, ZcashOrchardKeys *keys);
+
+/**
+ * Compute the ZIP 244 shielded sighash for Orchard spend authorization.
+ *
+ * For shielded-only transactions, transparent_sig_digest uses the "no inputs"
+ * form. For mixed transactions, transparent data must be provided separately.
+ *
+ * @param header_digest     32-byte pre-computed header digest
+ * @param transparent_digest 32-byte transparent sig digest (or empty hash)
+ * @param sapling_digest    32-byte sapling digest (or empty hash)
+ * @param orchard_digest    32-byte orchard digest
+ * @param branch_id         Consensus branch ID (LE)
+ * @param sighash_out       32-byte output sighash
+ * @return true on success
+ */
+bool zcash_compute_shielded_sighash(const uint8_t header_digest[32],
+                                    const uint8_t transparent_digest[32],
+                                    const uint8_t sapling_digest[32],
+                                    const uint8_t orchard_digest[32],
+                                    uint32_t branch_id,
+                                    uint8_t sighash_out[32]);
+
+#endif

--- a/include/keepkey/firmware/zcash.h
+++ b/include/keepkey/firmware/zcash.h
@@ -25,10 +25,10 @@
 
 /* Orchard spending keys derived via ZIP-32 */
 typedef struct {
-  uint8_t sk[32];    /* Spending key (master secret at this level) */
-  uint8_t ask[32];   /* Spend authorizing key (scalar) */
-  uint8_t nk[32];    /* Nullifier deriving key */
-  uint8_t rivk[32];  /* Commitment randomness key */
+  uint8_t sk[32];   /* Spending key (master secret at this level) */
+  uint8_t ask[32];  /* Spend authorizing key (scalar) */
+  uint8_t nk[32];   /* Nullifier deriving key */
+  uint8_t rivk[32]; /* Commitment randomness key */
 } ZcashOrchardKeys;
 
 /**
@@ -43,8 +43,8 @@ typedef struct {
  * @param keys       Output: derived Orchard keys
  * @return true on success
  */
-bool zcash_derive_orchard_keys(const uint8_t *seed, uint32_t seed_len,
-                               uint32_t account, ZcashOrchardKeys *keys);
+bool zcash_derive_orchard_keys(const uint8_t* seed, uint32_t seed_len,
+                               uint32_t account, ZcashOrchardKeys* keys);
 
 /**
  * Compute the ZIP 244 shielded sighash for Orchard spend authorization.

--- a/include/keepkey/transport/interface.h
+++ b/include/keepkey/transport/interface.h
@@ -35,6 +35,10 @@
 #include "messages-tendermint.pb.h"
 #include "messages-thorchain.pb.h"
 #include "messages-mayachain.pb.h"
+#include "messages-solana.pb.h"
+#include "messages-tron.pb.h"
+#include "messages-ton.pb.h"
+#include "messages-zcash.pb.h"
 
 #include "types.pb.h"
 #include "trezor_transport.h"

--- a/include/keepkey/transport/messages-ethereum.options
+++ b/include/keepkey/transport/messages-ethereum.options
@@ -47,3 +47,6 @@ Ethereum712TypesValues.eip712types               max_size:2048
 Ethereum712TypesValues.eip712primetype           max_size:80
 Ethereum712TypesValues.eip712data			          max_size:2048
 
+EthereumTxMetadata.signed_payload                max_size:1024
+EthereumMetadataAck.display_summary              max_size:32
+

--- a/include/keepkey/transport/messages-solana.options
+++ b/include/keepkey/transport/messages-solana.options
@@ -1,11 +1,15 @@
 SolanaGetAddress.address_n max_count:8
 SolanaGetAddress.coin_name max_size:21
 
-SolanaAddress.address max_size:64
+SolanaAddress.address max_size:45
+
+SolanaTokenInfo.mint max_size:32
+SolanaTokenInfo.symbol max_size:13
 
 SolanaSignTx.address_n max_count:8
 SolanaSignTx.coin_name max_size:21
-SolanaSignTx.raw_tx max_size:2048
+SolanaSignTx.raw_tx max_size:1232
+SolanaSignTx.token_info max_count:4
 
 SolanaSignedTx.signature max_size:64
 

--- a/include/keepkey/transport/messages-ton.options
+++ b/include/keepkey/transport/messages-ton.options
@@ -8,5 +8,8 @@ TonSignTx.address_n max_count:8
 TonSignTx.coin_name max_size:21
 TonSignTx.raw_tx max_size:1024
 TonSignTx.to_address max_size:50
+TonSignTx.memo max_size:121
 
+TonAddress.address max_size:50
+TonAddress.raw_address max_size:70
 TonSignedTx.signature max_size:64

--- a/include/keepkey/transport/messages-tron.options
+++ b/include/keepkey/transport/messages-tron.options
@@ -3,12 +3,19 @@ TronGetAddress.coin_name max_size:21
 
 TronAddress.address max_size:35
 
+TronTransferContract.to_address max_size:35
+
+TronTriggerSmartContract.contract_address max_size:35
+TronTriggerSmartContract.data max_size:512
+
 TronSignTx.address_n max_count:8
 TronSignTx.coin_name max_size:21
-TronSignTx.raw_data max_size:2048
-TronSignTx.ref_block_bytes max_size:4
-TronSignTx.ref_block_hash max_size:32
+TronSignTx.raw_data max_size:1024
+TronSignTx.ref_block_bytes max_size:2
+TronSignTx.ref_block_hash max_size:8
 TronSignTx.contract_type max_size:64
 TronSignTx.to_address max_size:35
+TronSignTx.data max_size:256
 
 TronSignedTx.signature max_size:65
+TronSignedTx.serialized_tx max_size:1024

--- a/include/keepkey/transport/messages-zcash.options
+++ b/include/keepkey/transport/messages-zcash.options
@@ -1,0 +1,38 @@
+ZcashSignPCZT.address_n                             max_count:10
+ZcashSignPCZT.pczt_data                             max_size:0
+ZcashSignPCZT.total_amount                          int_size:IS_64
+ZcashSignPCZT.fee                                   int_size:IS_64
+ZcashSignPCZT.header_digest                         max_size:32
+ZcashSignPCZT.transparent_digest                    max_size:32
+ZcashSignPCZT.sapling_digest                        max_size:32
+ZcashSignPCZT.orchard_digest                        max_size:32
+ZcashSignPCZT.orchard_value_balance                 int_size:IS_64
+ZcashSignPCZT.orchard_anchor                        max_size:32
+
+ZcashPCZTAction.alpha                               max_size:32
+ZcashPCZTAction.sighash                             max_size:32
+ZcashPCZTAction.cv_net                              max_size:32
+ZcashPCZTAction.value                               int_size:IS_64
+ZcashPCZTAction.nullifier                           max_size:32
+ZcashPCZTAction.cmx                                 max_size:32
+ZcashPCZTAction.epk                                 max_size:32
+ZcashPCZTAction.enc_compact                         max_size:52
+ZcashPCZTAction.enc_memo                            max_size:512
+ZcashPCZTAction.enc_noncompact                      max_size:564
+ZcashPCZTAction.rk                                  max_size:32
+ZcashPCZTAction.out_ciphertext                      max_size:80
+
+ZcashSignedPCZT.signatures                          max_count:16, max_size:64
+ZcashSignedPCZT.txid                                max_size:32
+
+ZcashGetOrchardFVK.address_n                        max_count:10
+
+ZcashOrchardFVK.ak                                  max_size:32
+ZcashOrchardFVK.nk                                  max_size:32
+ZcashOrchardFVK.rivk                                max_size:32
+
+ZcashTransparentInput.sighash                       max_size:32
+ZcashTransparentInput.address_n                     max_count:8
+ZcashTransparentInput.amount                        int_size:IS_64
+
+ZcashTransparentSig.signature                       max_size:73

--- a/include/keepkey/transport/messages-zcash.options
+++ b/include/keepkey/transport/messages-zcash.options
@@ -36,3 +36,11 @@ ZcashTransparentInput.address_n                     max_count:8
 ZcashTransparentInput.amount                        int_size:IS_64
 
 ZcashTransparentSig.signature                       max_size:73
+
+# TODO: ZcashDisplayAddress/ZcashAddress options — re-enable when proto is in upstream device-protocol
+# ZcashDisplayAddress.address_n                       max_count:8
+# ZcashDisplayAddress.address                         max_size:128
+# ZcashDisplayAddress.ak                              max_size:32
+# ZcashDisplayAddress.nk                              max_size:32
+# ZcashDisplayAddress.rivk                            max_size:32
+# ZcashAddress.address                                max_size:128

--- a/include/keepkey/transport/messages.options
+++ b/include/keepkey/transport/messages.options
@@ -5,7 +5,7 @@ Features.label				max_size:33
 Features.coins				max_count:0
 Features.revision			max_size:41
 Features.bootloader_hash		max_size:32
-Features.policies			max_count:6
+Features.policies			max_count:4
 Features.model              max_size:32
 Features.firmware_variant    max_size:32
 Features.firmware_hash		max_size:32

--- a/include/keepkey/transport/messages.options
+++ b/include/keepkey/transport/messages.options
@@ -5,7 +5,7 @@ Features.label				max_size:33
 Features.coins				max_count:0
 Features.revision			max_size:41
 Features.bootloader_hash		max_size:32
-Features.policies			max_count:4
+Features.policies			max_count:6
 Features.model              max_size:32
 Features.firmware_variant    max_size:32
 Features.firmware_hash		max_size:32

--- a/lib/firmware/CMakeLists.txt
+++ b/lib/firmware/CMakeLists.txt
@@ -2,6 +2,7 @@ set(sources
     app_confirm.c
     app_layout.c
     authenticator.c
+    zcash.c
     binance.c
     coins.c
     crypto.c

--- a/lib/firmware/fsm.c
+++ b/lib/firmware/fsm.c
@@ -46,6 +46,7 @@
 #include "keepkey/firmware/fsm.h"
 #include "keepkey/firmware/home_sm.h"
 #include "keepkey/firmware/mayachain.h"
+#include "keepkey/firmware/zcash.h"
 #include "keepkey/firmware/osmosis.h"
 #include "keepkey/firmware/passphrase_sm.h"
 #include "keepkey/firmware/pin_sm.h"
@@ -284,3 +285,4 @@ void fsm_msgClearSession(ClearSession* msg) {
 #include "fsm_msg_tendermint.h"
 #include "fsm_msg_thorchain.h"
 #include "fsm_msg_mayachain.h"
+#include "fsm_msg_zcash.h"

--- a/lib/firmware/fsm.c
+++ b/lib/firmware/fsm.c
@@ -85,6 +85,7 @@
 #include "messages-ripple.pb.h"
 #include "messages-thorchain.pb.h"
 #include "messages-mayachain.pb.h"
+#include "messages-zcash.pb.h"
 
 #include <stdio.h>
 

--- a/lib/firmware/fsm_msg_zcash.h
+++ b/lib/firmware/fsm_msg_zcash.h
@@ -106,8 +106,8 @@ void fsm_msgZcashSignPCZT(const ZcashSignPCZT *msg) {
   }
 
   /* Confirm with user */
-  char amount_str[32];
-  char fee_str[32];
+  char amount_str[48];
+  char fee_str[48];
   uint64_t total = msg->has_total_amount ? msg->total_amount : 0;
   uint64_t fee = msg->has_fee ? msg->fee : 0;
 

--- a/lib/firmware/fsm_msg_zcash.h
+++ b/lib/firmware/fsm_msg_zcash.h
@@ -111,13 +111,30 @@ void fsm_msgZcashSignPCZT(const ZcashSignPCZT *msg) {
   uint64_t total = msg->has_total_amount ? msg->total_amount : 0;
   uint64_t fee = msg->has_fee ? msg->fee : 0;
 
-  /* Format amounts (1 ZEC = 100,000,000 zatoshis) */
-  snprintf(amount_str, sizeof(amount_str), "%llu.%08llu ZEC",
-           (unsigned long long)(total / 100000000ULL),
-           (unsigned long long)(total % 100000000ULL));
-  snprintf(fee_str, sizeof(fee_str), "%llu.%08llu ZEC",
-           (unsigned long long)(fee / 100000000ULL),
-           (unsigned long long)(fee % 100000000ULL));
+  /* Format amounts (1 ZEC = 100,000,000 zatoshis).
+   * Strip trailing zeros from the fractional part for readability:
+   * 10000 zatoshis → "0.0001 ZEC" not "0.00010000 ZEC" */
+  {
+    char frac_buf[16];
+    unsigned long long w = (unsigned long long)(total / 100000000ULL);
+    unsigned long long f = (unsigned long long)(total % 100000000ULL);
+    snprintf(frac_buf, sizeof(frac_buf), "%08llu", f);
+    /* strip trailing zeros, keep at least 1 digit */
+    int flen = 8;
+    while (flen > 1 && frac_buf[flen - 1] == '0') flen--;
+    frac_buf[flen] = '\0';
+    snprintf(amount_str, sizeof(amount_str), "%llu.%s ZEC", w, frac_buf);
+  }
+  {
+    char frac_buf[16];
+    unsigned long long w = (unsigned long long)(fee / 100000000ULL);
+    unsigned long long f = (unsigned long long)(fee % 100000000ULL);
+    snprintf(frac_buf, sizeof(frac_buf), "%08llu", f);
+    int flen = 8;
+    while (flen > 1 && frac_buf[flen - 1] == '0') flen--;
+    frac_buf[flen] = '\0';
+    snprintf(fee_str, sizeof(fee_str), "%llu.%s ZEC", w, frac_buf);
+  }
 
   /* Display confirmation — different text for shielded-only vs hybrid */
   uint32_t n_tinputs = msg->has_n_transparent_inputs ? msg->n_transparent_inputs : 0;
@@ -279,6 +296,15 @@ void fsm_msgZcashGetOrchardFVK(const ZcashGetOrchardFVK *msg) {
   CHECK_INITIALIZED
 
   CHECK_PIN
+
+  /* Confirmation required: FVK reveals all transaction history */
+  if (!confirm(ButtonRequestType_ButtonRequest_Other,
+               "Zcash Orchard", "Export Full Viewing Key?\n"
+               "This reveals all\ntransaction history.")) {
+    fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
+    layoutHome();
+    return;
+  }
 
   /* Determine account from path or explicit account field */
   uint32_t account = 0;
@@ -636,10 +662,17 @@ void fsm_msgZcashTransparentInput(const ZcashTransparentInput *msg) {
   {
     char input_str[64];
     uint64_t amt = msg->has_amount ? msg->amount : 0;
-    snprintf(input_str, sizeof(input_str), "Input %lu: %llu.%08llu ZEC",
-             (unsigned long)(msg->index + 1),
-             (unsigned long long)(amt / 100000000ULL),
-             (unsigned long long)(amt % 100000000ULL));
+    {
+      char frac_buf[16];
+      unsigned long long w = (unsigned long long)(amt / 100000000ULL);
+      unsigned long long f = (unsigned long long)(amt % 100000000ULL);
+      snprintf(frac_buf, sizeof(frac_buf), "%08llu", f);
+      int flen = 8;
+      while (flen > 1 && frac_buf[flen - 1] == '0') flen--;
+      frac_buf[flen] = '\0';
+      snprintf(input_str, sizeof(input_str), "Input %lu: %llu.%s ZEC",
+               (unsigned long)(msg->index + 1), w, frac_buf);
+    }
     if (!confirm(ButtonRequestType_ButtonRequest_SignTx,
                  "Sign Input", "Sign transparent input?\n%s",
                  input_str)) {

--- a/lib/firmware/fsm_msg_zcash.h
+++ b/lib/firmware/fsm_msg_zcash.h
@@ -29,18 +29,14 @@
  * These are BLAKE2b-256 with the respective personalizations over empty input.
  * Verified against Keystone3 test vectors. */
 static const uint8_t EMPTY_TRANSPARENT_DIGEST[32] = {
-  0xc3, 0x3f, 0x2e, 0x95, 0x70, 0x5f, 0xaa, 0xb3,
-  0x5f, 0x8d, 0x53, 0x3f, 0xa6, 0x1e, 0x95, 0xc3,
-  0xb7, 0xaa, 0xba, 0x07, 0x76, 0xb8, 0x74, 0xa9,
-  0xf7, 0x4f, 0xc1, 0x27, 0x84, 0x37, 0x6a, 0x59
-};
+    0xc3, 0x3f, 0x2e, 0x95, 0x70, 0x5f, 0xaa, 0xb3, 0x5f, 0x8d, 0x53,
+    0x3f, 0xa6, 0x1e, 0x95, 0xc3, 0xb7, 0xaa, 0xba, 0x07, 0x76, 0xb8,
+    0x74, 0xa9, 0xf7, 0x4f, 0xc1, 0x27, 0x84, 0x37, 0x6a, 0x59};
 
 static const uint8_t EMPTY_SAPLING_DIGEST[32] = {
-  0x6f, 0x2f, 0xc8, 0xf9, 0x8f, 0xea, 0xfd, 0x94,
-  0xe7, 0x4a, 0x0d, 0xf4, 0xbe, 0xd7, 0x43, 0x91,
-  0xee, 0x0b, 0x5a, 0x69, 0x94, 0x5e, 0x4c, 0xed,
-  0x8c, 0xa8, 0xa0, 0x95, 0x20, 0x6f, 0x00, 0xae
-};
+    0x6f, 0x2f, 0xc8, 0xf9, 0x8f, 0xea, 0xfd, 0x94, 0xe7, 0x4a, 0x0d,
+    0xf4, 0xbe, 0xd7, 0x43, 0x91, 0xee, 0x0b, 0x5a, 0x69, 0x94, 0x5e,
+    0x4c, 0xed, 0x8c, 0xa8, 0xa0, 0x95, 0x20, 0x6f, 0x00, 0xae};
 
 /* Zcash shielded signing state */
 static struct {
@@ -74,7 +70,7 @@ static struct {
 #define ZCASH_MAX_ACTIONS 16
 #define ZCASH_MAX_TRANSPARENT_INPUTS 8
 
-void fsm_msgZcashSignPCZT(const ZcashSignPCZT *msg) {
+void fsm_msgZcashSignPCZT(const ZcashSignPCZT* msg) {
   RESP_INIT(ZcashPCZTActionAck);
 
   CHECK_INITIALIZED
@@ -83,8 +79,7 @@ void fsm_msgZcashSignPCZT(const ZcashSignPCZT *msg) {
 
   /* Validate parameters */
   if (!msg->has_n_actions || msg->n_actions == 0) {
-    fsm_sendFailure(FailureType_Failure_SyntaxError,
-                    _("No actions specified"));
+    fsm_sendFailure(FailureType_Failure_SyntaxError, _("No actions specified"));
     layoutHome();
     return;
   }
@@ -102,7 +97,7 @@ void fsm_msgZcashSignPCZT(const ZcashSignPCZT *msg) {
     account = msg->account;
   } else if (msg->address_n_count >= 3) {
     /* Extract account from path: m/32'/133'/account' */
-    account = msg->address_n[2] & 0x7FFFFFFF;  /* Strip hardened bit */
+    account = msg->address_n[2] & 0x7FFFFFFF; /* Strip hardened bit */
   }
 
   /* Confirm with user */
@@ -137,13 +132,13 @@ void fsm_msgZcashSignPCZT(const ZcashSignPCZT *msg) {
   }
 
   /* Display confirmation — different text for shielded-only vs hybrid */
-  uint32_t n_tinputs = msg->has_n_transparent_inputs ? msg->n_transparent_inputs : 0;
+  uint32_t n_tinputs =
+      msg->has_n_transparent_inputs ? msg->n_transparent_inputs : 0;
   if (n_tinputs > 0) {
-    if (!confirm(ButtonRequestType_ButtonRequest_SignTx,
-                 "Zcash Shield", "Shield transparent ZEC to Orchard?\n"
+    if (!confirm(ButtonRequestType_ButtonRequest_SignTx, "Zcash Shield",
+                 "Shield transparent ZEC to Orchard?\n"
                  "Amount: %s\nFee: %s\nInputs: %lu\nActions: %lu",
-                 amount_str, fee_str,
-                 (unsigned long)n_tinputs,
+                 amount_str, fee_str, (unsigned long)n_tinputs,
                  (unsigned long)msg->n_actions)) {
       fsm_sendFailure(FailureType_Failure_ActionCancelled,
                       _("Signing cancelled"));
@@ -151,8 +146,8 @@ void fsm_msgZcashSignPCZT(const ZcashSignPCZT *msg) {
       return;
     }
   } else {
-    if (!confirm(ButtonRequestType_ButtonRequest_SignTx,
-                 "Zcash Shielded", "Sign shielded transaction?\n"
+    if (!confirm(ButtonRequestType_ButtonRequest_SignTx, "Zcash Shielded",
+                 "Sign shielded transaction?\n"
                  "Amount: %s\nFee: %s\nActions: %lu",
                  amount_str, fee_str, (unsigned long)msg->n_actions)) {
       fsm_sendFailure(FailureType_Failure_ActionCancelled,
@@ -167,7 +162,7 @@ void fsm_msgZcashSignPCZT(const ZcashSignPCZT *msg) {
    * handling passphrase entry if needed. This is NOT the BIP-32
    * root key — ZIP-32 Orchard uses a completely separate derivation
    * tree rooted at the raw seed. */
-  const uint8_t *seed = storage_getRawSeed(true);
+  const uint8_t* seed = storage_getRawSeed(true);
   if (!seed) {
     fsm_sendFailure(FailureType_Failure_NotInitialized,
                     _("Device not initialized or seed unavailable"));
@@ -175,8 +170,7 @@ void fsm_msgZcashSignPCZT(const ZcashSignPCZT *msg) {
     return;
   }
 
-  if (!zcash_derive_orchard_keys(seed, 64, account,
-                                 &zcash_signing.keys)) {
+  if (!zcash_derive_orchard_keys(seed, 64, account, &zcash_signing.keys)) {
     fsm_sendFailure(FailureType_Failure_Other,
                     _("Orchard key derivation failed"));
     layoutHome();
@@ -235,7 +229,6 @@ void fsm_msgZcashSignPCZT(const ZcashSignPCZT *msg) {
    *   (Keystone, Trezor) for the streaming PCZT protocol. */
   if (msg->has_header_digest && msg->header_digest.size == 32 &&
       msg->has_orchard_digest && msg->orchard_digest.size == 32) {
-
     uint8_t t_digest[32], s_digest[32];
 
     /* Use provided transparent digest, or default to empty */
@@ -253,10 +246,8 @@ void fsm_msgZcashSignPCZT(const ZcashSignPCZT *msg) {
     }
 
     zcash_compute_shielded_sighash(
-        msg->header_digest.bytes, t_digest, s_digest,
-        msg->orchard_digest.bytes,
-        zcash_signing.branch_id,
-        zcash_signing.sighash);
+        msg->header_digest.bytes, t_digest, s_digest, msg->orchard_digest.bytes,
+        zcash_signing.branch_id, zcash_signing.sighash);
     zcash_signing.has_device_sighash = true;
 
     /* Phase 2b: Initialize orchard digest verification if bundle metadata
@@ -265,18 +256,17 @@ void fsm_msgZcashSignPCZT(const ZcashSignPCZT *msg) {
      * the computed orchard_digest matches the one used for sighash. */
     if (msg->has_orchard_flags && msg->has_orchard_value_balance &&
         msg->has_orchard_anchor && msg->orchard_anchor.size == 32) {
-
-      memcpy(zcash_signing.expected_orchard_digest,
-             msg->orchard_digest.bytes, 32);
+      memcpy(zcash_signing.expected_orchard_digest, msg->orchard_digest.bytes,
+             32);
       zcash_signing.orchard_flags = (uint8_t)msg->orchard_flags;
       zcash_signing.orchard_value_balance = msg->orchard_value_balance;
       memcpy(zcash_signing.orchard_anchor, msg->orchard_anchor.bytes, 32);
 
       /* Initialize BLAKE2b streaming contexts for the 3 sub-hashes */
-      blake2b_InitPersonal(&zcash_signing.compact_ctx, 32,
-                           "ZTxIdOrcActCHash", 16);
-      blake2b_InitPersonal(&zcash_signing.memos_ctx, 32,
-                           "ZTxIdOrcActMHash", 16);
+      blake2b_InitPersonal(&zcash_signing.compact_ctx, 32, "ZTxIdOrcActCHash",
+                           16);
+      blake2b_InitPersonal(&zcash_signing.memos_ctx, 32, "ZTxIdOrcActMHash",
+                           16);
       blake2b_InitPersonal(&zcash_signing.noncompact_ctx, 32,
                            "ZTxIdOrcActNHash", 16);
       zcash_signing.verify_orchard_digest = true;
@@ -290,7 +280,7 @@ void fsm_msgZcashSignPCZT(const ZcashSignPCZT *msg) {
   layoutProgress(_("Signing Zcash"), 0);
 }
 
-void fsm_msgZcashGetOrchardFVK(const ZcashGetOrchardFVK *msg) {
+void fsm_msgZcashGetOrchardFVK(const ZcashGetOrchardFVK* msg) {
   RESP_INIT(ZcashOrchardFVK);
 
   CHECK_INITIALIZED
@@ -298,8 +288,8 @@ void fsm_msgZcashGetOrchardFVK(const ZcashGetOrchardFVK *msg) {
   CHECK_PIN
 
   /* Confirmation required: FVK reveals all transaction history */
-  if (!confirm(ButtonRequestType_ButtonRequest_Other,
-               "Zcash Orchard", "Export Full Viewing Key?\n"
+  if (!confirm(ButtonRequestType_ButtonRequest_Other, "Zcash Orchard",
+               "Export Full Viewing Key?\n"
                "This reveals all\ntransaction history.")) {
     fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
     layoutHome();
@@ -315,7 +305,7 @@ void fsm_msgZcashGetOrchardFVK(const ZcashGetOrchardFVK *msg) {
   }
 
   /* Get the real BIP-39 seed for ZIP-32 Orchard derivation */
-  const uint8_t *seed = storage_getRawSeed(true);
+  const uint8_t* seed = storage_getRawSeed(true);
   if (!seed) {
     fsm_sendFailure(FailureType_Failure_NotInitialized,
                     _("Device not initialized or seed unavailable"));
@@ -367,7 +357,7 @@ void fsm_msgZcashGetOrchardFVK(const ZcashGetOrchardFVK *msg) {
   layoutHome();
 }
 
-void fsm_msgZcashPCZTAction(const ZcashPCZTAction *msg) {
+void fsm_msgZcashPCZTAction(const ZcashPCZTAction* msg) {
   if (!zcash_signing.active) {
     fsm_sendFailure(FailureType_Failure_UnexpectedMessage,
                     _("Not in Zcash signing mode"));
@@ -422,17 +412,14 @@ void fsm_msgZcashPCZTAction(const ZcashPCZTAction *msg) {
   }
 
   /* Phase 2b: feed action data into incremental BLAKE2b contexts */
-  if (zcash_signing.verify_orchard_digest &&
-      msg->has_nullifier && msg->nullifier.size == 32 &&
-      msg->has_cmx && msg->cmx.size == 32 &&
-      msg->has_epk && msg->epk.size == 32 &&
-      msg->has_enc_compact && msg->enc_compact.size == 52 &&
-      msg->has_enc_memo && msg->enc_memo.size == 512 &&
-      msg->has_enc_noncompact && msg->enc_noncompact.size > 0 &&
-      msg->has_cv_net && msg->cv_net.size == 32 &&
-      msg->has_rk && msg->rk.size == 32 &&
+  if (zcash_signing.verify_orchard_digest && msg->has_nullifier &&
+      msg->nullifier.size == 32 && msg->has_cmx && msg->cmx.size == 32 &&
+      msg->has_epk && msg->epk.size == 32 && msg->has_enc_compact &&
+      msg->enc_compact.size == 52 && msg->has_enc_memo &&
+      msg->enc_memo.size == 512 && msg->has_enc_noncompact &&
+      msg->enc_noncompact.size > 0 && msg->has_cv_net &&
+      msg->cv_net.size == 32 && msg->has_rk && msg->rk.size == 32 &&
       msg->has_out_ciphertext && msg->out_ciphertext.size == 80) {
-
     /* Compact: nf || cmx || epk || enc[0..52] */
     blake2b_Update(&zcash_signing.compact_ctx, msg->nullifier.bytes, 32);
     blake2b_Update(&zcash_signing.compact_ctx, msg->cmx.bytes, 32);
@@ -445,25 +432,22 @@ void fsm_msgZcashPCZTAction(const ZcashPCZTAction *msg) {
     /* Noncompact: cv_net || rk || enc[564..] || out_ciphertext */
     blake2b_Update(&zcash_signing.noncompact_ctx, msg->cv_net.bytes, 32);
     blake2b_Update(&zcash_signing.noncompact_ctx, msg->rk.bytes, 32);
-    blake2b_Update(&zcash_signing.noncompact_ctx,
-                   msg->enc_noncompact.bytes, msg->enc_noncompact.size);
-    blake2b_Update(&zcash_signing.noncompact_ctx,
-                   msg->out_ciphertext.bytes, 80);
+    blake2b_Update(&zcash_signing.noncompact_ctx, msg->enc_noncompact.bytes,
+                   msg->enc_noncompact.size);
+    blake2b_Update(&zcash_signing.noncompact_ctx, msg->out_ciphertext.bytes,
+                   80);
   }
 
   /* Use device-computed sighash if available, otherwise legacy host sighash */
-  const uint8_t *sighash = zcash_signing.has_device_sighash
-      ? zcash_signing.sighash
-      : msg->sighash.bytes;
+  const uint8_t* sighash = zcash_signing.has_device_sighash
+                               ? zcash_signing.sighash
+                               : msg->sighash.bytes;
 
   /* Sign this action with RedPallas:
    * sig = RedPallas.sign(ask, alpha, sighash) */
-  if (redpallas_sign_digest(zcash_signing.keys.ask,
-                            msg->alpha.bytes,
-                            sighash,
+  if (redpallas_sign_digest(zcash_signing.keys.ask, msg->alpha.bytes, sighash,
                             zcash_signing.signatures[msg->index]) != 0) {
-    fsm_sendFailure(FailureType_Failure_Other,
-                    _("RedPallas signing failed"));
+    fsm_sendFailure(FailureType_Failure_Other, _("RedPallas signing failed"));
     zcash_signing.active = false;
     memzero(&zcash_signing.keys, sizeof(zcash_signing.keys));
     layoutHome();
@@ -473,13 +457,12 @@ void fsm_msgZcashPCZTAction(const ZcashPCZTAction *msg) {
   zcash_signing.current_action++;
 
   /* Update progress */
-  uint32_t progress = (zcash_signing.current_action * 1000) /
-                      zcash_signing.n_actions;
+  uint32_t progress =
+      (zcash_signing.current_action * 1000) / zcash_signing.n_actions;
   layoutProgress(_("Signing Zcash"), progress);
 
   /* Check if all actions are signed */
   if (zcash_signing.current_action >= zcash_signing.n_actions) {
-
     /* Phase 2b: verify orchard digest before returning signatures */
     if (zcash_signing.verify_orchard_digest) {
       uint8_t compact_hash[32], memos_hash[32], noncompact_hash[32];
@@ -498,15 +481,15 @@ void fsm_msgZcashPCZTAction(const ZcashPCZTAction *msg) {
       blake2b_Update(&orchard_ctx, noncompact_hash, 32);
       blake2b_Update(&orchard_ctx, &zcash_signing.orchard_flags, 1);
       blake2b_Update(&orchard_ctx,
-                     (const uint8_t *)&zcash_signing.orchard_value_balance, 8);
+                     (const uint8_t*)&zcash_signing.orchard_value_balance, 8);
       blake2b_Update(&orchard_ctx, zcash_signing.orchard_anchor, 32);
 
       uint8_t computed_orchard_digest[32];
       blake2b_Final(&orchard_ctx, computed_orchard_digest, 32);
 
       /* Verify computed matches expected */
-      if (memcmp(computed_orchard_digest,
-                 zcash_signing.expected_orchard_digest, 32) != 0) {
+      if (memcmp(computed_orchard_digest, zcash_signing.expected_orchard_digest,
+                 32) != 0) {
         fsm_sendFailure(FailureType_Failure_Other,
                         _("Orchard digest mismatch: transaction data "
                           "does not match sighash"));
@@ -519,7 +502,7 @@ void fsm_msgZcashPCZTAction(const ZcashPCZTAction *msg) {
     }
 
     /* All done - send the collected signatures */
-    ZcashSignedPCZT *resp_signed = (ZcashSignedPCZT *)msg_resp;
+    ZcashSignedPCZT* resp_signed = (ZcashSignedPCZT*)msg_resp;
     memset(resp_signed, 0, sizeof(ZcashSignedPCZT));
 
     resp_signed->signatures_count = zcash_signing.n_actions;
@@ -537,7 +520,7 @@ void fsm_msgZcashPCZTAction(const ZcashPCZTAction *msg) {
     layoutHome();
   } else {
     /* Request next action */
-    ZcashPCZTActionAck *resp_ack = (ZcashPCZTActionAck *)msg_resp;
+    ZcashPCZTActionAck* resp_ack = (ZcashPCZTActionAck*)msg_resp;
     memset(resp_ack, 0, sizeof(ZcashPCZTActionAck));
     resp_ack->has_next_index = true;
     resp_ack->next_index = zcash_signing.current_action;
@@ -554,7 +537,7 @@ void fsm_msgZcashPCZTAction(const ZcashPCZTAction *msg) {
  *
  * After all transparent inputs, the device transitions to the Orchard
  * action phase (ZcashPCZTAction streaming). */
-void fsm_msgZcashTransparentInput(const ZcashTransparentInput *msg) {
+void fsm_msgZcashTransparentInput(const ZcashTransparentInput* msg) {
   RESP_INIT(ZcashTransparentSig);
 
   if (!zcash_signing.active) {
@@ -583,8 +566,7 @@ void fsm_msgZcashTransparentInput(const ZcashTransparentInput *msg) {
   }
 
   if (msg->sighash.size != 32) {
-    fsm_sendFailure(FailureType_Failure_SyntaxError,
-                    _("Invalid sighash size"));
+    fsm_sendFailure(FailureType_Failure_SyntaxError, _("Invalid sighash size"));
     zcash_signing.active = false;
     memzero(&zcash_signing.keys, sizeof(zcash_signing.keys));
     layoutHome();
@@ -673,9 +655,8 @@ void fsm_msgZcashTransparentInput(const ZcashTransparentInput *msg) {
       snprintf(input_str, sizeof(input_str), "Input %lu: %llu.%s ZEC",
                (unsigned long)(msg->index + 1), w, frac_buf);
     }
-    if (!confirm(ButtonRequestType_ButtonRequest_SignTx,
-                 "Sign Input", "Sign transparent input?\n%s",
-                 input_str)) {
+    if (!confirm(ButtonRequestType_ButtonRequest_SignTx, "Sign Input",
+                 "Sign transparent input?\n%s", input_str)) {
       fsm_sendFailure(FailureType_Failure_ActionCancelled,
                       _("Signing cancelled"));
       zcash_signing.active = false;
@@ -686,7 +667,7 @@ void fsm_msgZcashTransparentInput(const ZcashTransparentInput *msg) {
   }
 
   /* Derive the secp256k1 key at the validated Zcash BIP44 path */
-  const CoinType *coin = fsm_getCoin(true, "Zcash");
+  const CoinType* coin = fsm_getCoin(true, "Zcash");
   if (!coin) {
     fsm_sendFailure(FailureType_Failure_Other, _("Unknown coin: Zcash"));
     zcash_signing.active = false;
@@ -695,7 +676,7 @@ void fsm_msgZcashTransparentInput(const ZcashTransparentInput *msg) {
     return;
   }
 
-  HDNode *node = fsm_getDerivedNode(coin->curve_name, msg->address_n,
+  HDNode* node = fsm_getDerivedNode(coin->curve_name, msg->address_n,
                                     msg->address_n_count, NULL);
   if (!node) {
     zcash_signing.active = false;
@@ -709,8 +690,7 @@ void fsm_msgZcashTransparentInput(const ZcashTransparentInput *msg) {
   /* ECDSA sign the per-input sighash */
   uint8_t sig[64];
   if (hdnode_sign_digest(node, msg->sighash.bytes, sig, NULL, NULL) != 0) {
-    fsm_sendFailure(FailureType_Failure_Other,
-                    _("ECDSA signing failed"));
+    fsm_sendFailure(FailureType_Failure_Other, _("ECDSA signing failed"));
     memzero(node, sizeof(*node));
     zcash_signing.active = false;
     memzero(&zcash_signing.keys, sizeof(zcash_signing.keys));
@@ -722,7 +702,8 @@ void fsm_msgZcashTransparentInput(const ZcashTransparentInput *msg) {
   uint8_t der_sig[73];
   int der_len = ecdsa_sig_to_der(sig, der_sig);
 
-  /* Build response — signature is a required field (no has_ prefix in nanopb) */
+  /* Build response — signature is a required field (no has_ prefix in nanopb)
+   */
   resp->signature.size = der_len;
   memcpy(resp->signature.bytes, der_sig, der_len);
 

--- a/lib/firmware/fsm_msg_zcash.h
+++ b/lib/firmware/fsm_msg_zcash.h
@@ -1,0 +1,711 @@
+/*
+ * This file is part of the KeepKey project.
+ *
+ * Copyright (C) 2025 KeepKey
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* Zcash-specific headers — included here because fsm_msg_zcash.h
+ * is #include'd inside fsm.c, not compiled separately. */
+#include "keepkey/firmware/zcash.h"
+#include "trezor/crypto/blake2b.h"
+#include "trezor/crypto/pallas.h"
+#include "trezor/crypto/redpallas.h"
+#include "trezor/crypto/memzero.h"
+
+/* Precomputed empty digest constants for shielded-only transactions.
+ * These are BLAKE2b-256 with the respective personalizations over empty input.
+ * Verified against Keystone3 test vectors. */
+static const uint8_t EMPTY_TRANSPARENT_DIGEST[32] = {
+  0xc3, 0x3f, 0x2e, 0x95, 0x70, 0x5f, 0xaa, 0xb3,
+  0x5f, 0x8d, 0x53, 0x3f, 0xa6, 0x1e, 0x95, 0xc3,
+  0xb7, 0xaa, 0xba, 0x07, 0x76, 0xb8, 0x74, 0xa9,
+  0xf7, 0x4f, 0xc1, 0x27, 0x84, 0x37, 0x6a, 0x59
+};
+
+static const uint8_t EMPTY_SAPLING_DIGEST[32] = {
+  0x6f, 0x2f, 0xc8, 0xf9, 0x8f, 0xea, 0xfd, 0x94,
+  0xe7, 0x4a, 0x0d, 0xf4, 0xbe, 0xd7, 0x43, 0x91,
+  0xee, 0x0b, 0x5a, 0x69, 0x94, 0x5e, 0x4c, 0xed,
+  0x8c, 0xa8, 0xa0, 0x95, 0x20, 0x6f, 0x00, 0xae
+};
+
+/* Zcash shielded signing state */
+static struct {
+  bool active;
+  uint32_t account;
+  uint32_t n_actions;
+  uint32_t current_action;
+  uint64_t total_amount;
+  uint64_t fee;
+  uint32_t branch_id;
+  ZcashOrchardKeys keys;
+  uint8_t sighash[32];
+  /* Phase 2a: on-device sighash computation */
+  bool has_device_sighash;
+  /* Phase 2b: incremental orchard digest verification */
+  bool verify_orchard_digest;
+  uint8_t expected_orchard_digest[32];
+  BLAKE2B_CTX compact_ctx;
+  BLAKE2B_CTX memos_ctx;
+  BLAKE2B_CTX noncompact_ctx;
+  uint8_t orchard_flags;
+  int64_t orchard_value_balance;
+  uint8_t orchard_anchor[32];
+  /* Signatures buffer: up to 16 actions (64 bytes each) */
+  uint8_t signatures[16][64];
+  /* Phase 3: transparent shielding state */
+  uint32_t n_transparent_inputs;
+  uint32_t current_transparent_input;
+} zcash_signing;
+
+#define ZCASH_MAX_ACTIONS 16
+#define ZCASH_MAX_TRANSPARENT_INPUTS 8
+
+void fsm_msgZcashSignPCZT(const ZcashSignPCZT *msg) {
+  RESP_INIT(ZcashPCZTActionAck);
+
+  CHECK_INITIALIZED
+
+  CHECK_PIN
+
+  /* Validate parameters */
+  if (!msg->has_n_actions || msg->n_actions == 0) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("No actions specified"));
+    layoutHome();
+    return;
+  }
+
+  if (msg->n_actions > ZCASH_MAX_ACTIONS) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Too many Orchard actions"));
+    layoutHome();
+    return;
+  }
+
+  /* Determine account from path or explicit account field */
+  uint32_t account = 0;
+  if (msg->has_account) {
+    account = msg->account;
+  } else if (msg->address_n_count >= 3) {
+    /* Extract account from path: m/32'/133'/account' */
+    account = msg->address_n[2] & 0x7FFFFFFF;  /* Strip hardened bit */
+  }
+
+  /* Confirm with user */
+  char amount_str[32];
+  char fee_str[32];
+  uint64_t total = msg->has_total_amount ? msg->total_amount : 0;
+  uint64_t fee = msg->has_fee ? msg->fee : 0;
+
+  /* Format amounts (1 ZEC = 100,000,000 zatoshis) */
+  snprintf(amount_str, sizeof(amount_str), "%llu.%08llu ZEC",
+           (unsigned long long)(total / 100000000ULL),
+           (unsigned long long)(total % 100000000ULL));
+  snprintf(fee_str, sizeof(fee_str), "%llu.%08llu ZEC",
+           (unsigned long long)(fee / 100000000ULL),
+           (unsigned long long)(fee % 100000000ULL));
+
+  /* Display confirmation — different text for shielded-only vs hybrid */
+  uint32_t n_tinputs = msg->has_n_transparent_inputs ? msg->n_transparent_inputs : 0;
+  if (n_tinputs > 0) {
+    if (!confirm(ButtonRequestType_ButtonRequest_SignTx,
+                 "Zcash Shield", "Shield transparent ZEC to Orchard?\n"
+                 "Amount: %s\nFee: %s\nInputs: %lu\nActions: %lu",
+                 amount_str, fee_str,
+                 (unsigned long)n_tinputs,
+                 (unsigned long)msg->n_actions)) {
+      fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                      _("Signing cancelled"));
+      layoutHome();
+      return;
+    }
+  } else {
+    if (!confirm(ButtonRequestType_ButtonRequest_SignTx,
+                 "Zcash Shielded", "Sign shielded transaction?\n"
+                 "Amount: %s\nFee: %s\nActions: %lu",
+                 amount_str, fee_str, (unsigned long)msg->n_actions)) {
+      fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                      _("Signing cancelled"));
+      layoutHome();
+      return;
+    }
+  }
+
+  /* Get the real BIP-39 seed for ZIP-32 Orchard derivation.
+   * storage_getSeed() returns the 64-byte mnemonic-derived seed,
+   * handling passphrase entry if needed. This is NOT the BIP-32
+   * root key — ZIP-32 Orchard uses a completely separate derivation
+   * tree rooted at the raw seed. */
+  const uint8_t *seed = storage_getRawSeed(true);
+  if (!seed) {
+    fsm_sendFailure(FailureType_Failure_NotInitialized,
+                    _("Device not initialized or seed unavailable"));
+    layoutHome();
+    return;
+  }
+
+  if (!zcash_derive_orchard_keys(seed, 64, account,
+                                 &zcash_signing.keys)) {
+    fsm_sendFailure(FailureType_Failure_Other,
+                    _("Orchard key derivation failed"));
+    layoutHome();
+    return;
+  }
+
+  /* Initialize signing state */
+  zcash_signing.active = true;
+  zcash_signing.account = account;
+  zcash_signing.n_actions = msg->n_actions;
+  zcash_signing.current_action = 0;
+  zcash_signing.total_amount = total;
+  zcash_signing.fee = fee;
+  zcash_signing.branch_id = msg->has_branch_id ? msg->branch_id : 0x37519621;
+  zcash_signing.has_device_sighash = false;
+  zcash_signing.verify_orchard_digest = false;
+  zcash_signing.n_transparent_inputs =
+      msg->has_n_transparent_inputs ? msg->n_transparent_inputs : 0;
+  zcash_signing.current_transparent_input = 0;
+
+  if (zcash_signing.n_transparent_inputs > ZCASH_MAX_TRANSPARENT_INPUTS) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Too many transparent inputs"));
+    zcash_signing.active = false;
+    layoutHome();
+    return;
+  }
+
+  /* Phase 2a: Compute sighash on-device if sub-digests are provided.
+   *
+   * TRUST MODEL:
+   *
+   * What the device verifies:
+   *   - Orchard digest: recomputed from streamed action data (Phase 2b)
+   *     covering nullifiers, commitments, ephemeral keys, ciphertexts,
+   *     value commitments, randomized keys, flags, value balance, anchor.
+   *   - Sighash: assembled on-device from the 4 sub-digests.
+   *
+   * What the device trusts from the host:
+   *   - header_digest, transparent_digest, sapling_digest: accepted
+   *     without verification. The device cannot recompute these without
+   *     the full transaction data, which exceeds memory constraints.
+   *   - Displayed amounts (total_amount, fee): these are for user
+   *     confirmation only. Orchard values are hidden by Pedersen
+   *     commitments (cv_net) — the device cannot extract plaintext
+   *     amounts from the verified digest. This is inherent to the
+   *     Zcash shielded protocol, not a firmware limitation.
+   *
+   * For shielded-only transactions (no transparent inputs):
+   *   transparent_digest defaults to the well-known empty hash,
+   *   so no trust assumption is needed for that component.
+   *
+   * For mixed transactions:
+   *   The host is trusted for non-Orchard components. This matches
+   *   the trust model of other Zcash hardware wallet implementations
+   *   (Keystone, Trezor) for the streaming PCZT protocol. */
+  if (msg->has_header_digest && msg->header_digest.size == 32 &&
+      msg->has_orchard_digest && msg->orchard_digest.size == 32) {
+
+    uint8_t t_digest[32], s_digest[32];
+
+    /* Use provided transparent digest, or default to empty */
+    if (msg->has_transparent_digest && msg->transparent_digest.size == 32) {
+      memcpy(t_digest, msg->transparent_digest.bytes, 32);
+    } else {
+      memcpy(t_digest, EMPTY_TRANSPARENT_DIGEST, 32);
+    }
+
+    /* Use provided sapling digest, or default to empty */
+    if (msg->has_sapling_digest && msg->sapling_digest.size == 32) {
+      memcpy(s_digest, msg->sapling_digest.bytes, 32);
+    } else {
+      memcpy(s_digest, EMPTY_SAPLING_DIGEST, 32);
+    }
+
+    zcash_compute_shielded_sighash(
+        msg->header_digest.bytes, t_digest, s_digest,
+        msg->orchard_digest.bytes,
+        zcash_signing.branch_id,
+        zcash_signing.sighash);
+    zcash_signing.has_device_sighash = true;
+
+    /* Phase 2b: Initialize orchard digest verification if bundle metadata
+     * is provided (orchard_flags, orchard_value_balance, orchard_anchor).
+     * The device will incrementally hash each action's data and verify
+     * the computed orchard_digest matches the one used for sighash. */
+    if (msg->has_orchard_flags && msg->has_orchard_value_balance &&
+        msg->has_orchard_anchor && msg->orchard_anchor.size == 32) {
+
+      memcpy(zcash_signing.expected_orchard_digest,
+             msg->orchard_digest.bytes, 32);
+      zcash_signing.orchard_flags = (uint8_t)msg->orchard_flags;
+      zcash_signing.orchard_value_balance = msg->orchard_value_balance;
+      memcpy(zcash_signing.orchard_anchor, msg->orchard_anchor.bytes, 32);
+
+      /* Initialize BLAKE2b streaming contexts for the 3 sub-hashes */
+      blake2b_InitPersonal(&zcash_signing.compact_ctx, 32,
+                           "ZTxIdOrcActCHash", 16);
+      blake2b_InitPersonal(&zcash_signing.memos_ctx, 32,
+                           "ZTxIdOrcActMHash", 16);
+      blake2b_InitPersonal(&zcash_signing.noncompact_ctx, 32,
+                           "ZTxIdOrcActNHash", 16);
+      zcash_signing.verify_orchard_digest = true;
+    }
+  }
+
+  /* Request first action data */
+  resp->has_next_index = true;
+  resp->next_index = 0;
+  msg_write(MessageType_MessageType_ZcashPCZTActionAck, resp);
+  layoutProgress(_("Signing Zcash"), 0);
+}
+
+void fsm_msgZcashGetOrchardFVK(const ZcashGetOrchardFVK *msg) {
+  RESP_INIT(ZcashOrchardFVK);
+
+  CHECK_INITIALIZED
+
+  CHECK_PIN
+
+  /* Determine account from path or explicit account field */
+  uint32_t account = 0;
+  if (msg->has_account) {
+    account = msg->account;
+  } else if (msg->address_n_count >= 3) {
+    account = msg->address_n[2] & 0x7FFFFFFF;
+  }
+
+  /* Get the real BIP-39 seed for ZIP-32 Orchard derivation */
+  const uint8_t *seed = storage_getRawSeed(true);
+  if (!seed) {
+    fsm_sendFailure(FailureType_Failure_NotInitialized,
+                    _("Device not initialized or seed unavailable"));
+    layoutHome();
+    return;
+  }
+
+  ZcashOrchardKeys keys;
+  if (!zcash_derive_orchard_keys(seed, 64, account, &keys)) {
+    fsm_sendFailure(FailureType_Failure_Other,
+                    _("Orchard key derivation failed"));
+    layoutHome();
+    return;
+  }
+
+  /* Compute ak = [ask]G_spendauth on Pallas curve (SpendAuth basepoint) */
+  bignum256 ask_scalar;
+  bn_read_le(keys.ask, &ask_scalar);
+  curve_point ak_point;
+  redpallas_scalar_mult_spendauth_G(&ask_scalar, &ak_point);
+
+  /* Serialize ak as Pallas point (LE x-coord, sign bit in high byte) */
+  uint8_t ak_bytes[32];
+  bignum256 x_copy;
+  bn_copy(&ak_point.x, &x_copy);
+  bn_write_le(&x_copy, ak_bytes);
+  if (bn_is_odd(&ak_point.y)) {
+    ak_bytes[31] |= 0x80;
+  }
+
+  /* Build response */
+  resp->has_ak = true;
+  resp->ak.size = 32;
+  memcpy(resp->ak.bytes, ak_bytes, 32);
+
+  resp->has_nk = true;
+  resp->nk.size = 32;
+  memcpy(resp->nk.bytes, keys.nk, 32);
+
+  resp->has_rivk = true;
+  resp->rivk.size = 32;
+  memcpy(resp->rivk.bytes, keys.rivk, 32);
+
+  /* Clean up sensitive data */
+  memzero(&ask_scalar, sizeof(ask_scalar));
+  memzero(&keys, sizeof(keys));
+
+  msg_write(MessageType_MessageType_ZcashOrchardFVK, resp);
+  layoutHome();
+}
+
+void fsm_msgZcashPCZTAction(const ZcashPCZTAction *msg) {
+  if (!zcash_signing.active) {
+    fsm_sendFailure(FailureType_Failure_UnexpectedMessage,
+                    _("Not in Zcash signing mode"));
+    layoutHome();
+    return;
+  }
+
+  /* Enforce transparent phase completion: if the session declared
+   * transparent inputs, ALL must be signed before Orchard actions.
+   * This prevents a malicious host from skipping transparent-input
+   * confirmations and jumping straight to Orchard signing. */
+  if (zcash_signing.current_transparent_input <
+      zcash_signing.n_transparent_inputs) {
+    fsm_sendFailure(FailureType_Failure_UnexpectedMessage,
+                    _("Transparent inputs not yet complete"));
+    zcash_signing.active = false;
+    memzero(&zcash_signing.keys, sizeof(zcash_signing.keys));
+    layoutHome();
+    return;
+  }
+
+  /* Validate action index */
+  if (!msg->has_index || msg->index != zcash_signing.current_action) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Unexpected action index"));
+    zcash_signing.active = false;
+    memzero(&zcash_signing.keys, sizeof(zcash_signing.keys));
+    layoutHome();
+    return;
+  }
+
+  /* Validate required fields */
+  if (!msg->has_alpha || msg->alpha.size != 32) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Missing or invalid alpha randomizer"));
+    zcash_signing.active = false;
+    memzero(&zcash_signing.keys, sizeof(zcash_signing.keys));
+    layoutHome();
+    return;
+  }
+
+  /* Phase 2a: require sighash only in legacy mode */
+  if (!zcash_signing.has_device_sighash) {
+    if (!msg->has_sighash || msg->sighash.size != 32) {
+      fsm_sendFailure(FailureType_Failure_SyntaxError,
+                      _("Missing or invalid sighash"));
+      zcash_signing.active = false;
+      memzero(&zcash_signing.keys, sizeof(zcash_signing.keys));
+      layoutHome();
+      return;
+    }
+  }
+
+  /* Phase 2b: feed action data into incremental BLAKE2b contexts */
+  if (zcash_signing.verify_orchard_digest &&
+      msg->has_nullifier && msg->nullifier.size == 32 &&
+      msg->has_cmx && msg->cmx.size == 32 &&
+      msg->has_epk && msg->epk.size == 32 &&
+      msg->has_enc_compact && msg->enc_compact.size == 52 &&
+      msg->has_enc_memo && msg->enc_memo.size == 512 &&
+      msg->has_enc_noncompact && msg->enc_noncompact.size > 0 &&
+      msg->has_cv_net && msg->cv_net.size == 32 &&
+      msg->has_rk && msg->rk.size == 32 &&
+      msg->has_out_ciphertext && msg->out_ciphertext.size == 80) {
+
+    /* Compact: nf || cmx || epk || enc[0..52] */
+    blake2b_Update(&zcash_signing.compact_ctx, msg->nullifier.bytes, 32);
+    blake2b_Update(&zcash_signing.compact_ctx, msg->cmx.bytes, 32);
+    blake2b_Update(&zcash_signing.compact_ctx, msg->epk.bytes, 32);
+    blake2b_Update(&zcash_signing.compact_ctx, msg->enc_compact.bytes, 52);
+
+    /* Memos: enc[52..564] */
+    blake2b_Update(&zcash_signing.memos_ctx, msg->enc_memo.bytes, 512);
+
+    /* Noncompact: cv_net || rk || enc[564..] || out_ciphertext */
+    blake2b_Update(&zcash_signing.noncompact_ctx, msg->cv_net.bytes, 32);
+    blake2b_Update(&zcash_signing.noncompact_ctx, msg->rk.bytes, 32);
+    blake2b_Update(&zcash_signing.noncompact_ctx,
+                   msg->enc_noncompact.bytes, msg->enc_noncompact.size);
+    blake2b_Update(&zcash_signing.noncompact_ctx,
+                   msg->out_ciphertext.bytes, 80);
+  }
+
+  /* Use device-computed sighash if available, otherwise legacy host sighash */
+  const uint8_t *sighash = zcash_signing.has_device_sighash
+      ? zcash_signing.sighash
+      : msg->sighash.bytes;
+
+  /* Sign this action with RedPallas:
+   * sig = RedPallas.sign(ask, alpha, sighash) */
+  if (redpallas_sign_digest(zcash_signing.keys.ask,
+                            msg->alpha.bytes,
+                            sighash,
+                            zcash_signing.signatures[msg->index]) != 0) {
+    fsm_sendFailure(FailureType_Failure_Other,
+                    _("RedPallas signing failed"));
+    zcash_signing.active = false;
+    memzero(&zcash_signing.keys, sizeof(zcash_signing.keys));
+    layoutHome();
+    return;
+  }
+
+  zcash_signing.current_action++;
+
+  /* Update progress */
+  uint32_t progress = (zcash_signing.current_action * 1000) /
+                      zcash_signing.n_actions;
+  layoutProgress(_("Signing Zcash"), progress);
+
+  /* Check if all actions are signed */
+  if (zcash_signing.current_action >= zcash_signing.n_actions) {
+
+    /* Phase 2b: verify orchard digest before returning signatures */
+    if (zcash_signing.verify_orchard_digest) {
+      uint8_t compact_hash[32], memos_hash[32], noncompact_hash[32];
+
+      blake2b_Final(&zcash_signing.compact_ctx, compact_hash, 32);
+      blake2b_Final(&zcash_signing.memos_ctx, memos_hash, 32);
+      blake2b_Final(&zcash_signing.noncompact_ctx, noncompact_hash, 32);
+
+      /* Compute orchard_digest = BLAKE2b("ZTxIdOrchardHash",
+       *   compact_hash || memos_hash || noncompact_hash ||
+       *   flags(1) || value_balance(8) || anchor(32)) */
+      BLAKE2B_CTX orchard_ctx;
+      blake2b_InitPersonal(&orchard_ctx, 32, "ZTxIdOrchardHash", 16);
+      blake2b_Update(&orchard_ctx, compact_hash, 32);
+      blake2b_Update(&orchard_ctx, memos_hash, 32);
+      blake2b_Update(&orchard_ctx, noncompact_hash, 32);
+      blake2b_Update(&orchard_ctx, &zcash_signing.orchard_flags, 1);
+      blake2b_Update(&orchard_ctx,
+                     (const uint8_t *)&zcash_signing.orchard_value_balance, 8);
+      blake2b_Update(&orchard_ctx, zcash_signing.orchard_anchor, 32);
+
+      uint8_t computed_orchard_digest[32];
+      blake2b_Final(&orchard_ctx, computed_orchard_digest, 32);
+
+      /* Verify computed matches expected */
+      if (memcmp(computed_orchard_digest,
+                 zcash_signing.expected_orchard_digest, 32) != 0) {
+        fsm_sendFailure(FailureType_Failure_Other,
+                        _("Orchard digest mismatch: transaction data "
+                          "does not match sighash"));
+        zcash_signing.active = false;
+        memzero(&zcash_signing.keys, sizeof(zcash_signing.keys));
+        memzero(zcash_signing.signatures, sizeof(zcash_signing.signatures));
+        layoutHome();
+        return;
+      }
+    }
+
+    /* All done - send the collected signatures */
+    ZcashSignedPCZT *resp_signed = (ZcashSignedPCZT *)msg_resp;
+    memset(resp_signed, 0, sizeof(ZcashSignedPCZT));
+
+    resp_signed->signatures_count = zcash_signing.n_actions;
+    for (uint32_t i = 0; i < zcash_signing.n_actions; i++) {
+      resp_signed->signatures[i].size = 64;
+      memcpy(resp_signed->signatures[i].bytes, zcash_signing.signatures[i], 64);
+    }
+
+    /* Clean up */
+    zcash_signing.active = false;
+    memzero(&zcash_signing.keys, sizeof(zcash_signing.keys));
+    memzero(zcash_signing.signatures, sizeof(zcash_signing.signatures));
+
+    msg_write(MessageType_MessageType_ZcashSignedPCZT, resp_signed);
+    layoutHome();
+  } else {
+    /* Request next action */
+    ZcashPCZTActionAck *resp_ack = (ZcashPCZTActionAck *)msg_resp;
+    memset(resp_ack, 0, sizeof(ZcashPCZTActionAck));
+    resp_ack->has_next_index = true;
+    resp_ack->next_index = zcash_signing.current_action;
+    msg_write(MessageType_MessageType_ZcashPCZTActionAck, resp_ack);
+  }
+}
+
+/* Phase 3: Transparent input signing for hybrid shielding transactions.
+ *
+ * The host sends one ZcashTransparentInput per transparent input after
+ * the initial ZcashSignPCZT. The device derives the secp256k1 key at
+ * the provided BIP44 path, ECDSA-signs the per-input sighash, and
+ * returns a DER signature.
+ *
+ * After all transparent inputs, the device transitions to the Orchard
+ * action phase (ZcashPCZTAction streaming). */
+void fsm_msgZcashTransparentInput(const ZcashTransparentInput *msg) {
+  RESP_INIT(ZcashTransparentSig);
+
+  if (!zcash_signing.active) {
+    fsm_sendFailure(FailureType_Failure_UnexpectedMessage,
+                    _("Not in Zcash signing mode"));
+    layoutHome();
+    return;
+  }
+
+  if (zcash_signing.n_transparent_inputs == 0) {
+    fsm_sendFailure(FailureType_Failure_UnexpectedMessage,
+                    _("No transparent inputs expected"));
+    zcash_signing.active = false;
+    memzero(&zcash_signing.keys, sizeof(zcash_signing.keys));
+    layoutHome();
+    return;
+  }
+
+  if (msg->index != zcash_signing.current_transparent_input) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Unexpected transparent input index"));
+    zcash_signing.active = false;
+    memzero(&zcash_signing.keys, sizeof(zcash_signing.keys));
+    layoutHome();
+    return;
+  }
+
+  if (msg->sighash.size != 32) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Invalid sighash size"));
+    zcash_signing.active = false;
+    memzero(&zcash_signing.keys, sizeof(zcash_signing.keys));
+    layoutHome();
+    return;
+  }
+
+  /* PATH ENFORCEMENT: transparent inputs must use exactly
+   * m/44'/133'/account'/change/index where:
+   *   - account' is hardened and matches the session account
+   *   - change is 0 (external) or 1 (internal)
+   *   - index is unhardened
+   *
+   * This prevents a compromised host from pivoting a shielding approval
+   * into signing with arbitrary secp256k1 keys on the device. */
+  if (msg->address_n_count != 5) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Path must be m/44'/133'/account'/change/index"));
+    zcash_signing.active = false;
+    memzero(&zcash_signing.keys, sizeof(zcash_signing.keys));
+    layoutHome();
+    return;
+  }
+
+  if (msg->address_n[0] != (0x80000000 | 44) ||
+      msg->address_n[1] != (0x80000000 | 133)) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Path must start with m/44'/133'"));
+    zcash_signing.active = false;
+    memzero(&zcash_signing.keys, sizeof(zcash_signing.keys));
+    layoutHome();
+    return;
+  }
+
+  /* Account must be hardened and match the approved session */
+  if (!(msg->address_n[2] & 0x80000000)) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Account must be hardened"));
+    zcash_signing.active = false;
+    memzero(&zcash_signing.keys, sizeof(zcash_signing.keys));
+    layoutHome();
+    return;
+  }
+
+  uint32_t path_account = msg->address_n[2] & 0x7FFFFFFF;
+  if (path_account != zcash_signing.account) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Account does not match approved session"));
+    zcash_signing.active = false;
+    memzero(&zcash_signing.keys, sizeof(zcash_signing.keys));
+    layoutHome();
+    return;
+  }
+
+  /* Change must be 0 (external) or 1 (internal), unhardened */
+  if (msg->address_n[3] > 1) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Change must be 0 or 1"));
+    zcash_signing.active = false;
+    memzero(&zcash_signing.keys, sizeof(zcash_signing.keys));
+    layoutHome();
+    return;
+  }
+
+  /* Index must be unhardened */
+  if (msg->address_n[4] & 0x80000000) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Index must not be hardened"));
+    zcash_signing.active = false;
+    memzero(&zcash_signing.keys, sizeof(zcash_signing.keys));
+    layoutHome();
+    return;
+  }
+
+  /* Per-input confirmation: show the user what's being signed */
+  {
+    char input_str[64];
+    uint64_t amt = msg->has_amount ? msg->amount : 0;
+    snprintf(input_str, sizeof(input_str), "Input %lu: %llu.%08llu ZEC",
+             (unsigned long)(msg->index + 1),
+             (unsigned long long)(amt / 100000000ULL),
+             (unsigned long long)(amt % 100000000ULL));
+    if (!confirm(ButtonRequestType_ButtonRequest_SignTx,
+                 "Sign Input", "Sign transparent input?\n%s",
+                 input_str)) {
+      fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                      _("Signing cancelled"));
+      zcash_signing.active = false;
+      memzero(&zcash_signing.keys, sizeof(zcash_signing.keys));
+      layoutHome();
+      return;
+    }
+  }
+
+  /* Derive the secp256k1 key at the validated Zcash BIP44 path */
+  const CoinType *coin = fsm_getCoin(true, "Zcash");
+  if (!coin) {
+    fsm_sendFailure(FailureType_Failure_Other, _("Unknown coin: Zcash"));
+    zcash_signing.active = false;
+    memzero(&zcash_signing.keys, sizeof(zcash_signing.keys));
+    layoutHome();
+    return;
+  }
+
+  HDNode *node = fsm_getDerivedNode(coin->curve_name, msg->address_n,
+                                    msg->address_n_count, NULL);
+  if (!node) {
+    zcash_signing.active = false;
+    memzero(&zcash_signing.keys, sizeof(zcash_signing.keys));
+    layoutHome();
+    return;
+  }
+
+  hdnode_fill_public_key(node);
+
+  /* ECDSA sign the per-input sighash */
+  uint8_t sig[64];
+  if (hdnode_sign_digest(node, msg->sighash.bytes, sig, NULL, NULL) != 0) {
+    fsm_sendFailure(FailureType_Failure_Other,
+                    _("ECDSA signing failed"));
+    memzero(node, sizeof(*node));
+    zcash_signing.active = false;
+    memzero(&zcash_signing.keys, sizeof(zcash_signing.keys));
+    layoutHome();
+    return;
+  }
+
+  /* DER encode the signature */
+  uint8_t der_sig[73];
+  int der_len = ecdsa_sig_to_der(sig, der_sig);
+
+  /* Build response — signature is a required field (no has_ prefix in nanopb) */
+  resp->signature.size = der_len;
+  memcpy(resp->signature.bytes, der_sig, der_len);
+
+  zcash_signing.current_transparent_input++;
+  resp->has_next_index = true;
+
+  if (zcash_signing.current_transparent_input >=
+      zcash_signing.n_transparent_inputs) {
+    resp->next_index = 0xFF;
+  } else {
+    resp->next_index = zcash_signing.current_transparent_input;
+  }
+
+  memzero(node, sizeof(*node));
+  memzero(sig, sizeof(sig));
+
+  msg_write(MessageType_MessageType_ZcashTransparentSig, resp);
+  layoutProgress(_("Signing Zcash"), 0);
+}

--- a/lib/firmware/messagemap.def
+++ b/lib/firmware/messagemap.def
@@ -147,9 +147,9 @@
     DEBUG_OUT(MessageType_MessageType_DebugLinkFlashDumpResponse,   DebugLinkFlashDumpResponse,  NO_PROCESS_FUNC)
 #endif
 
-    MSG_IN(MessageType_MessageType_ZcashSignPCZT, ZcashSignPCZT, fsm_msgZcashSignPczt)
-    MSG_IN(MessageType_MessageType_ZcashPCZTAction, ZcashPCZTAction, fsm_msgZcashPcztAction)
-    MSG_IN(MessageType_MessageType_ZcashGetOrchardFVK, ZcashGetOrchardFVK, fsm_msgZcashGetOrchardFvk)
+    MSG_IN(MessageType_MessageType_ZcashSignPCZT, ZcashSignPCZT, fsm_msgZcashSignPCZT)
+    MSG_IN(MessageType_MessageType_ZcashPCZTAction, ZcashPCZTAction, fsm_msgZcashPCZTAction)
+    MSG_IN(MessageType_MessageType_ZcashGetOrchardFVK, ZcashGetOrchardFVK, fsm_msgZcashGetOrchardFVK)
     MSG_IN(MessageType_MessageType_ZcashTransparentInput, ZcashTransparentInput, fsm_msgZcashTransparentInput)
     MSG_OUT(MessageType_MessageType_ZcashPCZTActionAck, ZcashPCZTActionAck, NO_PROCESS_FUNC)
     MSG_OUT(MessageType_MessageType_ZcashSignedPCZT, ZcashSignedPCZT, NO_PROCESS_FUNC)

--- a/lib/firmware/messagemap.def
+++ b/lib/firmware/messagemap.def
@@ -146,3 +146,12 @@
     DEBUG_OUT(MessageType_MessageType_DebugLinkLog,                 DebugLinkLog,                NO_PROCESS_FUNC)
     DEBUG_OUT(MessageType_MessageType_DebugLinkFlashDumpResponse,   DebugLinkFlashDumpResponse,  NO_PROCESS_FUNC)
 #endif
+
+    MSG_IN(MessageType_MessageType_ZcashSignPCZT, ZcashSignPCZT, fsm_msgZcashSignPczt)
+    MSG_IN(MessageType_MessageType_ZcashPCZTAction, ZcashPCZTAction, fsm_msgZcashPcztAction)
+    MSG_IN(MessageType_MessageType_ZcashGetOrchardFVK, ZcashGetOrchardFVK, fsm_msgZcashGetOrchardFvk)
+    MSG_IN(MessageType_MessageType_ZcashTransparentInput, ZcashTransparentInput, fsm_msgZcashTransparentInput)
+    MSG_OUT(MessageType_MessageType_ZcashPCZTActionAck, ZcashPCZTActionAck, NO_PROCESS_FUNC)
+    MSG_OUT(MessageType_MessageType_ZcashSignedPCZT, ZcashSignedPCZT, NO_PROCESS_FUNC)
+    MSG_OUT(MessageType_MessageType_ZcashOrchardFVK, ZcashOrchardFVK, NO_PROCESS_FUNC)
+    MSG_OUT(MessageType_MessageType_ZcashTransparentSig, ZcashTransparentSig, NO_PROCESS_FUNC)

--- a/lib/firmware/storage.c
+++ b/lib/firmware/storage.c
@@ -1866,11 +1866,11 @@ const uint8_t* storage_getSeed(const ConfigFlash* cfg, bool usePassphrase) {
   return NULL;
 }
 
-const uint8_t *storage_getRawSeed(bool usePassphrase) {
+const uint8_t* storage_getRawSeed(bool usePassphrase) {
   return storage_getSeed(&shadow_config, usePassphrase);
 }
 
-bool storage_getRootNode(const char *curve, bool usePassphrase, HDNode *node) {
+bool storage_getRootNode(const char* curve, bool usePassphrase, HDNode* node) {
   // if storage has node, decrypt and use it
   if (shadow_config.storage.pub.has_node &&
       strcmp(curve, SECP256K1_NAME) == 0) {

--- a/lib/firmware/storage.c
+++ b/lib/firmware/storage.c
@@ -1866,7 +1866,11 @@ const uint8_t* storage_getSeed(const ConfigFlash* cfg, bool usePassphrase) {
   return NULL;
 }
 
-bool storage_getRootNode(const char* curve, bool usePassphrase, HDNode* node) {
+const uint8_t *storage_getRawSeed(bool usePassphrase) {
+  return storage_getSeed(&shadow_config, usePassphrase);
+}
+
+bool storage_getRootNode(const char *curve, bool usePassphrase, HDNode *node) {
   // if storage has node, decrypt and use it
   if (shadow_config.storage.pub.has_node &&
       strcmp(curve, SECP256K1_NAME) == 0) {

--- a/lib/firmware/transaction.c
+++ b/lib/firmware/transaction.c
@@ -239,7 +239,7 @@ int compile_output(const CoinType* coin, const HDNode* root, TxOutputType* in,
       } else {
 #ifndef BITCOIN_ONLY
         // is this thorchain data?
-        if (!thorchain_parseConfirmMemo((const char *)in->op_return_data.bytes,
+        if (!thorchain_parseConfirmMemo((const char*)in->op_return_data.bytes,
                                         (size_t)in->op_return_data.size)) {
 #endif
           if (!confirm_data(ButtonRequestType_ButtonRequest_ConfirmOutput,
@@ -251,7 +251,6 @@ int compile_output(const CoinType* coin, const HDNode* root, TxOutputType* in,
         }
 #endif
       }
-
     }
     uint32_t r = 0;
     out->script_pubkey.bytes[0] = 0x6A;

--- a/lib/firmware/transaction.c
+++ b/lib/firmware/transaction.c
@@ -237,16 +237,21 @@ int compile_output(const CoinType* coin, const HDNode* root, TxOutputType* in,
           return -1;  // user aborted
         }
       } else {
+#ifndef BITCOIN_ONLY
         // is this thorchain data?
-        if (!thorchain_parseConfirmMemo((const char*)in->op_return_data.bytes,
+        if (!thorchain_parseConfirmMemo((const char *)in->op_return_data.bytes,
                                         (size_t)in->op_return_data.size)) {
+#endif
           if (!confirm_data(ButtonRequestType_ButtonRequest_ConfirmOutput,
                             _("Confirm OP_RETURN"), in->op_return_data.bytes,
                             in->op_return_data.size)) {
             return -1;  // user aborted
           }
+#ifndef BITCOIN_ONLY
         }
+#endif
       }
+
     }
     uint32_t r = 0;
     out->script_pubkey.bytes[0] = 0x6A;

--- a/lib/firmware/zcash.c
+++ b/lib/firmware/zcash.c
@@ -57,7 +57,7 @@
  * Used for: I = BLAKE2b-512("ZcashIP32Orchard", seed)
  * NOT used for child derivation (which uses PRF^expand).
  */
-static void zip32_orchard_master(const uint8_t *seed, size_t seed_len,
+static void zip32_orchard_master(const uint8_t* seed, size_t seed_len,
                                  uint8_t out[64]) {
   BLAKE2B_CTX ctx;
   blake2b_InitPersonal(&ctx, 64, "ZcashIP32Orchard", 16);
@@ -66,7 +66,7 @@ static void zip32_orchard_master(const uint8_t *seed, size_t seed_len,
 }
 
 /* PRF^expand(sk, t) = BLAKE2b-512("Zcash_ExpandSeed", sk || t) */
-static void prf_expand(const uint8_t sk[32], const uint8_t *t, size_t t_len,
+static void prf_expand(const uint8_t sk[32], const uint8_t* t, size_t t_len,
                        uint8_t out[64]) {
   BLAKE2B_CTX ctx;
   blake2b_InitPersonal(&ctx, 64, "Zcash_ExpandSeed", 16);
@@ -82,10 +82,9 @@ static void prf_expand(const uint8_t sk[32], const uint8_t *t, size_t t_len,
  * Verified: R + 3*q == 2^256.
  */
 static const uint8_t two_256_mod_q[32] = {
-    0xfd, 0xff, 0xff, 0xff, 0x9c, 0x3e, 0x2b, 0x5b,
-    0x67, 0x05, 0x42, 0xe3, 0x0b, 0x35, 0x2c, 0x99,
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x3f,
+    0xfd, 0xff, 0xff, 0xff, 0x9c, 0x3e, 0x2b, 0x5b, 0x67, 0x05, 0x42,
+    0xe3, 0x0b, 0x35, 0x2c, 0x99, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x3f,
 };
 
 /*
@@ -95,10 +94,9 @@ static const uint8_t two_256_mod_q[32] = {
  * Verified: R + 3*p == 2^256.
  */
 static const uint8_t two_256_mod_p[32] = {
-    0xfd, 0xff, 0xff, 0xff, 0x38, 0x6d, 0x78, 0x34,
-    0xad, 0x14, 0x19, 0xe4, 0x0b, 0x35, 0x2c, 0x99,
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x3f,
+    0xfd, 0xff, 0xff, 0xff, 0x38, 0x6d, 0x78, 0x34, 0xad, 0x14, 0x19,
+    0xe4, 0x0b, 0x35, 0x2c, 0x99, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x3f,
 };
 
 /*
@@ -171,8 +169,8 @@ static void to_base(const uint8_t input[64], uint8_t output[32]) {
 /* Hardened child index */
 #define ZIP32_HARDENED 0x80000000
 
-bool zcash_derive_orchard_keys(const uint8_t *seed, uint32_t seed_len,
-                               uint32_t account, ZcashOrchardKeys *keys) {
+bool zcash_derive_orchard_keys(const uint8_t* seed, uint32_t seed_len,
+                               uint32_t account, ZcashOrchardKeys* keys) {
   uint8_t I[64];
   uint8_t sk[32], chain_code[32];
 
@@ -192,16 +190,16 @@ bool zcash_derive_orchard_keys(const uint8_t *seed, uint32_t seed_len,
    * So: I = BLAKE2b-512("Zcash_ExpandSeed",
    *           chain_code || 0x81 || sk || index_le)
    */
-  uint32_t path[3] = {
-      32 | ZIP32_HARDENED,       /* Purpose (Orchard) */
-      133 | ZIP32_HARDENED,      /* Coin type (Zcash) */
-      account | ZIP32_HARDENED   /* Account */
+  const uint32_t path[3] = {
+      32 | ZIP32_HARDENED,     /* Purpose (Orchard) */
+      133 | ZIP32_HARDENED,    /* Coin type (Zcash) */
+      account | ZIP32_HARDENED /* Account */
   };
 
   for (int i = 0; i < 3; i++) {
     /* Build PRF^expand input: [0x81] || sk || I2LEOSP32(index) */
     uint8_t child_input[1 + 32 + 4];
-    child_input[0] = 0x81;  /* ORCHARD_ZIP32_CHILD domain separator */
+    child_input[0] = 0x81; /* ORCHARD_ZIP32_CHILD domain separator */
     memcpy(child_input + 1, sk, 32);
     /* Little-endian index (I2LEOSP32) */
     uint32_t idx = path[i];
@@ -249,7 +247,8 @@ bool zcash_derive_orchard_keys(const uint8_t *seed, uint32_t seed_len,
       /* neg_ask = order - ask */
       int32_t borrow = 0;
       for (int i = 0; i < 9; i++) {
-        int32_t diff = (int32_t)neg_ask.val[i] - (int32_t)ask_val.val[i] + borrow;
+        int32_t diff =
+            (int32_t)neg_ask.val[i] - (int32_t)ask_val.val[i] + borrow;
         if (diff < 0) {
           diff += (1 << 29);
           borrow = -1;

--- a/lib/firmware/zcash.c
+++ b/lib/firmware/zcash.c
@@ -1,0 +1,308 @@
+/*
+ * This file is part of the KeepKey project.
+ *
+ * Copyright (C) 2025 KeepKey
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "keepkey/firmware/zcash.h"
+
+#include <string.h>
+
+#include "trezor/crypto/bignum.h"
+#include "trezor/crypto/blake2b.h"
+#include "trezor/crypto/hasher.h"
+#include "trezor/crypto/memzero.h"
+#include "trezor/crypto/pallas.h"
+#include "trezor/crypto/redpallas.h"
+
+/*
+ * ZIP-32 Orchard key derivation.
+ *
+ * Master key:
+ *   I = BLAKE2b-512("ZcashIP32Orchard", seed)
+ *   sk = I[0..32], chain_code = I[32..64]
+ *
+ * Child derivation (hardened only):
+ *   I = BLAKE2b-512("ZcashIP32Orchard", chain_code,
+ *                    0x11 || sk || i_be)
+ *   where 0x11 indicates hardened derivation with Orchard,
+ *   and i_be is the 4-byte big-endian child index with the hardened bit set.
+ *
+ * From the spending key sk, subkeys are derived using PRF^expand:
+ *   PRF^expand(sk, t) = BLAKE2b-512("Zcash_ExpandSeed", sk || t)
+ *
+ *   ask  = ToScalar(PRF^expand(sk, [0x06]))
+ *   nk   = ToBase(PRF^expand(sk, [0x07]))
+ *   rivk = ToScalar(PRF^expand(sk, [0x08]))
+ *
+ * ToScalar: interpret 64 bytes as LE integer, reduce mod order
+ * ToBase: interpret 64 bytes as LE integer, reduce mod prime
+ */
+
+/*
+ * BLAKE2b-512 with personalization "ZcashIP32Orchard" — master key only.
+ * Used for: I = BLAKE2b-512("ZcashIP32Orchard", seed)
+ * NOT used for child derivation (which uses PRF^expand).
+ */
+static void zip32_orchard_master(const uint8_t *seed, size_t seed_len,
+                                 uint8_t out[64]) {
+  BLAKE2B_CTX ctx;
+  blake2b_InitPersonal(&ctx, 64, "ZcashIP32Orchard", 16);
+  blake2b_Update(&ctx, seed, seed_len);
+  blake2b_Final(&ctx, out, 64);
+}
+
+/* PRF^expand(sk, t) = BLAKE2b-512("Zcash_ExpandSeed", sk || t) */
+static void prf_expand(const uint8_t sk[32], const uint8_t *t, size_t t_len,
+                       uint8_t out[64]) {
+  BLAKE2B_CTX ctx;
+  blake2b_InitPersonal(&ctx, 64, "Zcash_ExpandSeed", 16);
+  blake2b_Update(&ctx, sk, 32);
+  blake2b_Update(&ctx, t, t_len);
+  blake2b_Final(&ctx, out, 64);
+}
+
+/*
+ * 2^256 mod q (Pallas scalar field order), little-endian.
+ * q = 0x40000000000000000000000000000000224698fc0994a8dd8c46eb2100000001
+ * R = 0x3FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF992C350BE34205675B2B3E9CFFFFFFFD
+ * Verified: R + 3*q == 2^256.
+ */
+static const uint8_t two_256_mod_q[32] = {
+    0xfd, 0xff, 0xff, 0xff, 0x9c, 0x3e, 0x2b, 0x5b,
+    0x67, 0x05, 0x42, 0xe3, 0x0b, 0x35, 0x2c, 0x99,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x3f,
+};
+
+/*
+ * 2^256 mod p (Pallas base field prime), little-endian.
+ * p = 0x40000000000000000000000000000000224698fc094cf91b992d30ed00000001
+ * R = 0x3FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF992C350BE41914AD34786D38FFFFFFFD
+ * Verified: R + 3*p == 2^256.
+ */
+static const uint8_t two_256_mod_p[32] = {
+    0xfd, 0xff, 0xff, 0xff, 0x38, 0x6d, 0x78, 0x34,
+    0xad, 0x14, 0x19, 0xe4, 0x0b, 0x35, 0x2c, 0x99,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x3f,
+};
+
+/*
+ * ToScalar: reduce a 512-bit LE integer mod Pallas scalar order.
+ *
+ * Uses wide reduction matching the orchard crate's from_uniform_bytes:
+ *   result = (lo + hi * 2^256) mod q
+ * where lo = input[0..31], hi = input[32..63] (little-endian).
+ */
+static void to_scalar(const uint8_t input[64], uint8_t output[32]) {
+  bignum256 lo, hi, t256, result;
+
+  bn_read_le(input, &lo);
+  pallas_mod_q(&lo);
+
+  bn_read_le(input + 32, &hi);
+  pallas_mod_q(&hi);
+
+  bn_read_le(two_256_mod_q, &t256);
+
+  /* result = hi * (2^256 mod q) mod q */
+  bn_copy(&hi, &result);
+  pallas_mul_mod_q(&result, &t256);
+
+  /* result = result + lo mod q */
+  pallas_add_mod_q(&result, &lo);
+
+  bn_write_le(&result, output);
+
+  memzero(&lo, sizeof(lo));
+  memzero(&hi, sizeof(hi));
+  memzero(&result, sizeof(result));
+}
+
+/*
+ * ToBase: reduce a 512-bit LE integer mod Pallas base field prime.
+ *
+ * Uses wide reduction:
+ *   result = (lo + hi * 2^256) mod p
+ * where lo = input[0..31], hi = input[32..63] (little-endian).
+ */
+static void to_base(const uint8_t input[64], uint8_t output[32]) {
+  bignum256 lo, hi, t256, result;
+
+  bn_read_le(input, &lo);
+  pallas_mod_p(&lo);
+
+  bn_read_le(input + 32, &hi);
+  pallas_mod_p(&hi);
+
+  bn_read_le(two_256_mod_p, &t256);
+
+  /* result = hi * (2^256 mod p) mod p */
+  bn_copy(&hi, &result);
+  pallas_mul_mod_p(&result, &t256);
+
+  /* result = result + lo mod p */
+  bignum256 sum;
+  pallas_add_mod_p(&result, &lo, &sum);
+  bn_copy(&sum, &result);
+  memzero(&sum, sizeof(sum));
+
+  bn_write_le(&result, output);
+
+  memzero(&lo, sizeof(lo));
+  memzero(&hi, sizeof(hi));
+  memzero(&result, sizeof(result));
+}
+
+/* Hardened child index */
+#define ZIP32_HARDENED 0x80000000
+
+bool zcash_derive_orchard_keys(const uint8_t *seed, uint32_t seed_len,
+                               uint32_t account, ZcashOrchardKeys *keys) {
+  uint8_t I[64];
+  uint8_t sk[32], chain_code[32];
+
+  /* Step 1: Master key from seed
+   * I = BLAKE2b-512("ZcashIP32Orchard", seed) */
+  zip32_orchard_master(seed, seed_len, I);
+  memcpy(sk, I, 32);
+  memcpy(chain_code, I + 32, 32);
+
+  /* Step 2: Derive path m_orchard / 32' / 133' / account'
+   *
+   * CKDOrchard child derivation (ZIP-32 hardened-only):
+   *   I = PRF^expand(chain_code, [0x81] || sk || I2LEOSP32(index))
+   *
+   * PRF^expand(sk, t) = BLAKE2b-512("Zcash_ExpandSeed", sk || t)
+   *
+   * So: I = BLAKE2b-512("Zcash_ExpandSeed",
+   *           chain_code || 0x81 || sk || index_le)
+   */
+  uint32_t path[3] = {
+      32 | ZIP32_HARDENED,       /* Purpose (Orchard) */
+      133 | ZIP32_HARDENED,      /* Coin type (Zcash) */
+      account | ZIP32_HARDENED   /* Account */
+  };
+
+  for (int i = 0; i < 3; i++) {
+    /* Build PRF^expand input: [0x81] || sk || I2LEOSP32(index) */
+    uint8_t child_input[1 + 32 + 4];
+    child_input[0] = 0x81;  /* ORCHARD_ZIP32_CHILD domain separator */
+    memcpy(child_input + 1, sk, 32);
+    /* Little-endian index (I2LEOSP32) */
+    uint32_t idx = path[i];
+    child_input[33] = idx & 0xff;
+    child_input[34] = (idx >> 8) & 0xff;
+    child_input[35] = (idx >> 16) & 0xff;
+    child_input[36] = (idx >> 24) & 0xff;
+
+    /* PRF^expand(chain_code, child_input) */
+    prf_expand(chain_code, child_input, sizeof(child_input), I);
+    memcpy(sk, I, 32);
+    memcpy(chain_code, I + 32, 32);
+
+    memzero(child_input, sizeof(child_input));
+  }
+
+  /* Step 3: Derive subkeys from final spending key */
+  memcpy(keys->sk, sk, 32);
+
+  uint8_t expanded[64];
+
+  /* ask = ToScalar(PRF^expand(sk, [0x06])) */
+  uint8_t t_ask = 0x06;
+  prf_expand(sk, &t_ask, 1, expanded);
+  to_scalar(expanded, keys->ask);
+
+  /*
+   * Zcash spec (§ 4.2.3): If [ask]*G_spendauth has odd y (ỹ = 1),
+   * negate ask so that the resulting ak always has ỹ = 0.
+   * This matches the orchard crate's SpendAuthorizingKey::from() behavior.
+   */
+  {
+    bignum256 ask_test;
+    bn_read_le(keys->ask, &ask_test);
+    curve_point ak_test;
+    redpallas_scalar_mult_spendauth_G(&ask_test, &ak_test);
+    if (bn_is_odd(&ak_test.y)) {
+      /* ask = order - ask (negate mod q) */
+      bignum256 neg_ask;
+      bn_copy(&pallas_order, &neg_ask);
+      bignum256 ask_val;
+      bn_read_le(keys->ask, &ask_val);
+      bn_normalize(&ask_val);
+      bn_normalize(&neg_ask);
+      /* neg_ask = order - ask */
+      int32_t borrow = 0;
+      for (int i = 0; i < 9; i++) {
+        int32_t diff = (int32_t)neg_ask.val[i] - (int32_t)ask_val.val[i] + borrow;
+        if (diff < 0) {
+          diff += (1 << 29);
+          borrow = -1;
+        } else {
+          borrow = 0;
+        }
+        neg_ask.val[i] = (uint32_t)diff;
+      }
+      bn_write_le(&neg_ask, keys->ask);
+      memzero(&neg_ask, sizeof(neg_ask));
+      memzero(&ask_val, sizeof(ask_val));
+    }
+    memzero(&ask_test, sizeof(ask_test));
+    memzero(&ak_test, sizeof(ak_test));
+  }
+
+  /* nk = ToBase(PRF^expand(sk, [0x07])) */
+  uint8_t t_nk = 0x07;
+  prf_expand(sk, &t_nk, 1, expanded);
+  to_base(expanded, keys->nk);
+
+  /* rivk = ToScalar(PRF^expand(sk, [0x08])) */
+  uint8_t t_rivk = 0x08;
+  prf_expand(sk, &t_rivk, 1, expanded);
+  to_scalar(expanded, keys->rivk);
+
+  /* Clean up */
+  memzero(I, sizeof(I));
+  memzero(sk, sizeof(sk));
+  memzero(chain_code, sizeof(chain_code));
+  memzero(expanded, sizeof(expanded));
+
+  return true;
+}
+
+bool zcash_compute_shielded_sighash(const uint8_t header_digest[32],
+                                    const uint8_t transparent_digest[32],
+                                    const uint8_t sapling_digest[32],
+                                    const uint8_t orchard_digest[32],
+                                    uint32_t branch_id,
+                                    uint8_t sighash_out[32]) {
+  Hasher h;
+  uint8_t personal[16];
+
+  memcpy(personal, "ZcashTxHash_", 12);
+  memcpy(personal + 12, &branch_id, 4);
+
+  hasher_InitParam(&h, HASHER_BLAKE2B_PERSONAL, personal, 16);
+  hasher_Update(&h, header_digest, 32);
+  hasher_Update(&h, transparent_digest, 32);
+  hasher_Update(&h, sapling_digest, 32);
+  hasher_Update(&h, orchard_digest, 32);
+  hasher_Final(&h, sighash_out);
+
+  return true;
+}

--- a/lib/transport/CMakeLists.txt
+++ b/lib/transport/CMakeLists.txt
@@ -18,6 +18,8 @@ set(protoc_pb_sources
     ${DEVICE_PROTOCOL}/messages-solana.proto
     ${DEVICE_PROTOCOL}/messages-tron.proto
     ${DEVICE_PROTOCOL}/messages-ton.proto
+    ${CMAKE_BINARY_DIR}/lib/transport/messages-zcash.proto
+    ${DEVICE_PROTOCOL}/messages-zcash.proto
     ${DEVICE_PROTOCOL}/messages.proto)
 
 set(protoc_pb_options
@@ -35,6 +37,7 @@ set(protoc_pb_options
     ${CMAKE_SOURCE_DIR}/include/keepkey/transport/messages-solana.options
     ${CMAKE_SOURCE_DIR}/include/keepkey/transport/messages-tron.options
     ${CMAKE_SOURCE_DIR}/include/keepkey/transport/messages-ton.options
+    ${CMAKE_SOURCE_DIR}/include/keepkey/transport/messages-zcash.options
     ${CMAKE_SOURCE_DIR}/include/keepkey/transport/messages.options)
 
 set(protoc_c_sources
@@ -52,6 +55,7 @@ set(protoc_c_sources
     ${CMAKE_BINARY_DIR}/lib/transport/messages-solana.pb.c
     ${CMAKE_BINARY_DIR}/lib/transport/messages-tron.pb.c
     ${CMAKE_BINARY_DIR}/lib/transport/messages-ton.pb.c
+    ${CMAKE_BINARY_DIR}/lib/transport/messages-zcash.pb.c
     ${CMAKE_BINARY_DIR}/lib/transport/messages.pb.c)
 
 set(protoc_c_headers
@@ -69,6 +73,7 @@ set(protoc_c_headers
     ${CMAKE_BINARY_DIR}/include/messages-solana.pb.h
     ${CMAKE_BINARY_DIR}/include/messages-tron.pb.h
     ${CMAKE_BINARY_DIR}/include/messages-ton.pb.h
+    ${CMAKE_BINARY_DIR}/include/messages-zcash.pb.h
     ${CMAKE_BINARY_DIR}/include/messages.pb.h)
 
 set(protoc_pb_sources_moved
@@ -86,6 +91,8 @@ set(protoc_pb_sources_moved
     ${CMAKE_BINARY_DIR}/lib/transport/messages-solana.proto
     ${CMAKE_BINARY_DIR}/lib/transport/messages-tron.proto
     ${CMAKE_BINARY_DIR}/lib/transport/messages-ton.proto
+    ${CMAKE_BINARY_DIR}/lib/transport/messages-zcash.proto
+    ${DEVICE_PROTOCOL}/messages-zcash.proto
     ${CMAKE_BINARY_DIR}/lib/transport/messages.proto)
 
 add_custom_command(
@@ -163,6 +170,9 @@ add_custom_command(
     ${PROTOC_BINARY} -I. -I/usr/include
       --plugin=nanopb=${NANOPB_DIR}/generator/protoc-gen-nanopb
       "--nanopb_out=-f messages-ton.options:." messages-ton.proto
+      "--nanopb_out=-f messages-zcash.options:." messages-zcash.proto
+    ${CMAKE_BINARY_DIR}/lib/transport/messages-zcash.proto
+    ${DEVICE_PROTOCOL}/messages-zcash.proto
   COMMAND
     ${PROTOC_BINARY} -I. -I/usr/include
       --plugin=nanopb=${NANOPB_DIR}/generator/protoc-gen-nanopb

--- a/lib/transport/CMakeLists.txt
+++ b/lib/transport/CMakeLists.txt
@@ -18,7 +18,6 @@ set(protoc_pb_sources
     ${DEVICE_PROTOCOL}/messages-solana.proto
     ${DEVICE_PROTOCOL}/messages-tron.proto
     ${DEVICE_PROTOCOL}/messages-ton.proto
-    ${CMAKE_BINARY_DIR}/lib/transport/messages-zcash.proto
     ${DEVICE_PROTOCOL}/messages-zcash.proto
     ${DEVICE_PROTOCOL}/messages.proto)
 
@@ -92,7 +91,6 @@ set(protoc_pb_sources_moved
     ${CMAKE_BINARY_DIR}/lib/transport/messages-tron.proto
     ${CMAKE_BINARY_DIR}/lib/transport/messages-ton.proto
     ${CMAKE_BINARY_DIR}/lib/transport/messages-zcash.proto
-    ${DEVICE_PROTOCOL}/messages-zcash.proto
     ${CMAKE_BINARY_DIR}/lib/transport/messages.proto)
 
 add_custom_command(
@@ -170,9 +168,10 @@ add_custom_command(
     ${PROTOC_BINARY} -I. -I/usr/include
       --plugin=nanopb=${NANOPB_DIR}/generator/protoc-gen-nanopb
       "--nanopb_out=-f messages-ton.options:." messages-ton.proto
+  COMMAND
+    ${PROTOC_BINARY} -I. -I/usr/include
+      --plugin=nanopb=${NANOPB_DIR}/generator/protoc-gen-nanopb
       "--nanopb_out=-f messages-zcash.options:." messages-zcash.proto
-    ${CMAKE_BINARY_DIR}/lib/transport/messages-zcash.proto
-    ${DEVICE_PROTOCOL}/messages-zcash.proto
   COMMAND
     ${PROTOC_BINARY} -I. -I/usr/include
       --plugin=nanopb=${NANOPB_DIR}/generator/protoc-gen-nanopb


### PR DESCRIPTION
## Summary
- Zcash Orchard shielded transaction signing via PCZT (Partially Constructed Zcash Transaction)
- ZIP-32 Orchard Full Viewing Key derivation (ak, nk, rivk)
- Transparent-to-shielded (hybrid shielding) with per-input ECDSA signing
- Pallas/RedPallas curve support via trezor-firmware fork

## Submodule Pins
- device-protocol: 18bb4a7 (upstream master, Zcash IDs 1300-1307)
- python-keepkey: b0c54b0 (fork features/7.15-dev, 58 expanded tests)
- trezor-firmware: 376c64bc (Pallas/RedPallas crypto)

## Files
- `lib/firmware/zcash.c` — ZIP-32 key derivation + sighash computation
- `lib/firmware/fsm_msg_zcash.h` — FSM handlers (PCZT, FVK, transparent)
- `include/keepkey/firmware/zcash.h` — public API
- `lib/firmware/storage.c` — storage_getRawSeed() for ZIP-32

## Test Plan
- [ ] Build compiles (ARM + emulator)
- [ ] Zcash Orchard FVK derivation tests pass
- [ ] PCZT signing tests pass (legacy + device sighash)
- [ ] Transparent shielding tests pass
- [ ] Existing test suite unaffected