### PR TITLE
chore(deps): pin python-keepkey to fork master

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,7 +13,7 @@ path = code-signing-keys
 url = https://github.com/keepkey/code-signing-keys.git
 [submodule "deps/python-keepkey"]
 path = deps/python-keepkey
-url = https://github.com/keepkey/python-keepkey.git
+url = https://github.com/BitHighlander/python-keepkey.git
 branch = master
 [submodule "deps/qrenc/QR-Code-generator"]
 path = deps/qrenc/QR-Code-generator


### PR DESCRIPTION
## Summary

Repoint `deps/python-keepkey` from upstream `keepkey/python-keepkey` to the BitHighlander fork.

Fork master is now a strict superset of upstream master:

```
upstream/master (a6c6602)
  + feat(transport): add DylibTransport for in-process libkkemu testing
  + test(dylib): screenshot regression for ringbuf capacity + canvas semantics
  + fix(dylib): address PR #14 review
```

`DylibTransport` enables in-process testing against `libkkemu` without an external transport, used by upcoming integration tests.

Backup of fork master pre-reconcile: tag `backup/pre-reconcile-2026-04-28` on `BitHighlander/python-keepkey`.

## Changes

- `.gitmodules`: URL `keepkey/python-keepkey.git` → `BitHighlander/python-keepkey.git`
- `deps/python-keepkey` pin: `62cc0d8` → `d4eda86`

## Test plan

- [ ] CI fetches submodule from new URL
- [ ] Existing python-keepkey integration tests still pass against d4eda86
- [ ] DylibTransport tests are available to firmware test suites