### PR TITLE
feat(tron): TIP-191 SignMessage + VerifyMessage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -511,6 +511,7 @@ jobs:
       - name: Generate test report PDF
         env:
           FW_VERSION: ${{ steps.version.outputs.fw_version }}
+          KK_BUILD_LABEL: ${{ github.head_ref || github.ref_name }}@${{ github.event.pull_request.head.sha || github.sha }}
         run: python3 scripts/generate-test-report.py
 
       - name: Upload test report

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,7 +13,7 @@ path = code-signing-keys
 url = https://github.com/keepkey/code-signing-keys.git
 [submodule "deps/python-keepkey"]
 path = deps/python-keepkey
-url = https://github.com/keepkey/python-keepkey.git
+url = https://github.com/BitHighlander/python-keepkey.git
 branch = master
 [submodule "deps/qrenc/QR-Code-generator"]
 path = deps/qrenc/QR-Code-generator

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "deps/device-protocol"]
 path = deps/device-protocol
 url = https://github.com/BitHighlander/device-protocol.git
-branch = feat/message-signing-parity
+branch = master
 [submodule "deps/trezor-firmware"]
 path = deps/crypto/trezor-firmware
 url = https://github.com/keepkey/trezor-firmware.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "deps/device-protocol"]
 path = deps/device-protocol
-url = https://github.com/keepkey/device-protocol.git
-branch = master
+url = https://github.com/BitHighlander/device-protocol.git
+branch = feat/message-signing-parity
 [submodule "deps/trezor-firmware"]
 path = deps/crypto/trezor-firmware
 url = https://github.com/keepkey/trezor-firmware.git

--- a/include/keepkey/firmware/fsm.h
+++ b/include/keepkey/firmware/fsm.h
@@ -120,6 +120,8 @@ void fsm_msgMayachainMsgAck(const MayachainMsgAck* msg);
 
 void fsm_msgTronGetAddress(const TronGetAddress* msg);
 void fsm_msgTronSignTx(TronSignTx* msg);
+void fsm_msgTronSignMessage(TronSignMessage* msg);
+void fsm_msgTronVerifyMessage(const TronVerifyMessage* msg);
 void fsm_msgTonGetAddress(const TonGetAddress* msg);
 void fsm_msgTonSignTx(TonSignTx* msg);
 void fsm_msgSolanaGetAddress(const SolanaGetAddress* msg);

--- a/include/keepkey/firmware/tron.h
+++ b/include/keepkey/firmware/tron.h
@@ -56,4 +56,21 @@ void tron_formatAmount(char* buf, size_t len, uint64_t amount);
  */
 bool tron_signTx(const HDNode* node, const TronSignTx* msg, TronSignedTx* resp);
 
+/**
+ * Sign an arbitrary message using TIP-191 personal_sign.
+ * Hash = keccak256("\x19TRON Signed Message:\n" + ASCII(len) + message)
+ * @param node HD node containing private key
+ * @param msg TronSignMessage request
+ * @param resp TronMessageSignature response (signature + Base58Check address)
+ * @return true on success
+ */
+bool tron_message_sign(const HDNode* node, const TronSignMessage* msg,
+                       TronMessageSignature* resp);
+
+/**
+ * Verify a TIP-191 signature against the claimed Base58Check TRON address.
+ * @return 0 on success, 1 on malformed input, 2 on signature/address mismatch
+ */
+int tron_message_verify(const TronVerifyMessage* msg);
+
 #endif

--- a/include/keepkey/transport/messages-solana.options
+++ b/include/keepkey/transport/messages-solana.options
@@ -19,3 +19,10 @@ SolanaSignMessage.message max_size:1024
 
 SolanaMessageSignature.public_key max_size:32
 SolanaMessageSignature.signature max_size:64
+
+SolanaSignOffchainMessage.address_n max_count:8
+SolanaSignOffchainMessage.coin_name max_size:21
+SolanaSignOffchainMessage.message max_size:1212
+
+SolanaOffchainMessageSignature.public_key max_size:32
+SolanaOffchainMessageSignature.signature max_size:64

--- a/include/keepkey/transport/messages-ton.options
+++ b/include/keepkey/transport/messages-ton.options
@@ -11,3 +11,10 @@ TonSignTx.to_address max_size:50
 TonSignTx.memo max_size:121
 
 TonSignedTx.signature max_size:64
+
+TonSignMessage.address_n max_count:8
+TonSignMessage.coin_name max_size:21
+TonSignMessage.message max_size:1024
+
+TonMessageSignature.public_key max_size:32
+TonMessageSignature.signature max_size:64

--- a/include/keepkey/transport/messages-tron.options
+++ b/include/keepkey/transport/messages-tron.options
@@ -19,3 +19,22 @@ TronSignTx.data max_size:256
 
 TronSignedTx.signature max_size:65
 TronSignedTx.serialized_tx max_size:1024
+
+TronSignMessage.address_n max_count:8
+TronSignMessage.coin_name max_size:21
+TronSignMessage.message max_size:1024
+
+TronMessageSignature.address max_size:35
+TronMessageSignature.signature max_size:65
+
+TronVerifyMessage.address max_size:35
+TronVerifyMessage.signature max_size:65
+TronVerifyMessage.message max_size:1024
+
+TronSignTypedHash.address_n max_count:8
+TronSignTypedHash.coin_name max_size:21
+TronSignTypedHash.domain_separator_hash max_size:32
+TronSignTypedHash.message_hash max_size:32
+
+TronTypedDataSignature.address max_size:35
+TronTypedDataSignature.signature max_size:65

--- a/lib/firmware/ethereum.c
+++ b/lib/firmware/ethereum.c
@@ -307,6 +307,23 @@ static void send_signature(void) {
 
   ethereum_signing_abort();
 }
+
+/* For EIP-1559 the empty access list (`0xC0`) closes the RLP body and MUST
+ * be the last byte fed to keccak before signing. Hashing it earlier — e.g.
+ * right after `data_initial_chunk` in `ethereum_signing_init` — would
+ * sandwich it between data chunks whenever `data_total > 1024`, producing a
+ * non-canonical pre-image whose signature recovers to a wrong-but-
+ * deterministic address (looks like a "malformed sig" / dropped tx).
+ * Call this helper from every `send_signature()` call site instead.
+ */
+static void finalize_eip1559_and_send_signature(void) {
+  if (ethereum_tx_type == ETHEREUM_TX_TYPE_EIP_1559) {
+    uint8_t datbuf[1] = {0xC0}; /* empty access list (0-length list) */
+    hash_data(datbuf, sizeof(datbuf));
+  }
+  send_signature();
+}
+
 /* Format a 256 bit number (amount in wei) into a human readable format
  * using standard ethereum units.
  * The buffer must be at least 25 bytes.
@@ -867,18 +884,12 @@ void ethereum_signing_init(EthereumSignTx* msg, const HDNode* node,
   hash_data(msg->data_initial_chunk.bytes, msg->data_initial_chunk.size);
   data_left = data_total - msg->data_initial_chunk.size;
 
-  if (ethereum_tx_type == ETHEREUM_TX_TYPE_EIP_1559) {
-    // Keepkey does not support an access list size >0 at this time
-    uint8_t datbuf[1] = {0xC0};  // size of empty access list
-    hash_data(datbuf, sizeof(datbuf));
-  }
-
   memcpy(privkey, node->private_key, 32);
 
   if (data_left > 0) {
     send_request_chunk();
   } else {
-    send_signature();
+    finalize_eip1559_and_send_signature();
   }
 }
 
@@ -909,7 +920,7 @@ void ethereum_signing_txack(EthereumTxAck* tx) {
   if (data_left > 0) {
     send_request_chunk();
   } else {
-    send_signature();
+    finalize_eip1559_and_send_signature();
   }
 }
 

--- a/lib/firmware/fsm_msg_tron.h
+++ b/lib/firmware/fsm_msg_tron.h
@@ -138,3 +138,131 @@ void fsm_msgTronSignTx(TronSignTx* msg) {
   msg_write(MessageType_MessageType_TronSignedTx, resp);
   layoutHome();
 }
+
+#ifndef TRON_MSG_DISPLAY_MAX
+#define TRON_MSG_DISPLAY_MAX (38 * 3)  // mirrors ETH MSG_MAX (3 lines × 38 chars)
+#endif
+
+void fsm_msgTronSignMessage(TronSignMessage* msg) {
+  RESP_INIT(TronMessageSignature);
+
+  CHECK_INITIALIZED
+
+  CHECK_PIN
+
+  // Validate path: m/44'/195'/...
+  if (msg->address_n_count < 3 || msg->address_n[0] != (0x80000000 | 44) ||
+      msg->address_n[1] != (0x80000000 | 195)) {
+    fsm_sendFailure(FailureType_Failure_Other,
+                    _("Invalid TRON path (expected m/44'/195'/...)"));
+    layoutHome();
+    return;
+  }
+
+  char msgBuf[TRON_MSG_DISPLAY_MAX + 1] = {0};
+  const char* typeIndicator;
+  bool canPrint = true;
+  unsigned ctr;
+
+  for (ctr = 0; ctr < msg->message.size; ctr++) {
+    if (isprint(msg->message.bytes[ctr]) == false) {
+      canPrint = false;
+      break;
+    }
+  }
+
+  if (canPrint) {
+    typeIndicator = "Sign TRON Message";
+    unsigned copy = msg->message.size;
+    if (copy > TRON_MSG_DISPLAY_MAX) copy = TRON_MSG_DISPLAY_MAX;
+    memcpy(msgBuf, msg->message.bytes, copy);
+    msgBuf[copy] = '\0';
+  } else {
+    typeIndicator = "Sign TRON Bytes";
+    unsigned hexBytes = msg->message.size;
+    if (hexBytes * 2 > TRON_MSG_DISPLAY_MAX) {
+      hexBytes = TRON_MSG_DISPLAY_MAX / 2;
+    }
+    for (ctr = 0; ctr < hexBytes; ctr++) {
+      snprintf(&msgBuf[2 * ctr], 3, "%02x", msg->message.bytes[ctr]);
+    }
+  }
+
+  if (!confirm(ButtonRequestType_ButtonRequest_ProtectCall, _(typeIndicator),
+               "%s", msgBuf)) {
+    fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
+    layoutHome();
+    return;
+  }
+
+  HDNode* node = fsm_getDerivedNode(SECP256K1_NAME, msg->address_n,
+                                    msg->address_n_count, NULL);
+  if (!node) return;
+  hdnode_fill_public_key(node);
+
+  if (!tron_message_sign(node, msg, resp)) {
+    memzero(node, sizeof(*node));
+    fsm_sendFailure(FailureType_Failure_Other, _("TRON message signing failed"));
+    layoutHome();
+    return;
+  }
+
+  memzero(node, sizeof(*node));
+  msg_write(MessageType_MessageType_TronMessageSignature, resp);
+  layoutHome();
+}
+
+void fsm_msgTronVerifyMessage(const TronVerifyMessage* msg) {
+  CHECK_PARAM(msg->has_address, _("No address provided"));
+  CHECK_PARAM(msg->has_message, _("No message provided"));
+  CHECK_PARAM(msg->has_signature, _("No signature provided"));
+
+  if (tron_message_verify(msg) != 0) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError, _("Invalid signature"));
+    return;
+  }
+
+  if (!confirm_address(_("Confirm Signer"), msg->address)) {
+    fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
+    layoutHome();
+    return;
+  }
+
+  char msgBuf[TRON_MSG_DISPLAY_MAX + 1] = {0};
+  const char* typeIndicator;
+  bool canPrint = true;
+  unsigned ctr;
+
+  for (ctr = 0; ctr < msg->message.size; ctr++) {
+    if (isprint(msg->message.bytes[ctr]) == false) {
+      canPrint = false;
+      break;
+    }
+  }
+
+  if (canPrint) {
+    typeIndicator = "Message Verified";
+    unsigned copy = msg->message.size;
+    if (copy > TRON_MSG_DISPLAY_MAX) copy = TRON_MSG_DISPLAY_MAX;
+    memcpy(msgBuf, msg->message.bytes, copy);
+    msgBuf[copy] = '\0';
+  } else {
+    typeIndicator = "Bytes Verified";
+    unsigned hexBytes = msg->message.size;
+    if (hexBytes * 2 > TRON_MSG_DISPLAY_MAX) {
+      hexBytes = TRON_MSG_DISPLAY_MAX / 2;
+    }
+    for (ctr = 0; ctr < hexBytes; ctr++) {
+      snprintf(&msgBuf[2 * ctr], 3, "%02x", msg->message.bytes[ctr]);
+    }
+  }
+
+  if (!confirm(ButtonRequestType_ButtonRequest_Other, _(typeIndicator), "%s",
+               msgBuf)) {
+    fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
+    layoutHome();
+    return;
+  }
+  fsm_sendSuccess(_("Message verified"));
+  layoutHome();
+}

--- a/lib/firmware/fsm_msg_tron.h
+++ b/lib/firmware/fsm_msg_tron.h
@@ -140,7 +140,8 @@ void fsm_msgTronSignTx(TronSignTx* msg) {
 }
 
 #ifndef TRON_MSG_DISPLAY_MAX
-#define TRON_MSG_DISPLAY_MAX (38 * 3)  // mirrors ETH MSG_MAX (3 lines × 38 chars)
+#define TRON_MSG_DISPLAY_MAX \
+  (38 * 3)  // mirrors ETH MSG_MAX (3 lines × 38 chars)
 #endif
 
 void fsm_msgTronSignMessage(TronSignMessage* msg) {
@@ -202,7 +203,8 @@ void fsm_msgTronSignMessage(TronSignMessage* msg) {
 
   if (!tron_message_sign(node, msg, resp)) {
     memzero(node, sizeof(*node));
-    fsm_sendFailure(FailureType_Failure_Other, _("TRON message signing failed"));
+    fsm_sendFailure(FailureType_Failure_Other,
+                    _("TRON message signing failed"));
     layoutHome();
     return;
   }

--- a/lib/firmware/messagemap.def
+++ b/lib/firmware/messagemap.def
@@ -135,9 +135,12 @@
     /* TRON */
     MSG_IN(MessageType_MessageType_TronGetAddress,                 TronGetAddress,              fsm_msgTronGetAddress)
     MSG_IN(MessageType_MessageType_TronSignTx,                     TronSignTx,                  fsm_msgTronSignTx)
+    MSG_IN(MessageType_MessageType_TronSignMessage,                TronSignMessage,             fsm_msgTronSignMessage)
+    MSG_IN(MessageType_MessageType_TronVerifyMessage,              TronVerifyMessage,           fsm_msgTronVerifyMessage)
 
     MSG_OUT(MessageType_MessageType_TronAddress,                   TronAddress,                 NO_PROCESS_FUNC)
     MSG_OUT(MessageType_MessageType_TronSignedTx,                  TronSignedTx,                NO_PROCESS_FUNC)
+    MSG_OUT(MessageType_MessageType_TronMessageSignature,          TronMessageSignature,        NO_PROCESS_FUNC)
 
     /* TON */
     MSG_IN(MessageType_MessageType_TonGetAddress,                  TonGetAddress,               fsm_msgTonGetAddress)

--- a/lib/firmware/tron.c
+++ b/lib/firmware/tron.c
@@ -130,3 +130,147 @@ bool tron_signTx(const HDNode* node, const TronSignTx* msg,
 
   return true;
 }
+
+static int tron_is_canonic(uint8_t v, uint8_t signature[64]) {
+  (void)v;
+  (void)signature;
+  return 0;
+}
+
+/**
+ * Compute the TIP-191 personal_sign hash:
+ *   keccak256("\x19TRON Signed Message:\n" || ASCII(len) || message)
+ *
+ * Mirrors ethereum_message_hash() — only the prefix differs.
+ */
+static void tron_message_hash(const uint8_t* message, size_t message_len,
+                              uint8_t hash[32]) {
+  struct SHA3_CTX ctx;
+  uint8_t c;
+
+  sha3_256_Init(&ctx);
+  sha3_Update(&ctx, (const uint8_t*)"\x19" "TRON Signed Message:\n", 22);
+  if (message_len >= 1000000000) {
+    c = '0' + message_len / 1000000000 % 10;
+    sha3_Update(&ctx, &c, 1);
+  }
+  if (message_len >= 100000000) {
+    c = '0' + message_len / 100000000 % 10;
+    sha3_Update(&ctx, &c, 1);
+  }
+  if (message_len >= 10000000) {
+    c = '0' + message_len / 10000000 % 10;
+    sha3_Update(&ctx, &c, 1);
+  }
+  if (message_len >= 1000000) {
+    c = '0' + message_len / 1000000 % 10;
+    sha3_Update(&ctx, &c, 1);
+  }
+  if (message_len >= 100000) {
+    c = '0' + message_len / 100000 % 10;
+    sha3_Update(&ctx, &c, 1);
+  }
+  if (message_len >= 10000) {
+    c = '0' + message_len / 10000 % 10;
+    sha3_Update(&ctx, &c, 1);
+  }
+  if (message_len >= 1000) {
+    c = '0' + message_len / 1000 % 10;
+    sha3_Update(&ctx, &c, 1);
+  }
+  if (message_len >= 100) {
+    c = '0' + message_len / 100 % 10;
+    sha3_Update(&ctx, &c, 1);
+  }
+  if (message_len >= 10) {
+    c = '0' + message_len / 10 % 10;
+    sha3_Update(&ctx, &c, 1);
+  }
+  c = '0' + message_len % 10;
+  sha3_Update(&ctx, &c, 1);
+  sha3_Update(&ctx, message, message_len);
+  keccak_Final(&ctx, hash);
+}
+
+/**
+ * Sign an arbitrary message under TIP-191 personal_sign.
+ * Output signature is 65 bytes (r || s || v) where v = 27 + recovery_id.
+ */
+bool tron_message_sign(const HDNode* node, const TronSignMessage* msg,
+                       TronMessageSignature* resp) {
+  if (!node || !msg || !resp) {
+    return false;
+  }
+
+  // Caller must have populated node->public_key (hdnode_fill_public_key).
+  char address[TRON_ADDRESS_MAX_LEN];
+  if (!tron_getAddress(node->public_key, address, sizeof(address))) {
+    return false;
+  }
+
+  uint8_t hash[32];
+  tron_message_hash(msg->message.bytes, msg->message.size, hash);
+
+  uint8_t v;
+  if (ecdsa_sign_digest(&secp256k1, node->private_key, hash,
+                        resp->signature.bytes, &v, tron_is_canonic) != 0) {
+    memzero(hash, sizeof(hash));
+    return false;
+  }
+
+  resp->signature.bytes[64] = 27 + v;
+  resp->signature.size = 65;
+  resp->has_signature = true;
+
+  strlcpy(resp->address, address, sizeof(resp->address));
+  resp->has_address = true;
+
+  memzero(hash, sizeof(hash));
+  return true;
+}
+
+/**
+ * Verify a TIP-191 signature against the claimed Base58Check TRON address.
+ * Returns 0 on success, non-zero on malformed input or signature mismatch.
+ */
+int tron_message_verify(const TronVerifyMessage* msg) {
+  if (!msg || msg->signature.size != 65) {
+    return 1;
+  }
+
+  uint8_t pubkey[65];
+  uint8_t hash[32];
+
+  tron_message_hash(msg->message.bytes, msg->message.size, hash);
+
+  uint8_t v = msg->signature.bytes[64];
+  if (v >= 27) {
+    v -= 27;
+  }
+  if (v >= 2 || ecdsa_recover_pub_from_sig(&secp256k1, pubkey,
+                                           msg->signature.bytes, hash, v) != 0) {
+    memzero(hash, sizeof(hash));
+    return 2;
+  }
+
+  uint8_t addr_hash[32];
+  keccak_256(pubkey + 1, 64, addr_hash);
+
+  uint8_t addr_bytes[21];
+  addr_bytes[0] = TRON_ADDRESS_PREFIX;
+  memcpy(addr_bytes + 1, addr_hash + 12, 20);
+
+  char recovered_addr[TRON_ADDRESS_MAX_LEN];
+  if (!base58_encode_check(addr_bytes, 21, HASHER_SHA2D, recovered_addr,
+                           sizeof(recovered_addr))) {
+    memzero(hash, sizeof(hash));
+    memzero(addr_hash, sizeof(addr_hash));
+    return 2;
+  }
+
+  int rv = (strcmp(recovered_addr, msg->address) != 0) ? 2 : 0;
+
+  memzero(hash, sizeof(hash));
+  memzero(addr_hash, sizeof(addr_hash));
+  return rv;
+}

--- a/lib/firmware/tron.c
+++ b/lib/firmware/tron.c
@@ -250,8 +250,8 @@ int tron_message_verify(const TronVerifyMessage* msg) {
   if (v >= 27) {
     v -= 27;
   }
-  if (v >= 2 || ecdsa_recover_pub_from_sig(&secp256k1, pubkey,
-                                           msg->signature.bytes, hash, v) != 0) {
+  if (v >= 2 || ecdsa_recover_pub_from_sig(
+                    &secp256k1, pubkey, msg->signature.bytes, hash, v) != 0) {
     memzero(hash, sizeof(hash));
     return 2;
   }

--- a/lib/firmware/tron.c
+++ b/lib/firmware/tron.c
@@ -132,9 +132,12 @@ bool tron_signTx(const HDNode* node, const TronSignTx* msg,
 }
 
 static int tron_is_canonic(uint8_t v, uint8_t signature[64]) {
-  (void)v;
+  // Match ethereum_is_canonic: accept only recovery IDs 0 and 1 (reject
+  // 2 and 3). Mirrors verifier expectations across the TRON/EVM ecosystem.
+  // Returning non-zero means "canonical, accept"; ecdsa_sign_digest retries
+  // when this returns 0, so a permanent 0 here causes signing to fail.
   (void)signature;
-  return 0;
+  return (v & 2) == 0;
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements TIP-191 \`personal_sign\` for TRON (\`TronSignMessage\` / \`TronVerifyMessage\`), the message-signing primitive that was overlooked in the 7.14.0 release. TRON shipped with \`GetAddress\` + \`SignTx\` only, while Solana shipped with \`SignMessage\` in the same release — this restores parity.

## Wire shape

Mirrors the Ethereum personal_sign shape exactly. Only the prefix differs:

\`\`\`
hash = keccak256(\"\\x19TRON Signed Message:\\n\" || ASCII(len) || message)
sig  = secp256k1_sign(hash) → 65 bytes (r || s || 27+v)
\`\`\`

## Changes

### Proto (folded into device-protocol fork master)
- \`TronSignMessage\` / \`TronMessageSignature\` (IDs 1404 / 1405)
- \`TronVerifyMessage\` (ID 1406)
- (Also pre-staged for future PRs: TIP-712 \`TronSignTypedHash\` 1407/1408)

### Firmware
- \`tron_message_sign()\` / \`tron_message_verify()\` in \`lib/firmware/tron.c\` — mirrors \`ethereum_message_sign\`/\`ethereum_message_verify\`
- \`fsm_msgTronSignMessage\` / \`fsm_msgTronVerifyMessage\` in \`fsm_msg_tron.h\` — PIN check, path validation (m/44'/195'/...), printable/hex display, user confirm
- \`MSG_IN\`/\`MSG_OUT\` entries in \`messagemap.def\`
- \`deps/device-protocol\` submodule re-pinned to fork master (\`e0bf5a4\`)

## UX

- **Sign**: confirm dialog shows message as text (printable) or hex (binary), truncated to 38×3 chars. Button-confirm before signing.
- **Verify**: recovers signer address from sig, confirms it matches the claimed Base58Check address, displays message, sends Success/Failure.

## Test plan

- [ ] Sign known TIP-191 vector with known seed; verify off-device with \`tronweb.Trx.verifyMessageV2()\`
- [ ] Sign empty message — should succeed (TIP-191 allows zero-length)
- [ ] Sign 1024-byte message (option ceiling) — should succeed; longer rejected by nanopb
- [ ] Verify a valid signature — confirm dialog renders, returns Success
- [ ] Verify an invalid signature (wrong address) — returns Failure
- [ ] Round-trip: sign on device, verify on device with the returned signature

## Out of scope (follow-up PRs)

- TRON TIP-712 \`TronSignTypedHash\` (proto already in master, firmware impl pending)
- TON \`TonSignMessage\` (proto already in master, firmware impl pending)
- Solana \`SolanaSignOffchainMessage\` (proto already in master, firmware impl pending)