### PR TITLE
fix: security bugfixes for 7.14.2 (TRON/ETH/EIP-712/tokens)

### DIFF
--- a/include/keepkey/firmware/eip712.h
+++ b/include/keepkey/firmware/eip712.h
@@ -95,8 +95,9 @@ typedef enum { DOMAIN = 1, MESSAGE } dm;
 #define JSON_TYPE_T_NOVAL 31
 #define ADDR_STRING_NULL 32
 #define JSON_TYPE_WNOVAL 33
+#define USER_CANCELLED 34
 
-#define LAST_ERROR JSON_TYPE_WNOVAL
+#define LAST_ERROR USER_CANCELLED
 
 int encode(const json_t* jsonTypes, const json_t* jsonVals, const char* typeS,
            uint8_t* hashRet);

--- a/include/keepkey/firmware/ethereum_contracts/thortx.h
+++ b/include/keepkey/firmware/ethereum_contracts/thortx.h
@@ -38,7 +38,8 @@
 
 /* deposit(address,address,uint256,string) — legacy selector */
 #define THOR_SELECTOR_DEPOSIT "\x1f\xec\xe7\xb4"
-/* depositWithExpiry(address,address,uint256,string,uint256) — current selector */
+/* depositWithExpiry(address,address,uint256,string,uint256) — current selector
+ */
 #define THOR_SELECTOR_DEPOSIT_WITH_EXPIRY "\x44\xbc\x93\x7b"
 
 typedef struct _EthereumSignTx EthereumSignTx;

--- a/include/keepkey/firmware/ethereum_tokens.h
+++ b/include/keepkey/firmware/ethereum_tokens.h
@@ -39,7 +39,7 @@ enum {
 typedef struct _TokenType {
   const char* const address;
   const char* const ticker;
-  uint8_t chain_id;
+  uint32_t chain_id;
   uint8_t decimals;
 } TokenType;
 
@@ -51,7 +51,7 @@ extern const TokenType* UnknownToken;
 
 const TokenType* tokenIter(int32_t* ctr);
 
-const TokenType* tokenByChainAddress(uint8_t chain_id, const uint8_t* address);
+const TokenType* tokenByChainAddress(uint32_t chain_id, const uint8_t* address);
 
 /// Tokens don't have unique tickers, so this might not return the one you're
 /// looking for :/
@@ -64,7 +64,7 @@ const TokenType* tokenByChainAddress(uint8_t chain_id, const uint8_t* address);
 /// \param[out] token The found token, assuming it was uniquely determinable.
 /// \returns true iff the token can be uniquely found in the list of known
 /// tokens.
-bool tokenByTicker(uint8_t chain_id, const char* ticker,
+bool tokenByTicker(uint32_t chain_id, const char* ticker,
                    const TokenType** token);
 
 void coinFromToken(CoinType* coin, const TokenType* token);

--- a/include/keepkey/firmware/thorchain.h
+++ b/include/keepkey/firmware/thorchain.h
@@ -16,8 +16,7 @@ bool thorchain_isValidDenom(const char* denom);
 
 bool thorchain_signTxInit(const HDNode* _node, const ThorchainSignTx* _msg);
 bool thorchain_signTxUpdateMsgSend(const uint64_t amount,
-                                   const char* to_address,
-                                   const char* denom);
+                                   const char* to_address, const char* denom);
 bool thorchain_signTxUpdateMsgDeposit(const ThorchainMsgDeposit* depmsg);
 bool thorchain_signTxFinalize(uint8_t* public_key, uint8_t* signature);
 bool thorchain_signingIsInited(void);

--- a/lib/board/signatures.c
+++ b/lib/board/signatures.c
@@ -89,21 +89,21 @@ int signatures_ok(void) {
   volatile int verify_acc = 0;
   volatile int verify_sentinel = 0;
 
-  verify_acc |= ecdsa_verify_digest(&secp256k1, pubkey[sigindex1 - 1],
-                                    (uint8_t*)FLASH_META_SIG1,
-                                    firmware_fingerprint);
+  verify_acc |=
+      ecdsa_verify_digest(&secp256k1, pubkey[sigindex1 - 1],
+                          (uint8_t*)FLASH_META_SIG1, firmware_fingerprint);
   verify_sentinel++;
   asm volatile("" ::: "memory");
 
-  verify_acc |= ecdsa_verify_digest(&secp256k1, pubkey[sigindex2 - 1],
-                                    (uint8_t*)FLASH_META_SIG2,
-                                    firmware_fingerprint);
+  verify_acc |=
+      ecdsa_verify_digest(&secp256k1, pubkey[sigindex2 - 1],
+                          (uint8_t*)FLASH_META_SIG2, firmware_fingerprint);
   verify_sentinel++;
   asm volatile("" ::: "memory");
 
-  verify_acc |= ecdsa_verify_digest(&secp256k1, pubkey[sigindex3 - 1],
-                                    (uint8_t*)FLASH_META_SIG3,
-                                    firmware_fingerprint);
+  verify_acc |=
+      ecdsa_verify_digest(&secp256k1, pubkey[sigindex3 - 1],
+                          (uint8_t*)FLASH_META_SIG3, firmware_fingerprint);
   verify_sentinel++;
   asm volatile("" ::: "memory");
 

--- a/lib/firmware/app_layout.c
+++ b/lib/firmware/app_layout.c
@@ -707,7 +707,7 @@ void layout_cipher(const char* current_word, const char* cipher,
   if (prev_word_info && prev_word_info[0]) {
     sp.y = 2;
     sp.x = 4;
-    sp.color = CIPHER_FONT_COLOR;  /* gray -- less prominent than current word */
+    sp.color = CIPHER_FONT_COLOR; /* gray -- less prominent than current word */
     draw_string(canvas, title_font, prev_word_info, &sp, 68,
                 font_height(title_font));
   }

--- a/lib/firmware/eip712.c
+++ b/lib/firmware/eip712.c
@@ -31,6 +31,7 @@
    strings and address should be prefixed by 0x
 */
 
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -288,16 +289,20 @@ int encodeBytesN(const char* typeT, const char* string, uint8_t* encoded) {
 int confirmName(const char* name, bool valAvailable) {
   if (valAvailable) {
     nameForValue = name;
-  } else {
-    (void)review(ButtonRequestType_ButtonRequest_Other, "MESSAGE DATA",
-                 "Press button to continue for\n\"%s\" values", name);
+    return SUCCESS;
+  }
+  if (!review(ButtonRequestType_ButtonRequest_Other, "MESSAGE DATA",
+              "Press button to continue for\n\"%s\" values", name)) {
+    return USER_CANCELLED;
   }
   return SUCCESS;
 }
 
 int confirmValue(const char* value) {
-  (void)review(ButtonRequestType_ButtonRequest_Other, "MESSAGE DATA", "%s %s",
-               nameForValue, value);
+  if (!review(ButtonRequestType_ButtonRequest_Other, "MESSAGE DATA", "%s %s",
+              nameForValue, value)) {
+    return USER_CANCELLED;
+  }
   return SUCCESS;
 }
 
@@ -547,8 +552,18 @@ int parseVals(const json_t* eip712Types, const json_t* jType,
                 encBytes[ctr] = 0;
               }
             }
-            // all int strings are assumed to be base 10 and fit into 64 bits
-            long long intVal = strtoll(valStr, NULL, 10);
+            /* EIP-712 int/uint values must fit in 64 bits (firmware limit).
+             * Reject values that overflow strtoll to avoid silent misencoding. */
+            char* endptr = NULL;
+            errno = 0;
+            long long intVal = strtoll(valStr, &endptr, 10);
+            if (errno == ERANGE || endptr == valStr || *endptr != '\0') {
+              return GENERAL_ERROR;
+            }
+            /* uint types must not be negative */
+            if (0 == strncmp("uint", typeType, 4) && intVal < 0) {
+              return GENERAL_ERROR;
+            }
             // Needs to be big endian, so add to encBytes appropriately
             encBytes[24] = (intVal >> 56) & 0xff;
             encBytes[25] = (intVal >> 48) & 0xff;

--- a/lib/firmware/eip712.c
+++ b/lib/firmware/eip712.c
@@ -553,7 +553,8 @@ int parseVals(const json_t* eip712Types, const json_t* jType,
               }
             }
             /* EIP-712 int/uint values must fit in 64 bits (firmware limit).
-             * Reject values that overflow strtoll to avoid silent misencoding. */
+             * Reject values that overflow strtoll to avoid silent misencoding.
+             */
             char* endptr = NULL;
             errno = 0;
             long long intVal = strtoll(valStr, &endptr, 10);

--- a/lib/firmware/ethereum.c
+++ b/lib/firmware/ethereum.c
@@ -860,19 +860,22 @@ void ethereum_signing_init(EthereumSignTx* msg, const HDNode* node,
     hash_rlp_field((uint8_t*)(&chain_id), sizeof(uint8_t));
   }
 
-  hash_rlp_field(msg->nonce.bytes, msg->nonce.size);
+  hash_rlp_bytes_stripped(msg->nonce.bytes, msg->nonce.size);
 
   if (msg->has_max_fee_per_gas) {
-    hash_rlp_field(msg->max_priority_fee_per_gas.bytes,
-                   msg->max_priority_fee_per_gas.size);
-    hash_rlp_field(msg->max_fee_per_gas.bytes, msg->max_fee_per_gas.size);
+    if (msg->has_max_priority_fee_per_gas) {
+      hash_rlp_bytes_stripped(msg->max_priority_fee_per_gas.bytes,
+                              msg->max_priority_fee_per_gas.size);
+    }
+    hash_rlp_bytes_stripped(msg->max_fee_per_gas.bytes,
+                            msg->max_fee_per_gas.size);
   } else {
-    hash_rlp_field(msg->gas_price.bytes, msg->gas_price.size);
+    hash_rlp_bytes_stripped(msg->gas_price.bytes, msg->gas_price.size);
   }
 
-  hash_rlp_field(msg->gas_limit.bytes, msg->gas_limit.size);
-  hash_rlp_field(msg->to.bytes, msg->to.size);
-  hash_rlp_field(msg->value.bytes, msg->value.size);
+  hash_rlp_bytes_stripped(msg->gas_limit.bytes, msg->gas_limit.size);
+  hash_rlp_field(msg->to.bytes, msg->to.size);  /* address: no strip */
+  hash_rlp_bytes_stripped(msg->value.bytes, msg->value.size);
   hash_rlp_length(data_total, msg->data_initial_chunk.bytes[0]);
   hash_data(msg->data_initial_chunk.bytes, msg->data_initial_chunk.size);
   data_left = data_total - msg->data_initial_chunk.size;

--- a/lib/firmware/ethereum.c
+++ b/lib/firmware/ethereum.c
@@ -799,9 +799,8 @@ void ethereum_signing_init(EthereumSignTx* msg, const HDNode* node,
 
   rlp_length += rlp_calculate_length(msg->nonce.size, msg->nonce.bytes[0]);
   if (msg->has_max_fee_per_gas) {
-    rlp_length +=
-        rlp_calculate_length(msg->max_priority_fee_per_gas.size,
-                             msg->max_priority_fee_per_gas.bytes[0]);
+    rlp_length += rlp_calculate_length(msg->max_priority_fee_per_gas.size,
+                                       msg->max_priority_fee_per_gas.bytes[0]);
     rlp_length += rlp_calculate_length(msg->max_fee_per_gas.size,
                                        msg->max_fee_per_gas.bytes[0]);
   } else {
@@ -874,7 +873,7 @@ void ethereum_signing_init(EthereumSignTx* msg, const HDNode* node,
   }
 
   hash_rlp_bytes_stripped(msg->gas_limit.bytes, msg->gas_limit.size);
-  hash_rlp_field(msg->to.bytes, msg->to.size);  /* address: no strip */
+  hash_rlp_field(msg->to.bytes, msg->to.size); /* address: no strip */
   hash_rlp_bytes_stripped(msg->value.bytes, msg->value.size);
   hash_rlp_length(data_total, msg->data_initial_chunk.bytes[0]);
   hash_data(msg->data_initial_chunk.bytes, msg->data_initial_chunk.size);

--- a/lib/firmware/ethereum_contracts.c
+++ b/lib/firmware/ethereum_contracts.c
@@ -66,7 +66,6 @@ bool ethereum_contractConfirmed(uint32_t data_total, const EthereumSignTx* msg,
   if (thor_isMayachainTx(msg)) return thor_confirmMayaTx(data_total, msg);
   if (thor_isThorchainTx(msg)) return thor_confirmThorTx(data_total, msg);
 
-
   if (makerdao_isMakerDAO(data_total, msg))
     return makerdao_confirmMakerDAO(data_total, msg);
 

--- a/lib/firmware/ethereum_contracts/thortx.c
+++ b/lib/firmware/ethereum_contracts/thortx.c
@@ -29,7 +29,8 @@
 
 bool thor_has_deposit_selector(const EthereumSignTx* msg) {
   if (msg->data_initial_chunk.size < 4) return false;
-  return (memcmp(msg->data_initial_chunk.bytes, THOR_SELECTOR_DEPOSIT, 4) == 0 ||
+  return (memcmp(msg->data_initial_chunk.bytes, THOR_SELECTOR_DEPOSIT, 4) ==
+              0 ||
           memcmp(msg->data_initial_chunk.bytes,
                  THOR_SELECTOR_DEPOSIT_WITH_EXPIRY, 4) == 0);
 }

--- a/lib/firmware/ethereum_tokens.c
+++ b/lib/firmware/ethereum_tokens.c
@@ -42,7 +42,8 @@ const TokenType* tokenIter(int32_t* ctr) {
   return &(tokens[*ctr - 1]);
 }
 
-const TokenType* tokenByChainAddress(uint32_t chain_id, const uint8_t* address) {
+const TokenType* tokenByChainAddress(uint32_t chain_id,
+                                     const uint8_t* address) {
   if (!address) return 0;
   for (int i = 0; i < TOKENS_COUNT; i++) {
     if (chain_id == tokens[i].chain_id &&

--- a/lib/firmware/ethereum_tokens.c
+++ b/lib/firmware/ethereum_tokens.c
@@ -42,7 +42,7 @@ const TokenType* tokenIter(int32_t* ctr) {
   return &(tokens[*ctr - 1]);
 }
 
-const TokenType* tokenByChainAddress(uint8_t chain_id, const uint8_t* address) {
+const TokenType* tokenByChainAddress(uint32_t chain_id, const uint8_t* address) {
   if (!address) return 0;
   for (int i = 0; i < TOKENS_COUNT; i++) {
     if (chain_id == tokens[i].chain_id &&
@@ -57,7 +57,7 @@ const TokenType* tokenByChainAddress(uint8_t chain_id, const uint8_t* address) {
   return UnknownToken;
 }
 
-bool tokenByTicker(uint8_t chain_id, const char* ticker,
+bool tokenByTicker(uint32_t chain_id, const char* ticker,
                    const TokenType** token) {
   *token = NULL;
 

--- a/lib/firmware/fsm_msg_ripple.h
+++ b/lib/firmware/fsm_msg_ripple.h
@@ -110,8 +110,8 @@ void fsm_msgRippleSignTx(RippleSignTx* msg) {
   }
 
   if (msg->has_memo && msg->memo[0] != '\0') {
-    if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, "Memo",
-                 "%s", msg->memo)) {
+    if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, "Memo", "%s",
+                 msg->memo)) {
       memzero(node, sizeof(*node));
       fsm_sendFailure(FailureType_Failure_ActionCancelled, "Signing cancelled");
       layoutHome();

--- a/lib/firmware/fsm_msg_thorchain.h
+++ b/lib/firmware/fsm_msg_thorchain.h
@@ -175,8 +175,8 @@ void fsm_msgThorchainMsgAck(const ThorchainMsgAck* msg) {
           return;
         }
         // Confirm the asset denom on its own screen.
-        if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
-                     "Asset", "%s", coin_denom)) {
+        if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, "Asset",
+                     "%s", coin_denom)) {
           thorchain_signAbort();
           fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
           layoutHome();

--- a/lib/firmware/fsm_msg_tron.h
+++ b/lib/firmware/fsm_msg_tron.h
@@ -102,24 +102,14 @@ void fsm_msgTronSignTx(TronSignTx* msg) {
     return;
   }
 
-  bool needs_confirm = true;
-
-  // Display transaction details if available
-  if (needs_confirm && msg->has_to_address && msg->has_amount) {
-    char amount_str[32];
-    tron_formatAmount(amount_str, sizeof(amount_str), msg->amount);
-
-    if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, "Send",
-                 "Send %s TRX to %s?", amount_str, msg->to_address)) {
-      memzero(node, sizeof(*node));
-      fsm_sendFailure(FailureType_Failure_ActionCancelled, "Signing cancelled");
-      layoutHome();
-      return;
-    }
-  }
-
-  if (!confirm(ButtonRequestType_ButtonRequest_SignTx, "Transaction",
-               "Really sign this TRON transaction?")) {
+  /* to_address and amount are deprecated fields not included in raw_data.
+   * Displaying them would show data that is not part of what is being signed.
+   * Show only the raw_data size so the user knows what they are authorising. */
+  char blind_msg[48];
+  snprintf(blind_msg, sizeof(blind_msg), "Sign %u-byte TRON transaction?",
+           (unsigned)msg->raw_data.size);
+  if (!confirm(ButtonRequestType_ButtonRequest_SignTx, "TRON Blind Sign",
+               "%s", blind_msg)) {
     memzero(node, sizeof(*node));
     fsm_sendFailure(FailureType_Failure_ActionCancelled, "Signing cancelled");
     layoutHome();

--- a/lib/firmware/fsm_msg_tron.h
+++ b/lib/firmware/fsm_msg_tron.h
@@ -108,8 +108,8 @@ void fsm_msgTronSignTx(TronSignTx* msg) {
   char blind_msg[48];
   snprintf(blind_msg, sizeof(blind_msg), "Sign %u-byte TRON transaction?",
            (unsigned)msg->raw_data.size);
-  if (!confirm(ButtonRequestType_ButtonRequest_SignTx, "TRON Blind Sign",
-               "%s", blind_msg)) {
+  if (!confirm(ButtonRequestType_ButtonRequest_SignTx, "TRON Blind Sign", "%s",
+               blind_msg)) {
     memzero(node, sizeof(*node));
     fsm_sendFailure(FailureType_Failure_ActionCancelled, "Signing cancelled");
     layoutHome();

--- a/lib/firmware/recovery_cipher.c
+++ b/lib/firmware/recovery_cipher.c
@@ -388,8 +388,8 @@ void next_character(void) {
   static char prev_info[32];
   prev_info[0] = '\0';
   if (word_pos > 0 && last_completed_word[0]) {
-    snprintf(prev_info, sizeof(prev_info), "(%" PRIu32 ".%s)",
-             word_pos, last_completed_word);
+    snprintf(prev_info, sizeof(prev_info), "(%" PRIu32 ".%s)", word_pos,
+             last_completed_word);
   }
 
   /* Show cipher and partial word */

--- a/lib/firmware/thorchain.c
+++ b/lib/firmware/thorchain.c
@@ -39,8 +39,8 @@ bool thorchain_isValidDenom(const char* denom) {
   if (!denom || !denom[0]) return false;
   for (size_t i = 0; denom[i]; i++) {
     char c = denom[i];
-    if (!((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
-          c == '.' || c == '/' || c == '-')) {
+    if (!((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '.' ||
+          c == '/' || c == '-')) {
       return false;
     }
   }
@@ -111,8 +111,7 @@ bool thorchain_signTxInit(const HDNode* _node, const ThorchainSignTx* _msg) {
 }
 
 bool thorchain_signTxUpdateMsgSend(const uint64_t amount,
-                                   const char* to_address,
-                                   const char* denom) {
+                                   const char* to_address, const char* denom) {
   const char mainnetp[] = "thor";
   const char testnetp[] = "tthor";
   const char* pfix;
@@ -136,7 +135,8 @@ bool thorchain_signTxUpdateMsgSend(const uint64_t amount,
     return false;
   }
 
-  // Default to "rune" for backward compatibility; validate all non-default denoms
+  // Default to "rune" for backward compatibility; validate all non-default
+  // denoms
   const char* coin_denom = (denom && denom[0]) ? denom : "rune";
   if (!thorchain_isValidDenom(coin_denom)) {
     return false;
@@ -148,10 +148,9 @@ bool thorchain_signTxUpdateMsgSend(const uint64_t amount,
   sha256_Update(&ctx, (uint8_t*)prelude, strlen(prelude));
 
   // Write amount prefix: 21 + ^20 = ^41
-  success &= tendermint_snprintf(&ctx, buffer, sizeof(buffer),
-                                 "\"amount\":[{\"amount\":\"%" PRIu64
-                                 "\",\"denom\":\"",
-                                 amount);
+  success &= tendermint_snprintf(
+      &ctx, buffer, sizeof(buffer),
+      "\"amount\":[{\"amount\":\"%" PRIu64 "\",\"denom\":\"", amount);
   // Use escaping as defense-in-depth; valid denoms have no escapable chars
   tendermint_sha256UpdateEscaped(&ctx, coin_denom, strlen(coin_denom));
   // Close coins array: 3 bytes


### PR DESCRIPTION
## Summary

Five security and correctness bugs fixed for the 7.14.2 release.

**Bug 1 — TRON display mismatch (critical)**
`fsm_msg_tron.h` displayed `to_address`/`amount` — deprecated fields NOT included in the `raw_data` bytes that are actually signed. A malicious or buggy host could show one transfer and get a different transaction signed. Removed the deprecated display block; replaced with a single blind-sign prompt showing only the `raw_data` byte count.

**Bug 5 — ETH RLP leading zeros (medium)**
`ethereum.c` passed nonce, gas_price, gas_limit, max_fee_per_gas, max_priority_fee_per_gas, and value through `hash_rlp_field`, which encodes the full byte array without stripping leading zeros. The Ethereum yellow paper requires leading zeros to be stripped from integer fields. Added `hash_rlp_bytes_stripped()` and applied it to all six numeric fields. The `to` address field is intentionally left using `hash_rlp_field` (addresses are not integers).

**Bug 6 — EIP-712 cancel ignored (critical)**
`confirmName()` and `confirmValue()` in `eip712.c` cast the return value of `review()` to `void`, silently discarding user cancellation. EIP-712 signing continued even after the user pressed reject. Added `USER_CANCELLED` error code (34) and propagated it correctly.

**Bug 7 — EIP-712 strtoll overflow (high)**
`eip712.c` used `strtoll()` to parse uint256/int256 values with no overflow check. Values above `INT64_MAX` wrapped silently; negative uint256 values were not rejected. Added `errno`/`endptr` validation and explicit rejection of negative values for uint types. (Full 256-bit parsing is a follow-up.)

**Bug 8 — Token chain_id truncation (high)**
`TokenType.chain_id` was `uint8_t`, silently truncating EVM chain IDs > 255 (Base=8453, Arbitrum=42161, etc.) causing wrong token recognition on modern chains. Widened to `uint32_t` throughout: struct definition, `tokenByChainAddress()`, `tokenByTicker()`. All call sites already pass `uint32_t` from protobuf.

## Test plan

- [ ] Build firmware — all changed files compile cleanly
- [ ] ETH legacy tx with leading-zero nonce/gas fields signs correctly and broadcasts
- [ ] EIP-1559 tx still signs correctly (nonce/fee/value stripped, `to` address not stripped)
- [ ] TRON sign tx shows "TRON Blind Sign / Sign N-byte TRON transaction?" prompt
- [ ] EIP-712 sign: pressing cancel on any field review aborts signing
- [ ] EIP-712 uint256 value > INT64_MAX returns error instead of silent wrap
- [ ] Token lookup for ETH mainnet tokens still works (chain_id=1 is unaffected)