### PR TITLE
feat(hive): SLIP-0048 + HiveGetPublicKeys + AccountCreate + AccountUpdate

### DIFF
--- a/include/keepkey/firmware/fsm.h
+++ b/include/keepkey/firmware/fsm.h
@@ -137,6 +137,9 @@ void fsm_msgZcashGetOrchardFVK(const ZcashGetOrchardFVK* msg);
 void fsm_msgZcashTransparentInput(const ZcashTransparentInput* msg);
 void fsm_msgZcashDisplayAddress(const ZcashDisplayAddress* msg);
 
+void fsm_msgHiveGetPublicKey(const HiveGetPublicKey* msg);
+void fsm_msgHiveSignTx(const HiveSignTx* msg);
+
 #if DEBUG_LINK
 // void fsm_msgDebugLinkDecision(DebugLinkDecision *msg);
 void fsm_msgDebugLinkGetState(DebugLinkGetState* msg);

--- a/include/keepkey/firmware/fsm.h
+++ b/include/keepkey/firmware/fsm.h
@@ -138,7 +138,10 @@ void fsm_msgZcashTransparentInput(const ZcashTransparentInput* msg);
 void fsm_msgZcashDisplayAddress(const ZcashDisplayAddress* msg);
 
 void fsm_msgHiveGetPublicKey(const HiveGetPublicKey* msg);
+void fsm_msgHiveGetPublicKeys(const HiveGetPublicKeys* msg);
 void fsm_msgHiveSignTx(const HiveSignTx* msg);
+void fsm_msgHiveSignAccountCreate(const HiveSignAccountCreate* msg);
+void fsm_msgHiveSignAccountUpdate(const HiveSignAccountUpdate* msg);
 
 #if DEBUG_LINK
 // void fsm_msgDebugLinkDecision(DebugLinkDecision *msg);

--- a/include/keepkey/firmware/hive.h
+++ b/include/keepkey/firmware/hive.h
@@ -5,7 +5,7 @@
 #include "messages-hive.pb.h"
 
 // ── Hive mainnet chain ID ─────────────────────────────────────────────────
-#define HIVE_CHAIN_ID \
+#define HIVE_CHAIN_ID                                \
   "\xbe\xea\xb0\xde\x00\x00\x00\x00\x00\x00\x00\x00" \
   "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" \
   "\x00\x00\x00\x00\x00\x00\x00\x00"
@@ -16,37 +16,38 @@
 
 // ── SLIP-0048 derivation constants (all hardened) ─────────────────────────
 // Path: m/48'/13'/role'/account_index'/0'
-#define HIVE_SLIP48_PURPOSE  (0x80000030u)  // 48'
-#define HIVE_SLIP48_NETWORK  (0x8000000Du)  // 13' — Hive SLIP-0048 network ID
-#define HIVE_ROLE_OWNER      (0x80000000u)  // 0'  — account recovery, authority changes
-#define HIVE_ROLE_ACTIVE     (0x80000001u)  // 1'  — transfers, staking
-#define HIVE_ROLE_MEMO       (0x80000003u)  // 3'  — memo field encryption
-#define HIVE_ROLE_POSTING    (0x80000004u)  // 4'  — votes, posts, follows
+#define HIVE_SLIP48_PURPOSE (0x80000030u)  // 48'
+#define HIVE_SLIP48_NETWORK (0x8000000Du)  // 13' — Hive SLIP-0048 network ID
+#define HIVE_ROLE_OWNER \
+  (0x80000000u)  // 0'  — account recovery, authority changes
+#define HIVE_ROLE_ACTIVE (0x80000001u)   // 1'  — transfers, staking
+#define HIVE_ROLE_MEMO (0x80000003u)     // 3'  — memo field encryption
+#define HIVE_ROLE_POSTING (0x80000004u)  // 4'  — votes, posts, follows
 
 // ── Graphene operation type IDs ───────────────────────────────────────────
-#define HIVE_OP_TRANSFER        2
-#define HIVE_OP_ACCOUNT_CREATE  9
-#define HIVE_OP_ACCOUNT_UPDATE  10
+#define HIVE_OP_TRANSFER 2
+#define HIVE_OP_ACCOUNT_CREATE 9
+#define HIVE_OP_ACCOUNT_UPDATE 10
 
 // ── Protocol limits ───────────────────────────────────────────────────────
-#define HIVE_MAX_ACCOUNT_LEN 16   // max Hive username length
-#define HIVE_DECIMALS        3    // HIVE and HBD both use 3 decimal places
+#define HIVE_MAX_ACCOUNT_LEN 16  // max Hive username length
+#define HIVE_DECIMALS 3          // HIVE and HBD both use 3 decimal places
 
 // ── Public API ────────────────────────────────────────────────────────────
 
 /**
- * Encode a 33-byte compressed public key in Hive/Steem STM-prefix base58 format.
- * Uses RIPEMD checksum (Graphene convention, not SHA256d).
+ * Encode a 33-byte compressed public key in Hive/Steem STM-prefix base58
+ * format. Uses RIPEMD checksum (Graphene convention, not SHA256d).
  */
-bool hive_getPublicKey(const uint8_t public_key[33], char *out, size_t out_len);
+bool hive_getPublicKey(const uint8_t public_key[33], char* out, size_t out_len);
 
 /**
  * Derive one SLIP-0048 role key for a given account index to raw 33 bytes.
- * role_hardened: HIVE_ROLE_OWNER | HIVE_ROLE_ACTIVE | HIVE_ROLE_MEMO | HIVE_ROLE_POSTING
- * account_index_hardened: account_index | 0x80000000u
- * Returns false if derivation fails.
+ * role_hardened: HIVE_ROLE_OWNER | HIVE_ROLE_ACTIVE | HIVE_ROLE_MEMO |
+ * HIVE_ROLE_POSTING account_index_hardened: account_index | 0x80000000u Returns
+ * false if derivation fails.
  */
-bool hive_deriveRawKey(const HDNode *root, uint32_t role_hardened,
+bool hive_deriveRawKey(const HDNode* root, uint32_t role_hardened,
                        uint32_t account_index_hardened, uint8_t out[33]);
 
 /**
@@ -54,42 +55,43 @@ bool hive_deriveRawKey(const HDNode *root, uint32_t role_hardened,
  * each as an STM-prefixed string. All output buffers must be >= 64 bytes.
  * Returns false if any derivation or encoding step fails.
  */
-bool hive_getPublicKeys(const HDNode *root, uint32_t account_index,
-                        char *owner_out,   size_t owner_len,
-                        char *active_out,  size_t active_len,
-                        char *memo_out,    size_t memo_len,
-                        char *posting_out, size_t posting_len);
+bool hive_getPublicKeys(const HDNode* root, uint32_t account_index,
+                        char* owner_out, size_t owner_len, char* active_out,
+                        size_t active_len, char* memo_out, size_t memo_len,
+                        char* posting_out, size_t posting_len);
 
 /**
  * Sign a Hive transfer transaction (op type 2).
  * Rejects memos longer than HIVE_MAX_MEMO_LEN (440 bytes).
  */
-void hive_signTx(const HDNode *node, const HiveSignTx *msg, HiveSignedTx *resp);
+void hive_signTx(const HDNode* node, const HiveSignTx* msg, HiveSignedTx* resp);
 
 /**
  * Sign a Hive account_create transaction (op type 9).
  * owner/active/posting/memo_raw must be device-derived 33-byte compressed keys.
- * The firmware uses these directly; host-supplied key strings in msg are ignored.
+ * The firmware uses these directly; host-supplied key strings in msg are
+ * ignored.
  */
-void hive_signAccountCreate(const HDNode *signing_node,
-                            const HiveSignAccountCreate *msg,
+void hive_signAccountCreate(const HDNode* signing_node,
+                            const HiveSignAccountCreate* msg,
                             const uint8_t owner_raw[33],
                             const uint8_t active_raw[33],
                             const uint8_t posting_raw[33],
                             const uint8_t memo_raw[33],
-                            HiveSignedAccountCreate *resp);
+                            HiveSignedAccountCreate* resp);
 
 /**
  * Sign a Hive account_update transaction (op type 10).
  * owner/active/posting/memo_raw must be device-derived 33-byte compressed keys.
- * The firmware uses these directly; host-supplied new_*_key strings in msg are ignored.
+ * The firmware uses these directly; host-supplied new_*_key strings in msg are
+ * ignored.
  */
-void hive_signAccountUpdate(const HDNode *signing_node,
-                            const HiveSignAccountUpdate *msg,
+void hive_signAccountUpdate(const HDNode* signing_node,
+                            const HiveSignAccountUpdate* msg,
                             const uint8_t owner_raw[33],
                             const uint8_t active_raw[33],
                             const uint8_t posting_raw[33],
                             const uint8_t memo_raw[33],
-                            HiveSignedAccountUpdate *resp);
+                            HiveSignedAccountUpdate* resp);
 
 #endif  // KEEPKEY_FIRMWARE_HIVE_H

--- a/include/keepkey/firmware/hive.h
+++ b/include/keepkey/firmware/hive.h
@@ -36,10 +36,6 @@
 #define HIVE_DECIMALS 3          // HIVE and HBD both use 3 decimal places
 
 // ── Public API ────────────────────────────────────────────────────────────
-bool hive_getPublicKey(const uint8_t public_key[33], char* out, size_t out_len);
-
-void hive_signTx(const HDNode* node, const HiveSignTx* msg, HiveSignedTx* resp);
-
 /**
  * Encode a 33-byte compressed public key in Hive/Steem STM-prefix base58
  * format. Uses RIPEMD checksum (Graphene convention, not SHA256d).

--- a/include/keepkey/firmware/hive.h
+++ b/include/keepkey/firmware/hive.h
@@ -6,9 +6,10 @@
 #include "messages-hive.pb.h"
 
 // Hive mainnet chain ID
-#define HIVE_CHAIN_ID "\xbe\xea\xb0\xde\x00\x00\x00\x00\x00\x00\x00\x00" \
-                      "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" \
-                      "\x00\x00\x00\x00\x00\x00\x00\x00"
+#define HIVE_CHAIN_ID                                \
+  "\xbe\xea\xb0\xde\x00\x00\x00\x00\x00\x00\x00\x00" \
+  "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" \
+  "\x00\x00\x00\x00\x00\x00\x00\x00"
 
 #define HIVE_CHAIN_ID_LEN 32
 
@@ -27,8 +28,8 @@
 // Transfer operation type ID in Graphene
 #define HIVE_OP_TRANSFER 2
 
-bool hive_getPublicKey(const uint8_t public_key[33], char *out, size_t out_len);
+bool hive_getPublicKey(const uint8_t public_key[33], char* out, size_t out_len);
 
-void hive_signTx(const HDNode *node, const HiveSignTx *msg, HiveSignedTx *resp);
+void hive_signTx(const HDNode* node, const HiveSignTx* msg, HiveSignedTx* resp);
 
 #endif

--- a/include/keepkey/firmware/hive.h
+++ b/include/keepkey/firmware/hive.h
@@ -2,34 +2,75 @@
 #define KEEPKEY_FIRMWARE_HIVE_H
 
 #include "trezor/crypto/bip32.h"
-
 #include "messages-hive.pb.h"
 
-// Hive mainnet chain ID
-#define HIVE_CHAIN_ID                                \
+// ── Hive mainnet chain ID ─────────────────────────────────────────────────
+#define HIVE_CHAIN_ID \
   "\xbe\xea\xb0\xde\x00\x00\x00\x00\x00\x00\x00\x00" \
   "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" \
   "\x00\x00\x00\x00\x00\x00\x00\x00"
-
 #define HIVE_CHAIN_ID_LEN 32
 
-// STM public key prefix (Hive inherited from Steem)
+// ── STM public key prefix (Hive inherited from Steem / Graphene) ──────────
 #define HIVE_PUBKEY_PREFIX "STM"
 
-// Max account name length on Hive
-#define HIVE_MAX_ACCOUNT_LEN 17
+// ── SLIP-0048 derivation constants (all hardened) ─────────────────────────
+// Path: m/48'/13'/role'/account_index'/0'
+#define HIVE_SLIP48_PURPOSE  (0x80000030u)  // 48'
+#define HIVE_SLIP48_NETWORK  (0x8000000Du)  // 13' — Hive SLIP-0048 network ID
+#define HIVE_ROLE_OWNER      (0x80000000u)  // 0'  — account recovery, authority changes
+#define HIVE_ROLE_ACTIVE     (0x80000001u)  // 1'  — transfers, staking
+#define HIVE_ROLE_MEMO       (0x80000003u)  // 3'  — memo field encryption
+#define HIVE_ROLE_POSTING    (0x80000004u)  // 4'  — votes, posts, follows
 
-// BIP44 coin type for HIVE
-#define HIVE_SLIP44 1275
+// ── Graphene operation type IDs ───────────────────────────────────────────
+#define HIVE_OP_TRANSFER        2
+#define HIVE_OP_ACCOUNT_CREATE  9
+#define HIVE_OP_ACCOUNT_UPDATE  10
 
-// Decimals for HIVE and HBD
-#define HIVE_DECIMALS 3
+// ── Protocol limits ───────────────────────────────────────────────────────
+#define HIVE_MAX_ACCOUNT_LEN 16   // max Hive username length
+#define HIVE_DECIMALS        3    // HIVE and HBD both use 3 decimal places
 
-// Transfer operation type ID in Graphene
-#define HIVE_OP_TRANSFER 2
+// ── Public API ────────────────────────────────────────────────────────────
 
-bool hive_getPublicKey(const uint8_t public_key[33], char* out, size_t out_len);
+/**
+ * Encode a 33-byte compressed public key in Hive/Steem STM-prefix base58 format.
+ * Uses RIPEMD checksum (Graphene convention, not SHA256d).
+ */
+bool hive_getPublicKey(const uint8_t public_key[33], char *out, size_t out_len);
 
-void hive_signTx(const HDNode* node, const HiveSignTx* msg, HiveSignedTx* resp);
+/**
+ * Derive all four SLIP-0048 role keys for a given account index and encode
+ * each as an STM-prefixed string. All output buffers must be >= 64 bytes.
+ * Returns false if any derivation or encoding step fails.
+ */
+bool hive_getPublicKeys(const HDNode *root, uint32_t account_index,
+                        char *owner_out,   size_t owner_len,
+                        char *active_out,  size_t active_len,
+                        char *memo_out,    size_t memo_len,
+                        char *posting_out, size_t posting_len);
 
-#endif
+/**
+ * Sign a Hive transfer transaction (op type 2).
+ */
+void hive_signTx(const HDNode *node, const HiveSignTx *msg, HiveSignedTx *resp);
+
+/**
+ * Sign a Hive account_create transaction (op type 9).
+ * All four role public keys are embedded as authorities.
+ * Device must display the new account name for user confirmation.
+ */
+void hive_signAccountCreate(const HDNode *node,
+                            const HiveSignAccountCreate *msg,
+                            HiveSignedAccountCreate *resp);
+
+/**
+ * Sign a Hive account_update transaction (op type 10).
+ * Replaces all authorities with new KeepKey-derived keys.
+ */
+void hive_signAccountUpdate(const HDNode *node,
+                            const HiveSignAccountUpdate *msg,
+                            HiveSignedAccountUpdate *resp);
+
+#endif  // KEEPKEY_FIRMWARE_HIVE_H

--- a/include/keepkey/firmware/hive.h
+++ b/include/keepkey/firmware/hive.h
@@ -41,6 +41,15 @@
 bool hive_getPublicKey(const uint8_t public_key[33], char *out, size_t out_len);
 
 /**
+ * Derive one SLIP-0048 role key for a given account index to raw 33 bytes.
+ * role_hardened: HIVE_ROLE_OWNER | HIVE_ROLE_ACTIVE | HIVE_ROLE_MEMO | HIVE_ROLE_POSTING
+ * account_index_hardened: account_index | 0x80000000u
+ * Returns false if derivation fails.
+ */
+bool hive_deriveRawKey(const HDNode *root, uint32_t role_hardened,
+                       uint32_t account_index_hardened, uint8_t out[33]);
+
+/**
  * Derive all four SLIP-0048 role keys for a given account index and encode
  * each as an STM-prefixed string. All output buffers must be >= 64 bytes.
  * Returns false if any derivation or encoding step fails.
@@ -53,24 +62,34 @@ bool hive_getPublicKeys(const HDNode *root, uint32_t account_index,
 
 /**
  * Sign a Hive transfer transaction (op type 2).
+ * Rejects memos longer than HIVE_MAX_MEMO_LEN (440 bytes).
  */
 void hive_signTx(const HDNode *node, const HiveSignTx *msg, HiveSignedTx *resp);
 
 /**
  * Sign a Hive account_create transaction (op type 9).
- * All four role public keys are embedded as authorities.
- * Device must display the new account name for user confirmation.
+ * owner/active/posting/memo_raw must be device-derived 33-byte compressed keys.
+ * The firmware uses these directly; host-supplied key strings in msg are ignored.
  */
-void hive_signAccountCreate(const HDNode *node,
+void hive_signAccountCreate(const HDNode *signing_node,
                             const HiveSignAccountCreate *msg,
+                            const uint8_t owner_raw[33],
+                            const uint8_t active_raw[33],
+                            const uint8_t posting_raw[33],
+                            const uint8_t memo_raw[33],
                             HiveSignedAccountCreate *resp);
 
 /**
  * Sign a Hive account_update transaction (op type 10).
- * Replaces all authorities with new KeepKey-derived keys.
+ * owner/active/posting/memo_raw must be device-derived 33-byte compressed keys.
+ * The firmware uses these directly; host-supplied new_*_key strings in msg are ignored.
  */
-void hive_signAccountUpdate(const HDNode *node,
+void hive_signAccountUpdate(const HDNode *signing_node,
                             const HiveSignAccountUpdate *msg,
+                            const uint8_t owner_raw[33],
+                            const uint8_t active_raw[33],
+                            const uint8_t posting_raw[33],
+                            const uint8_t memo_raw[33],
                             HiveSignedAccountUpdate *resp);
 
 #endif  // KEEPKEY_FIRMWARE_HIVE_H

--- a/include/keepkey/transport/interface.h
+++ b/include/keepkey/transport/interface.h
@@ -39,6 +39,7 @@
 #include "messages-ton.pb.h"
 #include "messages-solana.pb.h"
 #include "messages-zcash.pb.h"
+#include "messages-hive.pb.h"
 
 #include "types.pb.h"
 #include "trezor_transport.h"

--- a/include/keepkey/transport/messages-hive.options
+++ b/include/keepkey/transport/messages-hive.options
@@ -1,0 +1,15 @@
+HiveGetPublicKey.address_n              max_count:8
+
+HivePublicKey.public_key                max_size:64
+HivePublicKey.raw_public_key            max_size:33
+
+HiveSignTx.address_n                    max_count:8
+HiveSignTx.chain_id                     max_size:32
+HiveSignTx.from                         max_size:16
+HiveSignTx.to                           max_size:16
+HiveSignTx.amount                       int_size:IS_64
+HiveSignTx.asset_symbol                 max_size:10
+HiveSignTx.memo                         max_size:2048
+
+HiveSignedTx.signature                  max_size:65
+HiveSignedTx.serialized_tx              max_size:1024

--- a/include/keepkey/transport/messages-hive.options
+++ b/include/keepkey/transport/messages-hive.options
@@ -3,6 +3,13 @@ HiveGetPublicKey.address_n              max_count:8
 HivePublicKey.public_key                max_size:64
 HivePublicKey.raw_public_key            max_size:33
 
+HiveGetPublicKeys.account_index         int_size:IS_32
+
+HivePublicKeys.owner_key                max_size:64
+HivePublicKeys.active_key               max_size:64
+HivePublicKeys.memo_key                 max_size:64
+HivePublicKeys.posting_key              max_size:64
+
 HiveSignTx.address_n                    max_count:8
 HiveSignTx.chain_id                     max_size:32
 HiveSignTx.from                         max_size:16
@@ -12,4 +19,28 @@ HiveSignTx.asset_symbol                 max_size:10
 HiveSignTx.memo                         max_size:2048
 
 HiveSignedTx.signature                  max_size:65
-HiveSignedTx.serialized_tx              max_size:1024
+HiveSignedTx.serialized_tx              max_size:512
+
+HiveSignAccountCreate.address_n         max_count:8
+HiveSignAccountCreate.chain_id          max_size:32
+HiveSignAccountCreate.creator           max_size:16
+HiveSignAccountCreate.new_account_name  max_size:16
+HiveSignAccountCreate.owner_key         max_size:64
+HiveSignAccountCreate.active_key        max_size:64
+HiveSignAccountCreate.posting_key       max_size:64
+HiveSignAccountCreate.memo_key          max_size:64
+HiveSignAccountCreate.fee_amount        int_size:IS_64
+
+HiveSignedAccountCreate.signature       max_size:65
+HiveSignedAccountCreate.serialized_tx   max_size:512
+
+HiveSignAccountUpdate.address_n         max_count:8
+HiveSignAccountUpdate.chain_id          max_size:32
+HiveSignAccountUpdate.account           max_size:16
+HiveSignAccountUpdate.new_owner_key     max_size:64
+HiveSignAccountUpdate.new_active_key    max_size:64
+HiveSignAccountUpdate.new_posting_key   max_size:64
+HiveSignAccountUpdate.new_memo_key      max_size:64
+
+HiveSignedAccountUpdate.signature       max_size:65
+HiveSignedAccountUpdate.serialized_tx   max_size:512

--- a/include/keepkey/transport/messages-ripple.options
+++ b/include/keepkey/transport/messages-ripple.options
@@ -3,6 +3,7 @@ RippleGetAddress.address_n max_count:8
 RippleAddress.address max_size:36
 
 RippleSignTx.address_n max_count:8
+RippleSignTx.memo max_size:200
 
 RipplePayment.destination max_size:36
 

--- a/lib/firmware/fsm_msg_hive.h
+++ b/lib/firmware/fsm_msg_hive.h
@@ -7,33 +7,27 @@
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-void fsm_msgHiveGetPublicKey(const HiveGetPublicKey* msg) {
+// ── HiveGetPublicKey ──────────────────────────────────────────────────────
+// Returns a single STM-prefixed public key for the given SLIP-0048 path.
+// Path format: m/48'/13'/role'/account'/0' (all 5 components hardened).
+
+void fsm_msgHiveGetPublicKey(const HiveGetPublicKey *msg) {
   RESP_INIT(HivePublicKey);
 
   CHECK_INITIALIZED
   CHECK_PIN
 
-  HDNode* node = fsm_getDerivedNode(SECP256K1_NAME, msg->address_n,
+  HDNode *node = fsm_getDerivedNode(SECP256K1_NAME, msg->address_n,
                                     msg->address_n_count, NULL);
   if (!node) return;
   hdnode_fill_public_key(node);
 
-  // Return raw 33-byte compressed pubkey
   resp->has_raw_public_key = true;
   resp->raw_public_key.size = 33;
   memcpy(resp->raw_public_key.bytes, node->public_key, 33);
 
-  // Return STM-encoded public key
   resp->has_public_key = true;
   if (!hive_getPublicKey(node->public_key, resp->public_key,
                          sizeof(resp->public_key))) {
@@ -45,10 +39,21 @@ void fsm_msgHiveGetPublicKey(const HiveGetPublicKey* msg) {
   }
 
   if (msg->has_show_display && msg->show_display) {
-    if (!confirm_ethereum_address("Hive Public Key", resp->public_key)) {
+    // Determine role label for display
+    const char *role_label = "Hive Public Key";
+    if (msg->has_role) {
+      switch (msg->role) {
+        case 0: role_label = "Hive Owner Key";   break;
+        case 1: role_label = "Hive Active Key";  break;
+        case 3: role_label = "Hive Memo Key";    break;
+        case 4: role_label = "Hive Posting Key"; break;
+        default: break;
+      }
+    }
+    if (!confirm_ethereum_address(role_label, resp->public_key)) {
       memzero(node, sizeof(*node));
       fsm_sendFailure(FailureType_Failure_ActionCancelled,
-                      _("Show public key cancelled"));
+                      _("Cancelled"));
       layoutHome();
       return;
     }
@@ -59,7 +64,64 @@ void fsm_msgHiveGetPublicKey(const HiveGetPublicKey* msg) {
   layoutHome();
 }
 
-void fsm_msgHiveSignTx(const HiveSignTx* msg) {
+// ── HiveGetPublicKeys ─────────────────────────────────────────────────────
+// Returns all four SLIP-0048 role keys (owner/active/memo/posting) for a
+// given account index in a single device interaction.
+
+void fsm_msgHiveGetPublicKeys(const HiveGetPublicKeys *msg) {
+  RESP_INIT(HivePublicKeys);
+
+  CHECK_INITIALIZED
+  CHECK_PIN
+
+  uint32_t account_index = msg->has_account_index ? msg->account_index : 0;
+
+  // Derive all four keys from root node via SLIP-0048
+  // fsm_getDerivedNode with an empty path gives us the root — we pass the
+  // full derivation into hive_getPublicKeys so it can derive each role cleanly.
+  HDNode *root = fsm_getDerivedNode(SECP256K1_NAME, NULL, 0, NULL);
+  if (!root) return;
+
+  resp->has_owner_key   = true;
+  resp->has_active_key  = true;
+  resp->has_memo_key    = true;
+  resp->has_posting_key = true;
+
+  if (!hive_getPublicKeys(root, account_index,
+                          resp->owner_key,   sizeof(resp->owner_key),
+                          resp->active_key,  sizeof(resp->active_key),
+                          resp->memo_key,    sizeof(resp->memo_key),
+                          resp->posting_key, sizeof(resp->posting_key))) {
+    memzero(root, sizeof(*root));
+    fsm_sendFailure(FailureType_Failure_FirmwareError,
+                    _("Failed to derive Hive keys"));
+    layoutHome();
+    return;
+  }
+
+  if (msg->has_show_display && msg->show_display) {
+    // Show owner key with account context; user confirms all roles together
+    char display[80];
+    snprintf(display, sizeof(display), "Account %u\n%s", account_index,
+             resp->owner_key);
+    if (!confirm(ButtonRequestType_ButtonRequest_Other,
+                 "Hive Keys", "Export all Hive keys for account %u?",
+                 account_index)) {
+      memzero(root, sizeof(*root));
+      fsm_sendFailure(FailureType_Failure_ActionCancelled, _("Cancelled"));
+      layoutHome();
+      return;
+    }
+  }
+
+  memzero(root, sizeof(*root));
+  msg_write(MessageType_MessageType_HivePublicKeys, resp);
+  layoutHome();
+}
+
+// ── HiveSignTx (transfer) ─────────────────────────────────────────────────
+
+void fsm_msgHiveSignTx(const HiveSignTx *msg) {
   RESP_INIT(HiveSignedTx);
 
   CHECK_INITIALIZED
@@ -74,22 +136,16 @@ void fsm_msgHiveSignTx(const HiveSignTx* msg) {
     return;
   }
 
-  HDNode* node = fsm_getDerivedNode(SECP256K1_NAME, msg->address_n,
+  HDNode *node = fsm_getDerivedNode(SECP256K1_NAME, msg->address_n,
                                     msg->address_n_count, NULL);
   if (!node) return;
   hdnode_fill_public_key(node);
 
-  // Format amount string for confirmation
-  const char* symbol = msg->has_asset_symbol ? msg->asset_symbol : "HIVE";
-  uint32_t decimals = msg->has_decimals ? msg->decimals : HIVE_DECIMALS;
-
+  const char *symbol = msg->has_asset_symbol ? msg->asset_symbol : "HIVE";
   char amount_str[32];
-  uint64_t whole = msg->amount / 1000;
-  uint64_t frac = msg->amount % 1000;
-  // Simple format: decimals=3 → "X.XXX SYMBOL"
-  (void)decimals;
-  snprintf(amount_str, sizeof(amount_str), "%" PRIu64 ".%03" PRIu64 " %s",
-           whole, frac, symbol);
+  snprintf(amount_str, sizeof(amount_str),
+           "%" PRIu64 ".%03" PRIu64 " %s",
+           msg->amount / 1000, msg->amount % 1000, symbol);
 
   if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, "Send Hive",
                "Send %s to @%s?", amount_str, msg->to)) {
@@ -100,8 +156,8 @@ void fsm_msgHiveSignTx(const HiveSignTx* msg) {
   }
 
   if (msg->has_memo && strlen(msg->memo) > 0) {
-    if (!confirm(ButtonRequestType_ButtonRequest_ConfirmMemo, "Memo", "%s",
-                 msg->memo)) {
+    if (!confirm(ButtonRequestType_ButtonRequest_ConfirmMemo, "Memo",
+                 "%s", msg->memo)) {
       memzero(node, sizeof(*node));
       fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
       layoutHome();
@@ -121,12 +177,136 @@ void fsm_msgHiveSignTx(const HiveSignTx* msg) {
   memzero(node, sizeof(*node));
 
   if (!resp->has_signature) {
-    fsm_sendFailure(FailureType_Failure_FirmwareError,
-                    _("Hive signing failed"));
+    fsm_sendFailure(FailureType_Failure_FirmwareError, _("Hive signing failed"));
     layoutHome();
     return;
   }
 
   msg_write(MessageType_MessageType_HiveSignedTx, resp);
+  layoutHome();
+}
+
+// ── HiveSignAccountCreate ─────────────────────────────────────────────────
+// Signs a Graphene account_create operation.
+// Device displays the new username. KeepKey-derived keys are the sole
+// authority from genesis — no software keys ever exist.
+
+void fsm_msgHiveSignAccountCreate(const HiveSignAccountCreate *msg) {
+  RESP_INIT(HiveSignedAccountCreate);
+
+  CHECK_INITIALIZED
+  CHECK_PIN
+
+  if (!msg->has_new_account_name || !msg->has_creator ||
+      !msg->has_owner_key || !msg->has_active_key ||
+      !msg->has_posting_key || !msg->has_memo_key ||
+      !msg->has_ref_block_num || !msg->has_ref_block_prefix ||
+      !msg->has_expiration) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Missing required account_create fields"));
+    layoutHome();
+    return;
+  }
+
+  HDNode *node = fsm_getDerivedNode(SECP256K1_NAME, msg->address_n,
+                                    msg->address_n_count, NULL);
+  if (!node) return;
+  hdnode_fill_public_key(node);
+
+  // Primary confirmation: show the username prominently
+  if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
+               "Create Hive Account",
+               "Create @%s secured by KeepKey?\n\nAll keys from your device.",
+               msg->new_account_name)) {
+    memzero(node, sizeof(*node));
+    fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
+    layoutHome();
+    return;
+  }
+
+  // Secondary confirmation: show sponsor + fee
+  char fee_str[32];
+  uint64_t fee = msg->has_fee_amount ? msg->fee_amount : 3000;
+  snprintf(fee_str, sizeof(fee_str), "%" PRIu64 ".%03" PRIu64 " HIVE",
+           fee / 1000, fee % 1000);
+  if (!confirm(ButtonRequestType_ButtonRequest_SignTx, "Creation Fee",
+               "Fee: %s paid by @%s", fee_str, msg->creator)) {
+    memzero(node, sizeof(*node));
+    fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
+    layoutHome();
+    return;
+  }
+
+  hive_signAccountCreate(node, msg, resp);
+  memzero(node, sizeof(*node));
+
+  if (!resp->has_signature) {
+    fsm_sendFailure(FailureType_Failure_FirmwareError,
+                    _("Hive account_create signing failed"));
+    layoutHome();
+    return;
+  }
+
+  msg_write(MessageType_MessageType_HiveSignedAccountCreate, resp);
+  layoutHome();
+}
+
+// ── HiveSignAccountUpdate ─────────────────────────────────────────────────
+// Signs a Graphene account_update operation.
+// Replaces all existing account authorities with KeepKey-derived keys.
+// Device shows a clear warning that old keys will be replaced.
+
+void fsm_msgHiveSignAccountUpdate(const HiveSignAccountUpdate *msg) {
+  RESP_INIT(HiveSignedAccountUpdate);
+
+  CHECK_INITIALIZED
+  CHECK_PIN
+
+  if (!msg->has_account || !msg->has_new_owner_key || !msg->has_new_active_key ||
+      !msg->has_new_posting_key || !msg->has_new_memo_key ||
+      !msg->has_ref_block_num || !msg->has_ref_block_prefix ||
+      !msg->has_expiration) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Missing required account_update fields"));
+    layoutHome();
+    return;
+  }
+
+  HDNode *node = fsm_getDerivedNode(SECP256K1_NAME, msg->address_n,
+                                    msg->address_n_count, NULL);
+  if (!node) return;
+  hdnode_fill_public_key(node);
+
+  // Warning: this replaces all existing keys
+  if (!confirm(ButtonRequestType_ButtonRequest_ProtectCall,
+               "Secure Hive Account",
+               "Replace ALL keys for @%s with KeepKey keys?\n\nOld keys will be retired.",
+               msg->account)) {
+    memzero(node, sizeof(*node));
+    fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
+    layoutHome();
+    return;
+  }
+
+  // Second confirm: show new owner key so user can verify it's their device
+  if (!confirm(ButtonRequestType_ButtonRequest_SignTx, "New Owner Key",
+               "%s", msg->new_owner_key)) {
+    memzero(node, sizeof(*node));
+    fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
+    layoutHome();
+    return;
+  }
+
+  hive_signAccountUpdate(node, msg, resp);
+  memzero(node, sizeof(*node));
+
+  if (!resp->has_signature) {
+    fsm_sendFailure(FailureType_Failure_FirmwareError,
+                    _("Hive account_update signing failed"));
+    layoutHome();
+    return;
+  }
+
+  msg_write(MessageType_MessageType_HiveSignedAccountUpdate, resp);
   layoutHome();
 }

--- a/lib/firmware/fsm_msg_hive.h
+++ b/lib/firmware/fsm_msg_hive.h
@@ -13,13 +13,13 @@
 // Returns a single STM-prefixed public key for the given SLIP-0048 path.
 // Path format: m/48'/13'/role'/account'/0' (all 5 components hardened).
 
-void fsm_msgHiveGetPublicKey(const HiveGetPublicKey *msg) {
+void fsm_msgHiveGetPublicKey(const HiveGetPublicKey* msg) {
   RESP_INIT(HivePublicKey);
 
   CHECK_INITIALIZED
   CHECK_PIN
 
-  HDNode *node = fsm_getDerivedNode(SECP256K1_NAME, msg->address_n,
+  HDNode* node = fsm_getDerivedNode(SECP256K1_NAME, msg->address_n,
                                     msg->address_n_count, NULL);
   if (!node) return;
   hdnode_fill_public_key(node);
@@ -40,20 +40,28 @@ void fsm_msgHiveGetPublicKey(const HiveGetPublicKey *msg) {
 
   if (msg->has_show_display && msg->show_display) {
     // Determine role label for display
-    const char *role_label = "Hive Public Key";
+    const char* role_label = "Hive Public Key";
     if (msg->has_role) {
       switch (msg->role) {
-        case 0: role_label = "Hive Owner Key";   break;
-        case 1: role_label = "Hive Active Key";  break;
-        case 3: role_label = "Hive Memo Key";    break;
-        case 4: role_label = "Hive Posting Key"; break;
-        default: break;
+        case 0:
+          role_label = "Hive Owner Key";
+          break;
+        case 1:
+          role_label = "Hive Active Key";
+          break;
+        case 3:
+          role_label = "Hive Memo Key";
+          break;
+        case 4:
+          role_label = "Hive Posting Key";
+          break;
+        default:
+          break;
       }
     }
     if (!confirm_ethereum_address(role_label, resp->public_key)) {
       memzero(node, sizeof(*node));
-      fsm_sendFailure(FailureType_Failure_ActionCancelled,
-                      _("Cancelled"));
+      fsm_sendFailure(FailureType_Failure_ActionCancelled, _("Cancelled"));
       layoutHome();
       return;
     }
@@ -68,7 +76,7 @@ void fsm_msgHiveGetPublicKey(const HiveGetPublicKey *msg) {
 // Returns all four SLIP-0048 role keys (owner/active/memo/posting) for a
 // given account index in a single device interaction.
 
-void fsm_msgHiveGetPublicKeys(const HiveGetPublicKeys *msg) {
+void fsm_msgHiveGetPublicKeys(const HiveGetPublicKeys* msg) {
   RESP_INIT(HivePublicKeys);
 
   CHECK_INITIALIZED
@@ -76,19 +84,19 @@ void fsm_msgHiveGetPublicKeys(const HiveGetPublicKeys *msg) {
 
   uint32_t account_index = msg->has_account_index ? msg->account_index : 0;
 
-  HDNode *root = fsm_getDerivedNode(SECP256K1_NAME, NULL, 0, NULL);
+  HDNode* root = fsm_getDerivedNode(SECP256K1_NAME, NULL, 0, NULL);
   if (!root) return;
 
-  resp->has_owner_key   = true;
-  resp->has_active_key  = true;
-  resp->has_memo_key    = true;
+  resp->has_owner_key = true;
+  resp->has_active_key = true;
+  resp->has_memo_key = true;
   resp->has_posting_key = true;
 
-  if (!hive_getPublicKeys(root, account_index,
-                          resp->owner_key,   sizeof(resp->owner_key),
-                          resp->active_key,  sizeof(resp->active_key),
-                          resp->memo_key,    sizeof(resp->memo_key),
-                          resp->posting_key, sizeof(resp->posting_key))) {
+  if (!hive_getPublicKeys(root, account_index, resp->owner_key,
+                          sizeof(resp->owner_key), resp->active_key,
+                          sizeof(resp->active_key), resp->memo_key,
+                          sizeof(resp->memo_key), resp->posting_key,
+                          sizeof(resp->posting_key))) {
     memzero(root, sizeof(*root));
     fsm_sendFailure(FailureType_Failure_FirmwareError,
                     _("Failed to derive Hive keys"));
@@ -97,9 +105,8 @@ void fsm_msgHiveGetPublicKeys(const HiveGetPublicKeys *msg) {
   }
 
   if (msg->has_show_display && msg->show_display) {
-    if (!confirm(ButtonRequestType_ButtonRequest_Other,
-                 "Hive Keys", "Export all Hive keys for account %u?",
-                 account_index)) {
+    if (!confirm(ButtonRequestType_ButtonRequest_Other, "Hive Keys",
+                 "Export all Hive keys for account %u?", account_index)) {
       memzero(root, sizeof(*root));
       fsm_sendFailure(FailureType_Failure_ActionCancelled, _("Cancelled"));
       layoutHome();
@@ -114,7 +121,7 @@ void fsm_msgHiveGetPublicKeys(const HiveGetPublicKeys *msg) {
 
 // ── HiveSignTx (transfer) ─────────────────────────────────────────────────
 
-void fsm_msgHiveSignTx(const HiveSignTx *msg) {
+void fsm_msgHiveSignTx(const HiveSignTx* msg) {
   RESP_INIT(HiveSignedTx);
 
   CHECK_INITIALIZED
@@ -129,15 +136,14 @@ void fsm_msgHiveSignTx(const HiveSignTx *msg) {
     return;
   }
 
-  HDNode *node = fsm_getDerivedNode(SECP256K1_NAME, msg->address_n,
+  HDNode* node = fsm_getDerivedNode(SECP256K1_NAME, msg->address_n,
                                     msg->address_n_count, NULL);
   if (!node) return;
   hdnode_fill_public_key(node);
 
-  const char *symbol = msg->has_asset_symbol ? msg->asset_symbol : "HIVE";
+  const char* symbol = msg->has_asset_symbol ? msg->asset_symbol : "HIVE";
   char amount_str[32];
-  snprintf(amount_str, sizeof(amount_str),
-           "%" PRIu64 ".%03" PRIu64 " %s",
+  snprintf(amount_str, sizeof(amount_str), "%" PRIu64 ".%03" PRIu64 " %s",
            msg->amount / 1000, msg->amount % 1000, symbol);
 
   if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, "Send Hive",
@@ -149,8 +155,8 @@ void fsm_msgHiveSignTx(const HiveSignTx *msg) {
   }
 
   if (msg->has_memo && strlen(msg->memo) > 0) {
-    if (!confirm(ButtonRequestType_ButtonRequest_ConfirmMemo, "Memo",
-                 "%s", msg->memo)) {
+    if (!confirm(ButtonRequestType_ButtonRequest_ConfirmMemo, "Memo", "%s",
+                 msg->memo)) {
       memzero(node, sizeof(*node));
       fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
       layoutHome();
@@ -170,7 +176,8 @@ void fsm_msgHiveSignTx(const HiveSignTx *msg) {
   memzero(node, sizeof(*node));
 
   if (!resp->has_signature) {
-    fsm_sendFailure(FailureType_Failure_FirmwareError, _("Hive signing failed"));
+    fsm_sendFailure(FailureType_Failure_FirmwareError,
+                    _("Hive signing failed"));
     layoutHome();
     return;
   }
@@ -185,7 +192,7 @@ void fsm_msgHiveSignTx(const HiveSignTx *msg) {
 // are informational only (displayed for confirmation) and never used for
 // the actual transaction. KeepKey is the sole root of trust from genesis.
 
-void fsm_msgHiveSignAccountCreate(const HiveSignAccountCreate *msg) {
+void fsm_msgHiveSignAccountCreate(const HiveSignAccountCreate* msg) {
   RESP_INIT(HiveSignedAccountCreate);
 
   CHECK_INITIALIZED
@@ -203,8 +210,7 @@ void fsm_msgHiveSignAccountCreate(const HiveSignAccountCreate *msg) {
   // Path must have at least 4 components so we can extract account_index.
   // Expected: m/48'/13'/0'/account_index'/0' (count = 5)
   if (msg->address_n_count < 4) {
-    fsm_sendFailure(FailureType_Failure_SyntaxError,
-                    _("Hive path too short"));
+    fsm_sendFailure(FailureType_Failure_SyntaxError, _("Hive path too short"));
     layoutHome();
     return;
   }
@@ -213,16 +219,16 @@ void fsm_msgHiveSignAccountCreate(const HiveSignAccountCreate *msg) {
   // Derive all four role keys from the device root.
   // Do this BEFORE fetching the signing node so the root static buffer
   // is not clobbered by the second fsm_getDerivedNode call.
-  HDNode *root = fsm_getDerivedNode(SECP256K1_NAME, NULL, 0, NULL);
+  HDNode* root = fsm_getDerivedNode(SECP256K1_NAME, NULL, 0, NULL);
   if (!root) return;
 
   uint8_t owner_raw[33], active_raw[33], posting_raw[33], memo_raw[33];
   uint32_t acc_hardened = account_index | 0x80000000u;
   bool keys_ok =
-    hive_deriveRawKey(root, HIVE_ROLE_OWNER,   acc_hardened, owner_raw)   &&
-    hive_deriveRawKey(root, HIVE_ROLE_ACTIVE,  acc_hardened, active_raw)  &&
-    hive_deriveRawKey(root, HIVE_ROLE_POSTING, acc_hardened, posting_raw) &&
-    hive_deriveRawKey(root, HIVE_ROLE_MEMO,    acc_hardened, memo_raw);
+      hive_deriveRawKey(root, HIVE_ROLE_OWNER, acc_hardened, owner_raw) &&
+      hive_deriveRawKey(root, HIVE_ROLE_ACTIVE, acc_hardened, active_raw) &&
+      hive_deriveRawKey(root, HIVE_ROLE_POSTING, acc_hardened, posting_raw) &&
+      hive_deriveRawKey(root, HIVE_ROLE_MEMO, acc_hardened, memo_raw);
   // root static buffer is done with; signing node derivation may overwrite it.
 
   if (!keys_ok) {
@@ -237,7 +243,7 @@ void fsm_msgHiveSignAccountCreate(const HiveSignAccountCreate *msg) {
   }
 
   // Now get the signing node (owner key, overwrites root static buffer).
-  HDNode *node = fsm_getDerivedNode(SECP256K1_NAME, msg->address_n,
+  HDNode* node = fsm_getDerivedNode(SECP256K1_NAME, msg->address_n,
                                     msg->address_n_count, NULL);
   if (!node) {
     memzero(owner_raw, sizeof(owner_raw));
@@ -278,8 +284,8 @@ void fsm_msgHiveSignAccountCreate(const HiveSignAccountCreate *msg) {
   }
 
   // Secondary confirmation: show device-derived owner key so user can verify.
-  if (!confirm(ButtonRequestType_ButtonRequest_Other, "Owner Key",
-               "%s", owner_stm)) {
+  if (!confirm(ButtonRequestType_ButtonRequest_Other, "Owner Key", "%s",
+               owner_stm)) {
     memzero(node, sizeof(*node));
     memzero(owner_raw, sizeof(owner_raw));
     memzero(active_raw, sizeof(active_raw));
@@ -307,8 +313,8 @@ void fsm_msgHiveSignAccountCreate(const HiveSignAccountCreate *msg) {
     return;
   }
 
-  hive_signAccountCreate(node, msg,
-                         owner_raw, active_raw, posting_raw, memo_raw, resp);
+  hive_signAccountCreate(node, msg, owner_raw, active_raw, posting_raw,
+                         memo_raw, resp);
   memzero(node, sizeof(*node));
   memzero(owner_raw, sizeof(owner_raw));
   memzero(active_raw, sizeof(active_raw));
@@ -332,15 +338,14 @@ void fsm_msgHiveSignAccountCreate(const HiveSignAccountCreate *msg) {
 // strings are not used for signing. The device-derived owner key is shown
 // so the user can verify it matches their device before replacing all keys.
 
-void fsm_msgHiveSignAccountUpdate(const HiveSignAccountUpdate *msg) {
+void fsm_msgHiveSignAccountUpdate(const HiveSignAccountUpdate* msg) {
   RESP_INIT(HiveSignedAccountUpdate);
 
   CHECK_INITIALIZED
   CHECK_PIN
 
-  if (!msg->has_account ||
-      !msg->has_ref_block_num || !msg->has_ref_block_prefix ||
-      !msg->has_expiration) {
+  if (!msg->has_account || !msg->has_ref_block_num ||
+      !msg->has_ref_block_prefix || !msg->has_expiration) {
     fsm_sendFailure(FailureType_Failure_SyntaxError,
                     _("Missing required account_update fields"));
     layoutHome();
@@ -348,24 +353,23 @@ void fsm_msgHiveSignAccountUpdate(const HiveSignAccountUpdate *msg) {
   }
 
   if (msg->address_n_count < 4) {
-    fsm_sendFailure(FailureType_Failure_SyntaxError,
-                    _("Hive path too short"));
+    fsm_sendFailure(FailureType_Failure_SyntaxError, _("Hive path too short"));
     layoutHome();
     return;
   }
   uint32_t account_index = msg->address_n[3] & 0x7FFFFFFFu;
 
   // Derive all four role keys before fetching the signing node.
-  HDNode *root = fsm_getDerivedNode(SECP256K1_NAME, NULL, 0, NULL);
+  HDNode* root = fsm_getDerivedNode(SECP256K1_NAME, NULL, 0, NULL);
   if (!root) return;
 
   uint8_t owner_raw[33], active_raw[33], posting_raw[33], memo_raw[33];
   uint32_t acc_hardened = account_index | 0x80000000u;
   bool keys_ok =
-    hive_deriveRawKey(root, HIVE_ROLE_OWNER,   acc_hardened, owner_raw)   &&
-    hive_deriveRawKey(root, HIVE_ROLE_ACTIVE,  acc_hardened, active_raw)  &&
-    hive_deriveRawKey(root, HIVE_ROLE_POSTING, acc_hardened, posting_raw) &&
-    hive_deriveRawKey(root, HIVE_ROLE_MEMO,    acc_hardened, memo_raw);
+      hive_deriveRawKey(root, HIVE_ROLE_OWNER, acc_hardened, owner_raw) &&
+      hive_deriveRawKey(root, HIVE_ROLE_ACTIVE, acc_hardened, active_raw) &&
+      hive_deriveRawKey(root, HIVE_ROLE_POSTING, acc_hardened, posting_raw) &&
+      hive_deriveRawKey(root, HIVE_ROLE_MEMO, acc_hardened, memo_raw);
 
   if (!keys_ok) {
     memzero(owner_raw, sizeof(owner_raw));
@@ -379,7 +383,7 @@ void fsm_msgHiveSignAccountUpdate(const HiveSignAccountUpdate *msg) {
   }
 
   // Signing node (overwrites root static buffer).
-  HDNode *node = fsm_getDerivedNode(SECP256K1_NAME, msg->address_n,
+  HDNode* node = fsm_getDerivedNode(SECP256K1_NAME, msg->address_n,
                                     msg->address_n_count, NULL);
   if (!node) {
     memzero(owner_raw, sizeof(owner_raw));
@@ -407,7 +411,8 @@ void fsm_msgHiveSignAccountUpdate(const HiveSignAccountUpdate *msg) {
   // Warning: this replaces all existing keys.
   if (!confirm(ButtonRequestType_ButtonRequest_ProtectCall,
                "Secure Hive Account",
-               "Replace ALL keys for @%s with KeepKey keys?\n\nOld keys will be retired.",
+               "Replace ALL keys for @%s with KeepKey keys?\n\nOld keys will "
+               "be retired.",
                msg->account)) {
     memzero(node, sizeof(*node));
     memzero(owner_raw, sizeof(owner_raw));
@@ -420,8 +425,8 @@ void fsm_msgHiveSignAccountUpdate(const HiveSignAccountUpdate *msg) {
   }
 
   // Show device-derived owner key so user can verify it's their device.
-  if (!confirm(ButtonRequestType_ButtonRequest_SignTx, "New Owner Key",
-               "%s", owner_stm)) {
+  if (!confirm(ButtonRequestType_ButtonRequest_SignTx, "New Owner Key", "%s",
+               owner_stm)) {
     memzero(node, sizeof(*node));
     memzero(owner_raw, sizeof(owner_raw));
     memzero(active_raw, sizeof(active_raw));
@@ -432,8 +437,8 @@ void fsm_msgHiveSignAccountUpdate(const HiveSignAccountUpdate *msg) {
     return;
   }
 
-  hive_signAccountUpdate(node, msg,
-                         owner_raw, active_raw, posting_raw, memo_raw, resp);
+  hive_signAccountUpdate(node, msg, owner_raw, active_raw, posting_raw,
+                         memo_raw, resp);
   memzero(node, sizeof(*node));
   memzero(owner_raw, sizeof(owner_raw));
   memzero(active_raw, sizeof(active_raw));

--- a/lib/firmware/fsm_msg_hive.h
+++ b/lib/firmware/fsm_msg_hive.h
@@ -219,7 +219,7 @@ void fsm_msgHiveSignAccountCreate(const HiveSignAccountCreate* msg) {
   // Derive all four role keys from the device root.
   // Do this BEFORE fetching the signing node so the root static buffer
   // is not clobbered by the second fsm_getDerivedNode call.
-  HDNode* root = fsm_getDerivedNode(SECP256K1_NAME, NULL, 0, NULL);
+  const HDNode* root = fsm_getDerivedNode(SECP256K1_NAME, NULL, 0, NULL);
   if (!root) return;
 
   uint8_t owner_raw[33], active_raw[33], posting_raw[33], memo_raw[33];
@@ -360,7 +360,7 @@ void fsm_msgHiveSignAccountUpdate(const HiveSignAccountUpdate* msg) {
   uint32_t account_index = msg->address_n[3] & 0x7FFFFFFFu;
 
   // Derive all four role keys before fetching the signing node.
-  HDNode* root = fsm_getDerivedNode(SECP256K1_NAME, NULL, 0, NULL);
+  const HDNode* root = fsm_getDerivedNode(SECP256K1_NAME, NULL, 0, NULL);
   if (!root) return;
 
   uint8_t owner_raw[33], active_raw[33], posting_raw[33], memo_raw[33];

--- a/lib/firmware/fsm_msg_hive.h
+++ b/lib/firmware/fsm_msg_hive.h
@@ -76,9 +76,6 @@ void fsm_msgHiveGetPublicKeys(const HiveGetPublicKeys *msg) {
 
   uint32_t account_index = msg->has_account_index ? msg->account_index : 0;
 
-  // Derive all four keys from root node via SLIP-0048
-  // fsm_getDerivedNode with an empty path gives us the root — we pass the
-  // full derivation into hive_getPublicKeys so it can derive each role cleanly.
   HDNode *root = fsm_getDerivedNode(SECP256K1_NAME, NULL, 0, NULL);
   if (!root) return;
 
@@ -100,10 +97,6 @@ void fsm_msgHiveGetPublicKeys(const HiveGetPublicKeys *msg) {
   }
 
   if (msg->has_show_display && msg->show_display) {
-    // Show owner key with account context; user confirms all roles together
-    char display[80];
-    snprintf(display, sizeof(display), "Account %u\n%s", account_index,
-             resp->owner_key);
     if (!confirm(ButtonRequestType_ButtonRequest_Other,
                  "Hive Keys", "Export all Hive keys for account %u?",
                  account_index)) {
@@ -188,8 +181,9 @@ void fsm_msgHiveSignTx(const HiveSignTx *msg) {
 
 // ── HiveSignAccountCreate ─────────────────────────────────────────────────
 // Signs a Graphene account_create operation.
-// Device displays the new username. KeepKey-derived keys are the sole
-// authority from genesis — no software keys ever exist.
+// Device derives all four role keys internally; host-supplied key strings
+// are informational only (displayed for confirmation) and never used for
+// the actual transaction. KeepKey is the sole root of trust from genesis.
 
 void fsm_msgHiveSignAccountCreate(const HiveSignAccountCreate *msg) {
   RESP_INIT(HiveSignedAccountCreate);
@@ -198,8 +192,6 @@ void fsm_msgHiveSignAccountCreate(const HiveSignAccountCreate *msg) {
   CHECK_PIN
 
   if (!msg->has_new_account_name || !msg->has_creator ||
-      !msg->has_owner_key || !msg->has_active_key ||
-      !msg->has_posting_key || !msg->has_memo_key ||
       !msg->has_ref_block_num || !msg->has_ref_block_prefix ||
       !msg->has_expiration) {
     fsm_sendFailure(FailureType_Failure_SyntaxError,
@@ -208,23 +200,97 @@ void fsm_msgHiveSignAccountCreate(const HiveSignAccountCreate *msg) {
     return;
   }
 
+  // Path must have at least 4 components so we can extract account_index.
+  // Expected: m/48'/13'/0'/account_index'/0' (count = 5)
+  if (msg->address_n_count < 4) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Hive path too short"));
+    layoutHome();
+    return;
+  }
+  uint32_t account_index = msg->address_n[3] & 0x7FFFFFFFu;
+
+  // Derive all four role keys from the device root.
+  // Do this BEFORE fetching the signing node so the root static buffer
+  // is not clobbered by the second fsm_getDerivedNode call.
+  HDNode *root = fsm_getDerivedNode(SECP256K1_NAME, NULL, 0, NULL);
+  if (!root) return;
+
+  uint8_t owner_raw[33], active_raw[33], posting_raw[33], memo_raw[33];
+  uint32_t acc_hardened = account_index | 0x80000000u;
+  bool keys_ok =
+    hive_deriveRawKey(root, HIVE_ROLE_OWNER,   acc_hardened, owner_raw)   &&
+    hive_deriveRawKey(root, HIVE_ROLE_ACTIVE,  acc_hardened, active_raw)  &&
+    hive_deriveRawKey(root, HIVE_ROLE_POSTING, acc_hardened, posting_raw) &&
+    hive_deriveRawKey(root, HIVE_ROLE_MEMO,    acc_hardened, memo_raw);
+  // root static buffer is done with; signing node derivation may overwrite it.
+
+  if (!keys_ok) {
+    memzero(owner_raw, sizeof(owner_raw));
+    memzero(active_raw, sizeof(active_raw));
+    memzero(posting_raw, sizeof(posting_raw));
+    memzero(memo_raw, sizeof(memo_raw));
+    fsm_sendFailure(FailureType_Failure_FirmwareError,
+                    _("Failed to derive Hive keys"));
+    layoutHome();
+    return;
+  }
+
+  // Now get the signing node (owner key, overwrites root static buffer).
   HDNode *node = fsm_getDerivedNode(SECP256K1_NAME, msg->address_n,
                                     msg->address_n_count, NULL);
-  if (!node) return;
+  if (!node) {
+    memzero(owner_raw, sizeof(owner_raw));
+    memzero(active_raw, sizeof(active_raw));
+    memzero(posting_raw, sizeof(posting_raw));
+    memzero(memo_raw, sizeof(memo_raw));
+    return;
+  }
   hdnode_fill_public_key(node);
 
-  // Primary confirmation: show the username prominently
+  // Encode the device-derived owner key for display confirmation.
+  char owner_stm[64];
+  if (!hive_getPublicKey(owner_raw, owner_stm, sizeof(owner_stm))) {
+    memzero(node, sizeof(*node));
+    memzero(owner_raw, sizeof(owner_raw));
+    memzero(active_raw, sizeof(active_raw));
+    memzero(posting_raw, sizeof(posting_raw));
+    memzero(memo_raw, sizeof(memo_raw));
+    fsm_sendFailure(FailureType_Failure_FirmwareError,
+                    _("Failed to encode Hive owner key"));
+    layoutHome();
+    return;
+  }
+
+  // Primary confirmation: show the new username prominently.
   if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
                "Create Hive Account",
                "Create @%s secured by KeepKey?\n\nAll keys from your device.",
                msg->new_account_name)) {
     memzero(node, sizeof(*node));
+    memzero(owner_raw, sizeof(owner_raw));
+    memzero(active_raw, sizeof(active_raw));
+    memzero(posting_raw, sizeof(posting_raw));
+    memzero(memo_raw, sizeof(memo_raw));
     fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
     layoutHome();
     return;
   }
 
-  // Secondary confirmation: show sponsor + fee
+  // Secondary confirmation: show device-derived owner key so user can verify.
+  if (!confirm(ButtonRequestType_ButtonRequest_Other, "Owner Key",
+               "%s", owner_stm)) {
+    memzero(node, sizeof(*node));
+    memzero(owner_raw, sizeof(owner_raw));
+    memzero(active_raw, sizeof(active_raw));
+    memzero(posting_raw, sizeof(posting_raw));
+    memzero(memo_raw, sizeof(memo_raw));
+    fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
+    layoutHome();
+    return;
+  }
+
+  // Tertiary confirmation: show sponsor + fee.
   char fee_str[32];
   uint64_t fee = msg->has_fee_amount ? msg->fee_amount : 3000;
   snprintf(fee_str, sizeof(fee_str), "%" PRIu64 ".%03" PRIu64 " HIVE",
@@ -232,13 +298,22 @@ void fsm_msgHiveSignAccountCreate(const HiveSignAccountCreate *msg) {
   if (!confirm(ButtonRequestType_ButtonRequest_SignTx, "Creation Fee",
                "Fee: %s paid by @%s", fee_str, msg->creator)) {
     memzero(node, sizeof(*node));
+    memzero(owner_raw, sizeof(owner_raw));
+    memzero(active_raw, sizeof(active_raw));
+    memzero(posting_raw, sizeof(posting_raw));
+    memzero(memo_raw, sizeof(memo_raw));
     fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
     layoutHome();
     return;
   }
 
-  hive_signAccountCreate(node, msg, resp);
+  hive_signAccountCreate(node, msg,
+                         owner_raw, active_raw, posting_raw, memo_raw, resp);
   memzero(node, sizeof(*node));
+  memzero(owner_raw, sizeof(owner_raw));
+  memzero(active_raw, sizeof(active_raw));
+  memzero(posting_raw, sizeof(posting_raw));
+  memzero(memo_raw, sizeof(memo_raw));
 
   if (!resp->has_signature) {
     fsm_sendFailure(FailureType_Failure_FirmwareError,
@@ -253,8 +328,9 @@ void fsm_msgHiveSignAccountCreate(const HiveSignAccountCreate *msg) {
 
 // ── HiveSignAccountUpdate ─────────────────────────────────────────────────
 // Signs a Graphene account_update operation.
-// Replaces all existing account authorities with KeepKey-derived keys.
-// Device shows a clear warning that old keys will be replaced.
+// Device derives all four new role keys internally; host-supplied new_*_key
+// strings are not used for signing. The device-derived owner key is shown
+// so the user can verify it matches their device before replacing all keys.
 
 void fsm_msgHiveSignAccountUpdate(const HiveSignAccountUpdate *msg) {
   RESP_INIT(HiveSignedAccountUpdate);
@@ -262,8 +338,7 @@ void fsm_msgHiveSignAccountUpdate(const HiveSignAccountUpdate *msg) {
   CHECK_INITIALIZED
   CHECK_PIN
 
-  if (!msg->has_account || !msg->has_new_owner_key || !msg->has_new_active_key ||
-      !msg->has_new_posting_key || !msg->has_new_memo_key ||
+  if (!msg->has_account ||
       !msg->has_ref_block_num || !msg->has_ref_block_prefix ||
       !msg->has_expiration) {
     fsm_sendFailure(FailureType_Failure_SyntaxError,
@@ -272,33 +347,98 @@ void fsm_msgHiveSignAccountUpdate(const HiveSignAccountUpdate *msg) {
     return;
   }
 
+  if (msg->address_n_count < 4) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Hive path too short"));
+    layoutHome();
+    return;
+  }
+  uint32_t account_index = msg->address_n[3] & 0x7FFFFFFFu;
+
+  // Derive all four role keys before fetching the signing node.
+  HDNode *root = fsm_getDerivedNode(SECP256K1_NAME, NULL, 0, NULL);
+  if (!root) return;
+
+  uint8_t owner_raw[33], active_raw[33], posting_raw[33], memo_raw[33];
+  uint32_t acc_hardened = account_index | 0x80000000u;
+  bool keys_ok =
+    hive_deriveRawKey(root, HIVE_ROLE_OWNER,   acc_hardened, owner_raw)   &&
+    hive_deriveRawKey(root, HIVE_ROLE_ACTIVE,  acc_hardened, active_raw)  &&
+    hive_deriveRawKey(root, HIVE_ROLE_POSTING, acc_hardened, posting_raw) &&
+    hive_deriveRawKey(root, HIVE_ROLE_MEMO,    acc_hardened, memo_raw);
+
+  if (!keys_ok) {
+    memzero(owner_raw, sizeof(owner_raw));
+    memzero(active_raw, sizeof(active_raw));
+    memzero(posting_raw, sizeof(posting_raw));
+    memzero(memo_raw, sizeof(memo_raw));
+    fsm_sendFailure(FailureType_Failure_FirmwareError,
+                    _("Failed to derive Hive keys"));
+    layoutHome();
+    return;
+  }
+
+  // Signing node (overwrites root static buffer).
   HDNode *node = fsm_getDerivedNode(SECP256K1_NAME, msg->address_n,
                                     msg->address_n_count, NULL);
-  if (!node) return;
+  if (!node) {
+    memzero(owner_raw, sizeof(owner_raw));
+    memzero(active_raw, sizeof(active_raw));
+    memzero(posting_raw, sizeof(posting_raw));
+    memzero(memo_raw, sizeof(memo_raw));
+    return;
+  }
   hdnode_fill_public_key(node);
 
-  // Warning: this replaces all existing keys
+  // Encode device-derived owner key for display.
+  char owner_stm[64];
+  if (!hive_getPublicKey(owner_raw, owner_stm, sizeof(owner_stm))) {
+    memzero(node, sizeof(*node));
+    memzero(owner_raw, sizeof(owner_raw));
+    memzero(active_raw, sizeof(active_raw));
+    memzero(posting_raw, sizeof(posting_raw));
+    memzero(memo_raw, sizeof(memo_raw));
+    fsm_sendFailure(FailureType_Failure_FirmwareError,
+                    _("Failed to encode Hive owner key"));
+    layoutHome();
+    return;
+  }
+
+  // Warning: this replaces all existing keys.
   if (!confirm(ButtonRequestType_ButtonRequest_ProtectCall,
                "Secure Hive Account",
                "Replace ALL keys for @%s with KeepKey keys?\n\nOld keys will be retired.",
                msg->account)) {
     memzero(node, sizeof(*node));
+    memzero(owner_raw, sizeof(owner_raw));
+    memzero(active_raw, sizeof(active_raw));
+    memzero(posting_raw, sizeof(posting_raw));
+    memzero(memo_raw, sizeof(memo_raw));
     fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
     layoutHome();
     return;
   }
 
-  // Second confirm: show new owner key so user can verify it's their device
+  // Show device-derived owner key so user can verify it's their device.
   if (!confirm(ButtonRequestType_ButtonRequest_SignTx, "New Owner Key",
-               "%s", msg->new_owner_key)) {
+               "%s", owner_stm)) {
     memzero(node, sizeof(*node));
+    memzero(owner_raw, sizeof(owner_raw));
+    memzero(active_raw, sizeof(active_raw));
+    memzero(posting_raw, sizeof(posting_raw));
+    memzero(memo_raw, sizeof(memo_raw));
     fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
     layoutHome();
     return;
   }
 
-  hive_signAccountUpdate(node, msg, resp);
+  hive_signAccountUpdate(node, msg,
+                         owner_raw, active_raw, posting_raw, memo_raw, resp);
   memzero(node, sizeof(*node));
+  memzero(owner_raw, sizeof(owner_raw));
+  memzero(active_raw, sizeof(active_raw));
+  memzero(posting_raw, sizeof(posting_raw));
+  memzero(memo_raw, sizeof(memo_raw));
 
   if (!resp->has_signature) {
     fsm_sendFailure(FailureType_Failure_FirmwareError,

--- a/lib/firmware/fsm_msg_hive.h
+++ b/lib/firmware/fsm_msg_hive.h
@@ -106,7 +106,8 @@ void fsm_msgHiveGetPublicKeys(const HiveGetPublicKeys* msg) {
 
   if (msg->has_show_display && msg->show_display) {
     if (!confirm(ButtonRequestType_ButtonRequest_Other, "Hive Keys",
-                 "Export all Hive keys for account %u?", account_index)) {
+                 "Export all Hive keys for account %u?",
+                 (unsigned int)account_index)) {
       memzero(root, sizeof(*root));
       fsm_sendFailure(FailureType_Failure_ActionCancelled, _("Cancelled"));
       layoutHome();

--- a/lib/firmware/fsm_msg_hive.h
+++ b/lib/firmware/fsm_msg_hive.h
@@ -17,13 +17,13 @@
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-void fsm_msgHiveGetPublicKey(const HiveGetPublicKey *msg) {
+void fsm_msgHiveGetPublicKey(const HiveGetPublicKey* msg) {
   RESP_INIT(HivePublicKey);
 
   CHECK_INITIALIZED
   CHECK_PIN
 
-  HDNode *node = fsm_getDerivedNode(SECP256K1_NAME, msg->address_n,
+  HDNode* node = fsm_getDerivedNode(SECP256K1_NAME, msg->address_n,
                                     msg->address_n_count, NULL);
   if (!node) return;
   hdnode_fill_public_key(node);
@@ -36,7 +36,7 @@ void fsm_msgHiveGetPublicKey(const HiveGetPublicKey *msg) {
   // Return STM-encoded public key
   resp->has_public_key = true;
   if (!hive_getPublicKey(node->public_key, resp->public_key,
-                          sizeof(resp->public_key))) {
+                         sizeof(resp->public_key))) {
     memzero(node, sizeof(*node));
     fsm_sendFailure(FailureType_Failure_FirmwareError,
                     _("Failed to encode Hive public key"));
@@ -59,7 +59,7 @@ void fsm_msgHiveGetPublicKey(const HiveGetPublicKey *msg) {
   layoutHome();
 }
 
-void fsm_msgHiveSignTx(const HiveSignTx *msg) {
+void fsm_msgHiveSignTx(const HiveSignTx* msg) {
   RESP_INIT(HiveSignedTx);
 
   CHECK_INITIALIZED
@@ -74,13 +74,13 @@ void fsm_msgHiveSignTx(const HiveSignTx *msg) {
     return;
   }
 
-  HDNode *node = fsm_getDerivedNode(SECP256K1_NAME, msg->address_n,
+  HDNode* node = fsm_getDerivedNode(SECP256K1_NAME, msg->address_n,
                                     msg->address_n_count, NULL);
   if (!node) return;
   hdnode_fill_public_key(node);
 
   // Format amount string for confirmation
-  const char *symbol = msg->has_asset_symbol ? msg->asset_symbol : "HIVE";
+  const char* symbol = msg->has_asset_symbol ? msg->asset_symbol : "HIVE";
   uint32_t decimals = msg->has_decimals ? msg->decimals : HIVE_DECIMALS;
 
   char amount_str[32];
@@ -100,8 +100,8 @@ void fsm_msgHiveSignTx(const HiveSignTx *msg) {
   }
 
   if (msg->has_memo && strlen(msg->memo) > 0) {
-    if (!confirm(ButtonRequestType_ButtonRequest_ConfirmMemo, "Memo",
-                 "%s", msg->memo)) {
+    if (!confirm(ButtonRequestType_ButtonRequest_ConfirmMemo, "Memo", "%s",
+                 msg->memo)) {
       memzero(node, sizeof(*node));
       fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
       layoutHome();

--- a/lib/firmware/hive.c
+++ b/lib/firmware/hive.c
@@ -66,7 +66,7 @@ bool hive_getPublicKeys(const HDNode* root, uint32_t account_index,
       HIVE_ROLE_POSTING,
   };
   char* outs[4] = {owner_out, active_out, memo_out, posting_out};
-  size_t lens[4] = {owner_len, active_len, memo_len, posting_len};
+  const size_t lens[4] = {owner_len, active_len, memo_len, posting_len};
 
   uint32_t account_hardened = account_index | 0x80000000u;
 

--- a/lib/firmware/hive.c
+++ b/lib/firmware/hive.c
@@ -34,64 +34,68 @@
  * This matches the EOS encoding (HASHER_RIPEMD checksum), which Hive inherited
  * from the Graphene framework.
  */
-bool hive_getPublicKey(const uint8_t public_key[33], char *out, size_t out_len) {
-    const size_t prefix_len = strlen(HIVE_PUBKEY_PREFIX);
-    if (out_len < prefix_len + 1) {
-        return false;
-    }
+bool hive_getPublicKey(const uint8_t public_key[33], char* out,
+                       size_t out_len) {
+  const size_t prefix_len = strlen(HIVE_PUBKEY_PREFIX);
+  if (out_len < prefix_len + 1) {
+    return false;
+  }
 
-    strlcpy(out, HIVE_PUBKEY_PREFIX, out_len);
+  strlcpy(out, HIVE_PUBKEY_PREFIX, out_len);
 
-    if (!base58_encode_check(public_key, 33, HASHER_RIPEMD,
-                             out + prefix_len, out_len - prefix_len)) {
-        return false;
-    }
+  if (!base58_encode_check(public_key, 33, HASHER_RIPEMD, out + prefix_len,
+                           out_len - prefix_len)) {
+    return false;
+  }
 
-    return true;
+  return true;
 }
 
 // ---- Graphene binary serialization helpers ----
 
-static void append_u8(uint8_t **buf, const uint8_t *end, uint8_t v) {
-    if (*buf < end) { **buf = v; (*buf)++; }
+static void append_u8(uint8_t** buf, const uint8_t* end, uint8_t v) {
+  if (*buf < end) {
+    **buf = v;
+    (*buf)++;
+  }
 }
 
-static void append_u16_le(uint8_t **buf, const uint8_t *end, uint16_t v) {
+static void append_u16_le(uint8_t** buf, const uint8_t* end, uint16_t v) {
+  append_u8(buf, end, v & 0xFF);
+  append_u8(buf, end, (v >> 8) & 0xFF);
+}
+
+static void append_u32_le(uint8_t** buf, const uint8_t* end, uint32_t v) {
+  append_u8(buf, end, v & 0xFF);
+  append_u8(buf, end, (v >> 8) & 0xFF);
+  append_u8(buf, end, (v >> 16) & 0xFF);
+  append_u8(buf, end, (v >> 24) & 0xFF);
+}
+
+static void append_u64_le(uint8_t** buf, const uint8_t* end, uint64_t v) {
+  for (int i = 0; i < 8; i++) {
     append_u8(buf, end, v & 0xFF);
-    append_u8(buf, end, (v >> 8) & 0xFF);
-}
-
-static void append_u32_le(uint8_t **buf, const uint8_t *end, uint32_t v) {
-    append_u8(buf, end, v & 0xFF);
-    append_u8(buf, end, (v >> 8) & 0xFF);
-    append_u8(buf, end, (v >> 16) & 0xFF);
-    append_u8(buf, end, (v >> 24) & 0xFF);
-}
-
-static void append_u64_le(uint8_t **buf, const uint8_t *end, uint64_t v) {
-    for (int i = 0; i < 8; i++) {
-        append_u8(buf, end, v & 0xFF);
-        v >>= 8;
-    }
+    v >>= 8;
+  }
 }
 
 // Graphene varint (uleb128)
-static void append_varint(uint8_t **buf, const uint8_t *end, uint64_t v) {
-    do {
-        uint8_t b = v & 0x7F;
-        v >>= 7;
-        if (v) b |= 0x80;
-        append_u8(buf, end, b);
-    } while (v);
+static void append_varint(uint8_t** buf, const uint8_t* end, uint64_t v) {
+  do {
+    uint8_t b = v & 0x7F;
+    v >>= 7;
+    if (v) b |= 0x80;
+    append_u8(buf, end, b);
+  } while (v);
 }
 
 // Length-prefixed string (varint length + bytes, no null terminator)
-static void append_string(uint8_t **buf, const uint8_t *end, const char *s) {
-    size_t len = s ? strlen(s) : 0;
-    append_varint(buf, end, len);
-    for (size_t i = 0; i < len && *buf < end; i++) {
-        append_u8(buf, end, (uint8_t)s[i]);
-    }
+static void append_string(uint8_t** buf, const uint8_t* end, const char* s) {
+  size_t len = s ? strlen(s) : 0;
+  append_varint(buf, end, len);
+  for (size_t i = 0; i < len && *buf < end; i++) {
+    append_u8(buf, end, (uint8_t)s[i]);
+  }
 }
 
 /*
@@ -109,84 +113,88 @@ static void append_string(uint8_t **buf, const uint8_t *end, const char *s) {
  *   memo            (string)
  *   num_extensions  (varint, = 0)
  */
-static size_t hive_serialize_tx(const HiveSignTx *msg, uint8_t *buf, size_t buf_len) {
-    uint8_t *p = buf;
-    const uint8_t *end = buf + buf_len;
+static size_t hive_serialize_tx(const HiveSignTx* msg, uint8_t* buf,
+                                size_t buf_len) {
+  uint8_t* p = buf;
+  const uint8_t* end = buf + buf_len;
 
-    append_u16_le(&p, end, (uint16_t)(msg->ref_block_num & 0xFFFF));
-    append_u32_le(&p, end, msg->ref_block_prefix);
-    append_u32_le(&p, end, msg->expiration);
+  append_u16_le(&p, end, (uint16_t)(msg->ref_block_num & 0xFFFF));
+  append_u32_le(&p, end, msg->ref_block_prefix);
+  append_u32_le(&p, end, msg->expiration);
 
-    // 1 operation
-    append_varint(&p, end, 1);
-    // transfer op type = 2
-    append_varint(&p, end, HIVE_OP_TRANSFER);
+  // 1 operation
+  append_varint(&p, end, 1);
+  // transfer op type = 2
+  append_varint(&p, end, HIVE_OP_TRANSFER);
 
-    append_string(&p, end, msg->has_from ? msg->from : "");
-    append_string(&p, end, msg->has_to ? msg->to : "");
+  append_string(&p, end, msg->has_from ? msg->from : "");
+  append_string(&p, end, msg->has_to ? msg->to : "");
 
-    // Asset: int64 amount + uint8 precision + 7-byte symbol (null-padded)
-    append_u64_le(&p, end, (uint64_t)msg->amount);
-    append_u8(&p, end, (uint8_t)(msg->has_decimals ? msg->decimals : HIVE_DECIMALS));
-    char sym[7] = {0};
-    if (msg->has_asset_symbol) {
-        strncpy(sym, msg->asset_symbol, sizeof(sym) - 1);
-    } else {
-        memcpy(sym, "HIVE", 4);
-    }
-    for (int i = 0; i < 7 && p < end; i++) {
-        append_u8(&p, end, (uint8_t)sym[i]);
-    }
+  // Asset: int64 amount + uint8 precision + 7-byte symbol (null-padded)
+  append_u64_le(&p, end, (uint64_t)msg->amount);
+  append_u8(&p, end,
+            (uint8_t)(msg->has_decimals ? msg->decimals : HIVE_DECIMALS));
+  char sym[7] = {0};
+  if (msg->has_asset_symbol) {
+    strncpy(sym, msg->asset_symbol, sizeof(sym) - 1);
+  } else {
+    memcpy(sym, "HIVE", 4);
+  }
+  for (int i = 0; i < 7 && p < end; i++) {
+    append_u8(&p, end, (uint8_t)sym[i]);
+  }
 
-    // Memo
-    append_string(&p, end, msg->has_memo ? msg->memo : "");
+  // Memo
+  append_string(&p, end, msg->has_memo ? msg->memo : "");
 
-    // 0 extensions
-    append_varint(&p, end, 0);
+  // 0 extensions
+  append_varint(&p, end, 0);
 
-    return (size_t)(p - buf);
+  return (size_t)(p - buf);
 }
 
-void hive_signTx(const HDNode *node, const HiveSignTx *msg, HiveSignedTx *resp) {
-    // Serialize transaction body
-    uint8_t tx_buf[512];
-    size_t tx_len = hive_serialize_tx(msg, tx_buf, sizeof(tx_buf));
+void hive_signTx(const HDNode* node, const HiveSignTx* msg,
+                 HiveSignedTx* resp) {
+  // Serialize transaction body
+  uint8_t tx_buf[512];
+  size_t tx_len = hive_serialize_tx(msg, tx_buf, sizeof(tx_buf));
 
-    // Determine chain ID (use mainnet default if not provided)
-    const uint8_t *chain_id;
-    uint8_t default_chain_id[32] = HIVE_CHAIN_ID;
-    if (msg->has_chain_id && msg->chain_id.size == HIVE_CHAIN_ID_LEN) {
-        chain_id = msg->chain_id.bytes;
-    } else {
-        chain_id = default_chain_id;
-    }
+  // Determine chain ID (use mainnet default if not provided)
+  const uint8_t* chain_id;
+  uint8_t default_chain_id[32] = HIVE_CHAIN_ID;
+  if (msg->has_chain_id && msg->chain_id.size == HIVE_CHAIN_ID_LEN) {
+    chain_id = msg->chain_id.bytes;
+  } else {
+    chain_id = default_chain_id;
+  }
 
-    // Digest = SHA256(chain_id || serialized_tx)
-    SHA256_CTX sha_ctx;
-    sha256_Init(&sha_ctx);
-    sha256_Update(&sha_ctx, chain_id, HIVE_CHAIN_ID_LEN);
-    sha256_Update(&sha_ctx, tx_buf, tx_len);
-    uint8_t digest[32];
-    sha256_Final(&sha_ctx, digest);
+  // Digest = SHA256(chain_id || serialized_tx)
+  SHA256_CTX sha_ctx;
+  sha256_Init(&sha_ctx);
+  sha256_Update(&sha_ctx, chain_id, HIVE_CHAIN_ID_LEN);
+  sha256_Update(&sha_ctx, tx_buf, tx_len);
+  uint8_t digest[32];
+  sha256_Final(&sha_ctx, digest);
 
-    // Sign with secp256k1 (recoverable signature)
-    uint8_t sig[65];
-    uint8_t pby;
-    if (ecdsa_sign_digest(&secp256k1, node->private_key, digest, sig + 1, &pby, NULL) != 0) {
-        memzero(sig, sizeof(sig));
-        return;
-    }
-    sig[0] = 27 + pby + 4;  // compact signature header byte (compressed key)
-
-    // Fill response
-    resp->has_signature = true;
-    resp->signature.size = 65;
-    memcpy(resp->signature.bytes, sig, 65);
-
-    resp->has_serialized_tx = true;
-    resp->serialized_tx.size = tx_len;
-    memcpy(resp->serialized_tx.bytes, tx_buf, tx_len);
-
+  // Sign with secp256k1 (recoverable signature)
+  uint8_t sig[65];
+  uint8_t pby;
+  if (ecdsa_sign_digest(&secp256k1, node->private_key, digest, sig + 1, &pby,
+                        NULL) != 0) {
     memzero(sig, sizeof(sig));
-    memzero(digest, sizeof(digest));
+    return;
+  }
+  sig[0] = 27 + pby + 4;  // compact signature header byte (compressed key)
+
+  // Fill response
+  resp->has_signature = true;
+  resp->signature.size = 65;
+  memcpy(resp->signature.bytes, sig, 65);
+
+  resp->has_serialized_tx = true;
+  resp->serialized_tx.size = tx_len;
+  memcpy(resp->serialized_tx.bytes, tx_buf, tx_len);
+
+  memzero(sig, sizeof(sig));
+  memzero(digest, sizeof(digest));
 }

--- a/lib/firmware/hive.c
+++ b/lib/firmware/hive.c
@@ -7,14 +7,6 @@
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include "keepkey/firmware/hive.h"
@@ -27,60 +19,79 @@
 #include <string.h>
 #include <stdint.h>
 
-/*
- * Encode a compressed public key in Hive/Steem format:
- *   "STM" + base58check_ripemd(pubkey_33)
- *
- * This matches the EOS encoding (HASHER_RIPEMD checksum), which Hive inherited
- * from the Graphene framework.
- */
-bool hive_getPublicKey(const uint8_t public_key[33], char* out,
-                       size_t out_len) {
+// ── STM public key encoding ───────────────────────────────────────────────
+
+bool hive_getPublicKey(const uint8_t public_key[33], char *out, size_t out_len) {
   const size_t prefix_len = strlen(HIVE_PUBKEY_PREFIX);
-  if (out_len < prefix_len + 1) {
-    return false;
-  }
-
+  if (out_len < prefix_len + 1) return false;
   strlcpy(out, HIVE_PUBKEY_PREFIX, out_len);
+  // Graphene uses RIPEMD checksum (not SHA256d) for public key encoding
+  return base58_encode_check(public_key, 33, HASHER_RIPEMD,
+                             out + prefix_len, out_len - prefix_len);
+}
 
-  if (!base58_encode_check(public_key, 33, HASHER_RIPEMD, out + prefix_len,
-                           out_len - prefix_len)) {
+// ── SLIP-0048 multi-role key derivation ───────────────────────────────────
+
+bool hive_getPublicKeys(const HDNode *root, uint32_t account_index,
+                        char *owner_out,   size_t owner_len,
+                        char *active_out,  size_t active_len,
+                        char *memo_out,    size_t memo_len,
+                        char *posting_out, size_t posting_len) {
+  const uint32_t roles[4] = {
+    HIVE_ROLE_OWNER,
+    HIVE_ROLE_ACTIVE,
+    HIVE_ROLE_MEMO,
+    HIVE_ROLE_POSTING,
+  };
+  char *outs[4] = { owner_out, active_out, memo_out, posting_out };
+  size_t lens[4] = { owner_len, active_len, memo_len, posting_len };
+
+  for (int i = 0; i < 4; i++) {
+    HDNode node;
+    memcpy(&node, root, sizeof(HDNode));
+
+    // m/48'/13'/role'/account_index'/0'
+    if (hdnode_private_ckd(&node, HIVE_SLIP48_PURPOSE) != 0) goto fail;
+    if (hdnode_private_ckd(&node, HIVE_SLIP48_NETWORK)  != 0) goto fail;
+    if (hdnode_private_ckd(&node, roles[i])              != 0) goto fail;
+    if (hdnode_private_ckd(&node, account_index | 0x80000000u) != 0) goto fail;
+    if (hdnode_private_ckd(&node, 0x80000000u)           != 0) goto fail;
+
+    hdnode_fill_public_key(&node);
+    if (!hive_getPublicKey(node.public_key, outs[i], lens[i])) goto fail;
+    memzero(&node, sizeof(node));
+    continue;
+
+  fail:
+    memzero(&node, sizeof(node));
     return false;
   }
-
   return true;
 }
 
-// ---- Graphene binary serialization helpers ----
+// ── Graphene binary serialization helpers ─────────────────────────────────
 
-static void append_u8(uint8_t** buf, const uint8_t* end, uint8_t v) {
-  if (*buf < end) {
-    **buf = v;
-    (*buf)++;
-  }
+static void append_u8(uint8_t **buf, const uint8_t *end, uint8_t v) {
+  if (*buf < end) { **buf = v; (*buf)++; }
 }
 
-static void append_u16_le(uint8_t** buf, const uint8_t* end, uint16_t v) {
+static void append_u16_le(uint8_t **buf, const uint8_t *end, uint16_t v) {
   append_u8(buf, end, v & 0xFF);
   append_u8(buf, end, (v >> 8) & 0xFF);
 }
 
-static void append_u32_le(uint8_t** buf, const uint8_t* end, uint32_t v) {
+static void append_u32_le(uint8_t **buf, const uint8_t *end, uint32_t v) {
   append_u8(buf, end, v & 0xFF);
   append_u8(buf, end, (v >> 8) & 0xFF);
   append_u8(buf, end, (v >> 16) & 0xFF);
   append_u8(buf, end, (v >> 24) & 0xFF);
 }
 
-static void append_u64_le(uint8_t** buf, const uint8_t* end, uint64_t v) {
-  for (int i = 0; i < 8; i++) {
-    append_u8(buf, end, v & 0xFF);
-    v >>= 8;
-  }
+static void append_u64_le(uint8_t **buf, const uint8_t *end, uint64_t v) {
+  for (int i = 0; i < 8; i++) { append_u8(buf, end, v & 0xFF); v >>= 8; }
 }
 
-// Graphene varint (uleb128)
-static void append_varint(uint8_t** buf, const uint8_t* end, uint64_t v) {
+static void append_varint(uint8_t **buf, const uint8_t *end, uint64_t v) {
   do {
     uint8_t b = v & 0x7F;
     v >>= 7;
@@ -89,104 +100,134 @@ static void append_varint(uint8_t** buf, const uint8_t* end, uint64_t v) {
   } while (v);
 }
 
-// Length-prefixed string (varint length + bytes, no null terminator)
-static void append_string(uint8_t** buf, const uint8_t* end, const char* s) {
+static void append_string(uint8_t **buf, const uint8_t *end, const char *s) {
   size_t len = s ? strlen(s) : 0;
   append_varint(buf, end, len);
-  for (size_t i = 0; i < len && *buf < end; i++) {
+  for (size_t i = 0; i < len && *buf < end; i++)
     append_u8(buf, end, (uint8_t)s[i]);
-  }
 }
 
 /*
- * Serialize a Hive transfer operation (op type 2) in Graphene binary format.
- *
- * Transaction wire format:
- *   ref_block_num   (uint16 LE)
- *   ref_block_prefix (uint32 LE)
- *   expiration      (uint32 LE)
- *   num_ops         (varint, = 1)
- *   op_type         (varint, = 2 for transfer)
- *   from            (string)
- *   to              (string)
- *   amount          (int64 LE) + precision (uint8) + symbol (7 bytes, padded)
- *   memo            (string)
- *   num_extensions  (varint, = 0)
+ * Graphene asset encoding: int64 LE amount + uint8 precision + 7-byte symbol
+ * The symbol field is null-padded to exactly 7 bytes.
  */
-static size_t hive_serialize_tx(const HiveSignTx* msg, uint8_t* buf,
-                                size_t buf_len) {
-  uint8_t* p = buf;
-  const uint8_t* end = buf + buf_len;
+static void append_asset(uint8_t **buf, const uint8_t *end,
+                         uint64_t amount, uint8_t precision, const char *symbol) {
+  append_u64_le(buf, end, amount);
+  append_u8(buf, end, precision);
+  char sym[7] = {0};
+  if (symbol) strncpy(sym, symbol, 6);
+  for (int i = 0; i < 7 && *buf < end; i++)
+    append_u8(buf, end, (uint8_t)sym[i]);
+}
 
-  append_u16_le(&p, end, (uint16_t)(msg->ref_block_num & 0xFFFF));
-  append_u32_le(&p, end, msg->ref_block_prefix);
-  append_u32_le(&p, end, msg->expiration);
+/*
+ * Graphene authority structure:
+ *   weight_threshold (uint32 LE) = 1
+ *   num_account_auths (varint)   = 0
+ *   num_key_auths (varint)       = 1
+ *     public_key (33 bytes compressed)
+ *     weight (uint16 LE)         = 1
+ *
+ * The public key must be provided as 33 raw bytes (not STM-encoded).
+ */
+static void append_authority(uint8_t **buf, const uint8_t *end,
+                             const uint8_t pubkey[33]) {
+  append_u32_le(buf, end, 1);  // weight_threshold = 1
+  append_varint(buf, end, 0);  // 0 account auths
+  append_varint(buf, end, 1);  // 1 key auth
+  // Key type prefix: 0x00 = secp256k1 (Graphene convention, 1 byte)
+  append_u8(buf, end, 0x00);
+  for (int i = 0; i < 33 && *buf < end; i++)
+    append_u8(buf, end, pubkey[i]);
+  append_u16_le(buf, end, 1);  // weight = 1
+}
 
-  // 1 operation
-  append_varint(&p, end, 1);
-  // transfer op type = 2
-  append_varint(&p, end, HIVE_OP_TRANSFER);
+/*
+ * Common transaction header: ref_block_num, ref_block_prefix, expiration,
+ * then a varint op count = 1, then the op type varint.
+ */
+static void append_tx_header(uint8_t **buf, const uint8_t *end,
+                             uint16_t ref_block_num, uint32_t ref_block_prefix,
+                             uint32_t expiration, uint32_t op_type) {
+  append_u16_le(buf, end, ref_block_num);
+  append_u32_le(buf, end, ref_block_prefix);
+  append_u32_le(buf, end, expiration);
+  append_varint(buf, end, 1);         // 1 operation
+  append_varint(buf, end, op_type);
+}
+
+static void append_tx_footer(uint8_t **buf, const uint8_t *end) {
+  append_varint(buf, end, 0);         // 0 extensions
+}
+
+/*
+ * Sign helper: SHA256(chain_id || serialized_tx) → secp256k1 recoverable sig.
+ * Writes 65 bytes into sig[]. Returns true on success.
+ */
+static bool hive_sign_digest(const HDNode *node, const uint8_t *chain_id,
+                             const uint8_t *tx_buf, size_t tx_len,
+                             uint8_t sig[65]) {
+  SHA256_CTX sha;
+  sha256_Init(&sha);
+  sha256_Update(&sha, chain_id, HIVE_CHAIN_ID_LEN);
+  sha256_Update(&sha, tx_buf, tx_len);
+  uint8_t digest[32];
+  sha256_Final(&sha, digest);
+
+  uint8_t pby;
+  if (ecdsa_sign_digest(&secp256k1, node->private_key, digest,
+                        sig + 1, &pby, NULL) != 0) {
+    memzero(digest, sizeof(digest));
+    return false;
+  }
+  // Compact signature header: 27 + recovery_id + 4 (compressed key flag)
+  sig[0] = 27 + pby + 4;
+  memzero(digest, sizeof(digest));
+  return true;
+}
+
+// ── Transfer (op type 2) ──────────────────────────────────────────────────
+
+static size_t hive_serialize_transfer(const HiveSignTx *msg,
+                                      uint8_t *buf, size_t buf_len) {
+  uint8_t *p = buf;
+  const uint8_t *end = buf + buf_len;
+
+  append_tx_header(&p, end,
+                   (uint16_t)(msg->ref_block_num & 0xFFFF),
+                   msg->ref_block_prefix,
+                   msg->expiration,
+                   HIVE_OP_TRANSFER);
 
   append_string(&p, end, msg->has_from ? msg->from : "");
-  append_string(&p, end, msg->has_to ? msg->to : "");
+  append_string(&p, end, msg->has_to   ? msg->to   : "");
 
-  // Asset: int64 amount + uint8 precision + 7-byte symbol (null-padded)
-  append_u64_le(&p, end, (uint64_t)msg->amount);
-  append_u8(&p, end,
-            (uint8_t)(msg->has_decimals ? msg->decimals : HIVE_DECIMALS));
-  char sym[7] = {0};
-  if (msg->has_asset_symbol) {
-    strncpy(sym, msg->asset_symbol, sizeof(sym) - 1);
-  } else {
-    memcpy(sym, "HIVE", 4);
-  }
-  for (int i = 0; i < 7 && p < end; i++) {
-    append_u8(&p, end, (uint8_t)sym[i]);
-  }
+  const char *sym = msg->has_asset_symbol ? msg->asset_symbol : "HIVE";
+  uint8_t prec = (uint8_t)(msg->has_decimals ? msg->decimals : HIVE_DECIMALS);
+  append_asset(&p, end, msg->amount, prec, sym);
 
-  // Memo
   append_string(&p, end, msg->has_memo ? msg->memo : "");
-
-  // 0 extensions
-  append_varint(&p, end, 0);
-
+  append_tx_footer(&p, end);
   return (size_t)(p - buf);
 }
 
-void hive_signTx(const HDNode* node, const HiveSignTx* msg,
-                 HiveSignedTx* resp) {
-  // Serialize transaction body
+void hive_signTx(const HDNode *node, const HiveSignTx *msg, HiveSignedTx *resp) {
   uint8_t tx_buf[512];
-  size_t tx_len = hive_serialize_tx(msg, tx_buf, sizeof(tx_buf));
+  size_t tx_len = hive_serialize_transfer(msg, tx_buf, sizeof(tx_buf));
 
-  // Determine chain ID (use mainnet default if not provided)
-  const uint8_t* chain_id;
-  uint8_t default_chain_id[32] = HIVE_CHAIN_ID;
-  if (msg->has_chain_id && msg->chain_id.size == HIVE_CHAIN_ID_LEN) {
-    chain_id = msg->chain_id.bytes;
-  } else {
-    chain_id = default_chain_id;
-  }
+  const uint8_t default_chain_id[32] = HIVE_CHAIN_ID;
+  const uint8_t *chain_id = (msg->has_chain_id &&
+                              msg->chain_id.size == HIVE_CHAIN_ID_LEN)
+                             ? msg->chain_id.bytes
+                             : default_chain_id;
 
-  // Digest = SHA256(chain_id || serialized_tx)
-  SHA256_CTX sha_ctx;
-  sha256_Init(&sha_ctx);
-  sha256_Update(&sha_ctx, chain_id, HIVE_CHAIN_ID_LEN);
-  sha256_Update(&sha_ctx, tx_buf, tx_len);
-  uint8_t digest[32];
-  sha256_Final(&sha_ctx, digest);
-
-  // Sign with secp256k1 (recoverable signature)
   uint8_t sig[65];
-  uint8_t pby;
-  if (ecdsa_sign_digest(&secp256k1, node->private_key, digest, sig + 1, &pby,
-                        NULL) != 0) {
+  if (!hive_sign_digest(node, chain_id, tx_buf, tx_len, sig)) {
     memzero(sig, sizeof(sig));
     return;
   }
-  sig[0] = 27 + pby + 4;  // compact signature header byte (compressed key)
 
-  // Fill response
   resp->has_signature = true;
   resp->signature.size = 65;
   memcpy(resp->signature.bytes, sig, 65);
@@ -196,5 +237,187 @@ void hive_signTx(const HDNode* node, const HiveSignTx* msg,
   memcpy(resp->serialized_tx.bytes, tx_buf, tx_len);
 
   memzero(sig, sizeof(sig));
-  memzero(digest, sizeof(digest));
+  memzero(tx_buf, tx_len);
+}
+
+// ── Account create (op type 9) ────────────────────────────────────────────
+
+/*
+ * Parse an STM-prefixed base58 public key back to 33 raw bytes.
+ * Strips the "STM" prefix and decodes base58check with RIPEMD checksum.
+ * Returns true on success.
+ */
+static bool parse_stm_pubkey(const char *stm_key, uint8_t out[33]) {
+  if (!stm_key || strncmp(stm_key, HIVE_PUBKEY_PREFIX, 3) != 0) return false;
+  const char *b58 = stm_key + 3;  // skip "STM"
+  int decoded_len = base58_decode_check(b58, HASHER_RIPEMD, out, 33);
+  return decoded_len == 33;
+}
+
+static size_t hive_serialize_account_create(const HiveSignAccountCreate *msg,
+                                             uint8_t *buf, size_t buf_len) {
+  uint8_t *p = buf;
+  const uint8_t *end = buf + buf_len;
+
+  append_tx_header(&p, end,
+                   (uint16_t)(msg->ref_block_num & 0xFFFF),
+                   msg->ref_block_prefix,
+                   msg->expiration,
+                   HIVE_OP_ACCOUNT_CREATE);
+
+  // fee (asset)
+  uint64_t fee = msg->has_fee_amount ? msg->fee_amount : 3000;
+  append_asset(&p, end, fee, HIVE_DECIMALS, "HIVE");
+
+  // creator
+  append_string(&p, end, msg->has_creator ? msg->creator : "");
+
+  // new_account_name
+  append_string(&p, end, msg->has_new_account_name ? msg->new_account_name : "");
+
+  // Parse all four STM public keys to raw bytes
+  uint8_t owner_raw[33] = {0}, active_raw[33] = {0};
+  uint8_t posting_raw[33] = {0}, memo_raw[33] = {0};
+
+  if (msg->has_owner_key)   parse_stm_pubkey(msg->owner_key,   owner_raw);
+  if (msg->has_active_key)  parse_stm_pubkey(msg->active_key,  active_raw);
+  if (msg->has_posting_key) parse_stm_pubkey(msg->posting_key, posting_raw);
+  if (msg->has_memo_key)    parse_stm_pubkey(msg->memo_key,    memo_raw);
+
+  // owner authority
+  append_authority(&p, end, owner_raw);
+  // active authority
+  append_authority(&p, end, active_raw);
+  // posting authority
+  append_authority(&p, end, posting_raw);
+  // memo_key (raw 33 bytes, no authority wrapper — just key type prefix + key)
+  append_u8(&p, end, 0x00);
+  for (int i = 0; i < 33 && p < end; i++) append_u8(&p, end, memo_raw[i]);
+
+  // json_metadata (empty string)
+  append_string(&p, end, "");
+  append_tx_footer(&p, end);
+
+  memzero(owner_raw, sizeof(owner_raw));
+  memzero(active_raw, sizeof(active_raw));
+  memzero(posting_raw, sizeof(posting_raw));
+  memzero(memo_raw, sizeof(memo_raw));
+
+  return (size_t)(p - buf);
+}
+
+void hive_signAccountCreate(const HDNode *node,
+                             const HiveSignAccountCreate *msg,
+                             HiveSignedAccountCreate *resp) {
+  uint8_t tx_buf[512];
+  size_t tx_len = hive_serialize_account_create(msg, tx_buf, sizeof(tx_buf));
+
+  const uint8_t default_chain_id[32] = HIVE_CHAIN_ID;
+  const uint8_t *chain_id = (msg->has_chain_id &&
+                              msg->chain_id.size == HIVE_CHAIN_ID_LEN)
+                             ? msg->chain_id.bytes
+                             : default_chain_id;
+
+  uint8_t sig[65];
+  if (!hive_sign_digest(node, chain_id, tx_buf, tx_len, sig)) {
+    memzero(sig, sizeof(sig));
+    memzero(tx_buf, sizeof(tx_buf));
+    return;
+  }
+
+  resp->has_signature = true;
+  resp->signature.size = 65;
+  memcpy(resp->signature.bytes, sig, 65);
+
+  resp->has_serialized_tx = true;
+  resp->serialized_tx.size = tx_len;
+  memcpy(resp->serialized_tx.bytes, tx_buf, tx_len);
+
+  memzero(sig, sizeof(sig));
+  memzero(tx_buf, tx_len);
+}
+
+// ── Account update (op type 10) ───────────────────────────────────────────
+
+static size_t hive_serialize_account_update(const HiveSignAccountUpdate *msg,
+                                             uint8_t *buf, size_t buf_len) {
+  uint8_t *p = buf;
+  const uint8_t *end = buf + buf_len;
+
+  append_tx_header(&p, end,
+                   (uint16_t)(msg->ref_block_num & 0xFFFF),
+                   msg->ref_block_prefix,
+                   msg->expiration,
+                   HIVE_OP_ACCOUNT_UPDATE);
+
+  // account name
+  append_string(&p, end, msg->has_account ? msg->account : "");
+
+  // Parse all four new public keys
+  uint8_t owner_raw[33] = {0}, active_raw[33] = {0};
+  uint8_t posting_raw[33] = {0}, memo_raw[33] = {0};
+
+  if (msg->has_new_owner_key)   parse_stm_pubkey(msg->new_owner_key,   owner_raw);
+  if (msg->has_new_active_key)  parse_stm_pubkey(msg->new_active_key,  active_raw);
+  if (msg->has_new_posting_key) parse_stm_pubkey(msg->new_posting_key, posting_raw);
+  if (msg->has_new_memo_key)    parse_stm_pubkey(msg->new_memo_key,    memo_raw);
+
+  /*
+   * account_update optional fields use a Graphene "optional" wrapper:
+   *   present: 0x01 + authority bytes
+   *   absent:  0x00
+   * We always include all four — this replaces all authorities.
+   */
+  append_u8(&p, end, 0x01);  // owner present
+  append_authority(&p, end, owner_raw);
+  append_u8(&p, end, 0x01);  // active present
+  append_authority(&p, end, active_raw);
+  append_u8(&p, end, 0x01);  // posting present
+  append_authority(&p, end, posting_raw);
+
+  // memo_key (raw, always present in account_update)
+  append_u8(&p, end, 0x00);
+  for (int i = 0; i < 33 && p < end; i++) append_u8(&p, end, memo_raw[i]);
+
+  // json_metadata (empty)
+  append_string(&p, end, "");
+  append_tx_footer(&p, end);
+
+  memzero(owner_raw, sizeof(owner_raw));
+  memzero(active_raw, sizeof(active_raw));
+  memzero(posting_raw, sizeof(posting_raw));
+  memzero(memo_raw, sizeof(memo_raw));
+
+  return (size_t)(p - buf);
+}
+
+void hive_signAccountUpdate(const HDNode *node,
+                             const HiveSignAccountUpdate *msg,
+                             HiveSignedAccountUpdate *resp) {
+  uint8_t tx_buf[512];
+  size_t tx_len = hive_serialize_account_update(msg, tx_buf, sizeof(tx_buf));
+
+  const uint8_t default_chain_id[32] = HIVE_CHAIN_ID;
+  const uint8_t *chain_id = (msg->has_chain_id &&
+                              msg->chain_id.size == HIVE_CHAIN_ID_LEN)
+                             ? msg->chain_id.bytes
+                             : default_chain_id;
+
+  uint8_t sig[65];
+  if (!hive_sign_digest(node, chain_id, tx_buf, tx_len, sig)) {
+    memzero(sig, sizeof(sig));
+    memzero(tx_buf, sizeof(tx_buf));
+    return;
+  }
+
+  resp->has_signature = true;
+  resp->signature.size = 65;
+  memcpy(resp->signature.bytes, sig, 65);
+
+  resp->has_serialized_tx = true;
+  resp->serialized_tx.size = tx_len;
+  memcpy(resp->serialized_tx.bytes, tx_buf, tx_len);
+
+  memzero(sig, sizeof(sig));
+  memzero(tx_buf, tx_len);
 }

--- a/lib/firmware/hive.c
+++ b/lib/firmware/hive.c
@@ -30,6 +30,28 @@ bool hive_getPublicKey(const uint8_t public_key[33], char *out, size_t out_len) 
                              out + prefix_len, out_len - prefix_len);
 }
 
+// ── Single-role key derivation to raw 33 bytes ────────────────────────────
+// Path: m/48'/13'/role_hardened/account_index_hardened/0'
+// hdnode_private_ckd() returns 1 on success, 0 on failure.
+
+bool hive_deriveRawKey(const HDNode *root, uint32_t role_hardened,
+                       uint32_t account_index_hardened, uint8_t out[33]) {
+  HDNode node;
+  memcpy(&node, root, sizeof(HDNode));
+  if (!hdnode_private_ckd(&node, HIVE_SLIP48_PURPOSE))     goto fail;
+  if (!hdnode_private_ckd(&node, HIVE_SLIP48_NETWORK))     goto fail;
+  if (!hdnode_private_ckd(&node, role_hardened))            goto fail;
+  if (!hdnode_private_ckd(&node, account_index_hardened))  goto fail;
+  if (!hdnode_private_ckd(&node, 0x80000000u))              goto fail;
+  hdnode_fill_public_key(&node);
+  memcpy(out, node.public_key, 33);
+  memzero(&node, sizeof(node));
+  return true;
+fail:
+  memzero(&node, sizeof(node));
+  return false;
+}
+
 // ── SLIP-0048 multi-role key derivation ───────────────────────────────────
 
 bool hive_getPublicKeys(const HDNode *root, uint32_t account_index,
@@ -38,33 +60,21 @@ bool hive_getPublicKeys(const HDNode *root, uint32_t account_index,
                         char *memo_out,    size_t memo_len,
                         char *posting_out, size_t posting_len) {
   const uint32_t roles[4] = {
-    HIVE_ROLE_OWNER,
-    HIVE_ROLE_ACTIVE,
-    HIVE_ROLE_MEMO,
-    HIVE_ROLE_POSTING,
+    HIVE_ROLE_OWNER, HIVE_ROLE_ACTIVE, HIVE_ROLE_MEMO, HIVE_ROLE_POSTING,
   };
   char *outs[4] = { owner_out, active_out, memo_out, posting_out };
   size_t lens[4] = { owner_len, active_len, memo_len, posting_len };
 
+  uint32_t account_hardened = account_index | 0x80000000u;
+
   for (int i = 0; i < 4; i++) {
-    HDNode node;
-    memcpy(&node, root, sizeof(HDNode));
-
-    // m/48'/13'/role'/account_index'/0'
-    if (hdnode_private_ckd(&node, HIVE_SLIP48_PURPOSE) != 0) goto fail;
-    if (hdnode_private_ckd(&node, HIVE_SLIP48_NETWORK)  != 0) goto fail;
-    if (hdnode_private_ckd(&node, roles[i])              != 0) goto fail;
-    if (hdnode_private_ckd(&node, account_index | 0x80000000u) != 0) goto fail;
-    if (hdnode_private_ckd(&node, 0x80000000u)           != 0) goto fail;
-
-    hdnode_fill_public_key(&node);
-    if (!hive_getPublicKey(node.public_key, outs[i], lens[i])) goto fail;
-    memzero(&node, sizeof(node));
-    continue;
-
-  fail:
-    memzero(&node, sizeof(node));
-    return false;
+    uint8_t raw[33];
+    if (!hive_deriveRawKey(root, roles[i], account_hardened, raw)) return false;
+    if (!hive_getPublicKey(raw, outs[i], lens[i])) {
+      memzero(raw, sizeof(raw));
+      return false;
+    }
+    memzero(raw, sizeof(raw));
   }
   return true;
 }
@@ -109,7 +119,6 @@ static void append_string(uint8_t **buf, const uint8_t *end, const char *s) {
 
 /*
  * Graphene asset encoding: int64 LE amount + uint8 precision + 7-byte symbol
- * The symbol field is null-padded to exactly 7 bytes.
  */
 static void append_asset(uint8_t **buf, const uint8_t *end,
                          uint64_t amount, uint8_t precision, const char *symbol) {
@@ -122,22 +131,20 @@ static void append_asset(uint8_t **buf, const uint8_t *end,
 }
 
 /*
- * Graphene authority structure:
+ * Graphene authority structure (Hive wire format):
  *   weight_threshold (uint32 LE) = 1
  *   num_account_auths (varint)   = 0
  *   num_key_auths (varint)       = 1
- *     public_key (33 bytes compressed)
+ *     compressed public key      (33 bytes, no type prefix)
  *     weight (uint16 LE)         = 1
  *
- * The public key must be provided as 33 raw bytes (not STM-encoded).
+ * Note: Hive does NOT use a key-type prefix byte before the 33 raw bytes.
  */
 static void append_authority(uint8_t **buf, const uint8_t *end,
                              const uint8_t pubkey[33]) {
   append_u32_le(buf, end, 1);  // weight_threshold = 1
   append_varint(buf, end, 0);  // 0 account auths
   append_varint(buf, end, 1);  // 1 key auth
-  // Key type prefix: 0x00 = secp256k1 (Graphene convention, 1 byte)
-  append_u8(buf, end, 0x00);
   for (int i = 0; i < 33 && *buf < end; i++)
     append_u8(buf, end, pubkey[i]);
   append_u16_le(buf, end, 1);  // weight = 1
@@ -189,6 +196,11 @@ static bool hive_sign_digest(const HDNode *node, const uint8_t *chain_id,
 
 // ── Transfer (op type 2) ──────────────────────────────────────────────────
 
+// Maximum memo length that fits safely in tx_buf[512] with all other fields.
+// Non-memo overhead: header(12) + from(17) + to(17) + asset(16) + footer(1) = ~63 bytes.
+// 512 - 63 - 3 (varint) = 446; use 440 as the conservative limit.
+#define HIVE_MAX_MEMO_LEN 440
+
 static size_t hive_serialize_transfer(const HiveSignTx *msg,
                                       uint8_t *buf, size_t buf_len) {
   uint8_t *p = buf;
@@ -213,6 +225,9 @@ static size_t hive_serialize_transfer(const HiveSignTx *msg,
 }
 
 void hive_signTx(const HDNode *node, const HiveSignTx *msg, HiveSignedTx *resp) {
+  // Reject memos that would overflow the fixed-size tx_buf.
+  if (msg->has_memo && strlen(msg->memo) > HIVE_MAX_MEMO_LEN) return;
+
   uint8_t tx_buf[512];
   size_t tx_len = hive_serialize_transfer(msg, tx_buf, sizeof(tx_buf));
 
@@ -241,20 +256,16 @@ void hive_signTx(const HDNode *node, const HiveSignTx *msg, HiveSignedTx *resp) 
 }
 
 // ── Account create (op type 9) ────────────────────────────────────────────
-
-/*
- * Parse an STM-prefixed base58 public key back to 33 raw bytes.
- * Strips the "STM" prefix and decodes base58check with RIPEMD checksum.
- * Returns true on success.
- */
-static bool parse_stm_pubkey(const char *stm_key, uint8_t out[33]) {
-  if (!stm_key || strncmp(stm_key, HIVE_PUBKEY_PREFIX, 3) != 0) return false;
-  const char *b58 = stm_key + 3;  // skip "STM"
-  int decoded_len = base58_decode_check(b58, HASHER_RIPEMD, out, 33);
-  return decoded_len == 33;
-}
+//
+// All four role keys are device-derived by the caller (FSM handler) and
+// passed as raw 33-byte compressed public keys. The firmware never uses
+// host-supplied key strings for the actual transaction.
 
 static size_t hive_serialize_account_create(const HiveSignAccountCreate *msg,
+                                             const uint8_t owner_raw[33],
+                                             const uint8_t active_raw[33],
+                                             const uint8_t posting_raw[33],
+                                             const uint8_t memo_raw[33],
                                              uint8_t *buf, size_t buf_len) {
   uint8_t *p = buf;
   const uint8_t *end = buf + buf_len;
@@ -275,42 +286,33 @@ static size_t hive_serialize_account_create(const HiveSignAccountCreate *msg,
   // new_account_name
   append_string(&p, end, msg->has_new_account_name ? msg->new_account_name : "");
 
-  // Parse all four STM public keys to raw bytes
-  uint8_t owner_raw[33] = {0}, active_raw[33] = {0};
-  uint8_t posting_raw[33] = {0}, memo_raw[33] = {0};
-
-  if (msg->has_owner_key)   parse_stm_pubkey(msg->owner_key,   owner_raw);
-  if (msg->has_active_key)  parse_stm_pubkey(msg->active_key,  active_raw);
-  if (msg->has_posting_key) parse_stm_pubkey(msg->posting_key, posting_raw);
-  if (msg->has_memo_key)    parse_stm_pubkey(msg->memo_key,    memo_raw);
-
-  // owner authority
+  // authority fields use device-derived raw bytes (no host trust, no type prefix)
   append_authority(&p, end, owner_raw);
-  // active authority
   append_authority(&p, end, active_raw);
-  // posting authority
   append_authority(&p, end, posting_raw);
-  // memo_key (raw 33 bytes, no authority wrapper — just key type prefix + key)
-  append_u8(&p, end, 0x00);
+
+  // memo_key: 33 raw bytes, no authority wrapper, no type prefix byte
   for (int i = 0; i < 33 && p < end; i++) append_u8(&p, end, memo_raw[i]);
 
-  // json_metadata (empty string)
+  // json_metadata (empty)
   append_string(&p, end, "");
   append_tx_footer(&p, end);
-
-  memzero(owner_raw, sizeof(owner_raw));
-  memzero(active_raw, sizeof(active_raw));
-  memzero(posting_raw, sizeof(posting_raw));
-  memzero(memo_raw, sizeof(memo_raw));
 
   return (size_t)(p - buf);
 }
 
-void hive_signAccountCreate(const HDNode *node,
-                             const HiveSignAccountCreate *msg,
-                             HiveSignedAccountCreate *resp) {
+void hive_signAccountCreate(const HDNode *signing_node,
+                            const HiveSignAccountCreate *msg,
+                            const uint8_t owner_raw[33],
+                            const uint8_t active_raw[33],
+                            const uint8_t posting_raw[33],
+                            const uint8_t memo_raw[33],
+                            HiveSignedAccountCreate *resp) {
   uint8_t tx_buf[512];
-  size_t tx_len = hive_serialize_account_create(msg, tx_buf, sizeof(tx_buf));
+  size_t tx_len = hive_serialize_account_create(msg,
+                                                 owner_raw, active_raw,
+                                                 posting_raw, memo_raw,
+                                                 tx_buf, sizeof(tx_buf));
 
   const uint8_t default_chain_id[32] = HIVE_CHAIN_ID;
   const uint8_t *chain_id = (msg->has_chain_id &&
@@ -319,7 +321,7 @@ void hive_signAccountCreate(const HDNode *node,
                              : default_chain_id;
 
   uint8_t sig[65];
-  if (!hive_sign_digest(node, chain_id, tx_buf, tx_len, sig)) {
+  if (!hive_sign_digest(signing_node, chain_id, tx_buf, tx_len, sig)) {
     memzero(sig, sizeof(sig));
     memzero(tx_buf, sizeof(tx_buf));
     return;
@@ -338,8 +340,15 @@ void hive_signAccountCreate(const HDNode *node,
 }
 
 // ── Account update (op type 10) ───────────────────────────────────────────
+//
+// All four new role keys are device-derived by the caller (FSM handler).
+// The host-supplied new_*_key fields in the message are not used for signing.
 
 static size_t hive_serialize_account_update(const HiveSignAccountUpdate *msg,
+                                             const uint8_t owner_raw[33],
+                                             const uint8_t active_raw[33],
+                                             const uint8_t posting_raw[33],
+                                             const uint8_t memo_raw[33],
                                              uint8_t *buf, size_t buf_len) {
   uint8_t *p = buf;
   const uint8_t *end = buf + buf_len;
@@ -353,17 +362,8 @@ static size_t hive_serialize_account_update(const HiveSignAccountUpdate *msg,
   // account name
   append_string(&p, end, msg->has_account ? msg->account : "");
 
-  // Parse all four new public keys
-  uint8_t owner_raw[33] = {0}, active_raw[33] = {0};
-  uint8_t posting_raw[33] = {0}, memo_raw[33] = {0};
-
-  if (msg->has_new_owner_key)   parse_stm_pubkey(msg->new_owner_key,   owner_raw);
-  if (msg->has_new_active_key)  parse_stm_pubkey(msg->new_active_key,  active_raw);
-  if (msg->has_new_posting_key) parse_stm_pubkey(msg->new_posting_key, posting_raw);
-  if (msg->has_new_memo_key)    parse_stm_pubkey(msg->new_memo_key,    memo_raw);
-
   /*
-   * account_update optional fields use a Graphene "optional" wrapper:
+   * account_update optional authority fields use a Graphene "optional" wrapper:
    *   present: 0x01 + authority bytes
    *   absent:  0x00
    * We always include all four — this replaces all authorities.
@@ -375,27 +375,28 @@ static size_t hive_serialize_account_update(const HiveSignAccountUpdate *msg,
   append_u8(&p, end, 0x01);  // posting present
   append_authority(&p, end, posting_raw);
 
-  // memo_key (raw, always present in account_update)
-  append_u8(&p, end, 0x00);
+  // memo_key: 33 raw bytes, always present, no type prefix byte
   for (int i = 0; i < 33 && p < end; i++) append_u8(&p, end, memo_raw[i]);
 
   // json_metadata (empty)
   append_string(&p, end, "");
   append_tx_footer(&p, end);
 
-  memzero(owner_raw, sizeof(owner_raw));
-  memzero(active_raw, sizeof(active_raw));
-  memzero(posting_raw, sizeof(posting_raw));
-  memzero(memo_raw, sizeof(memo_raw));
-
   return (size_t)(p - buf);
 }
 
-void hive_signAccountUpdate(const HDNode *node,
-                             const HiveSignAccountUpdate *msg,
-                             HiveSignedAccountUpdate *resp) {
+void hive_signAccountUpdate(const HDNode *signing_node,
+                            const HiveSignAccountUpdate *msg,
+                            const uint8_t owner_raw[33],
+                            const uint8_t active_raw[33],
+                            const uint8_t posting_raw[33],
+                            const uint8_t memo_raw[33],
+                            HiveSignedAccountUpdate *resp) {
   uint8_t tx_buf[512];
-  size_t tx_len = hive_serialize_account_update(msg, tx_buf, sizeof(tx_buf));
+  size_t tx_len = hive_serialize_account_update(msg,
+                                                 owner_raw, active_raw,
+                                                 posting_raw, memo_raw,
+                                                 tx_buf, sizeof(tx_buf));
 
   const uint8_t default_chain_id[32] = HIVE_CHAIN_ID;
   const uint8_t *chain_id = (msg->has_chain_id &&
@@ -404,7 +405,7 @@ void hive_signAccountUpdate(const HDNode *node,
                              : default_chain_id;
 
   uint8_t sig[65];
-  if (!hive_sign_digest(node, chain_id, tx_buf, tx_len, sig)) {
+  if (!hive_sign_digest(signing_node, chain_id, tx_buf, tx_len, sig)) {
     memzero(sig, sizeof(sig));
     memzero(tx_buf, sizeof(tx_buf));
     return;

--- a/lib/firmware/hive.c
+++ b/lib/firmware/hive.c
@@ -21,28 +21,29 @@
 
 // ── STM public key encoding ───────────────────────────────────────────────
 
-bool hive_getPublicKey(const uint8_t public_key[33], char *out, size_t out_len) {
+bool hive_getPublicKey(const uint8_t public_key[33], char* out,
+                       size_t out_len) {
   const size_t prefix_len = strlen(HIVE_PUBKEY_PREFIX);
   if (out_len < prefix_len + 1) return false;
   strlcpy(out, HIVE_PUBKEY_PREFIX, out_len);
   // Graphene uses RIPEMD checksum (not SHA256d) for public key encoding
-  return base58_encode_check(public_key, 33, HASHER_RIPEMD,
-                             out + prefix_len, out_len - prefix_len);
+  return base58_encode_check(public_key, 33, HASHER_RIPEMD, out + prefix_len,
+                             out_len - prefix_len);
 }
 
 // ── Single-role key derivation to raw 33 bytes ────────────────────────────
 // Path: m/48'/13'/role_hardened/account_index_hardened/0'
 // hdnode_private_ckd() returns 1 on success, 0 on failure.
 
-bool hive_deriveRawKey(const HDNode *root, uint32_t role_hardened,
+bool hive_deriveRawKey(const HDNode* root, uint32_t role_hardened,
                        uint32_t account_index_hardened, uint8_t out[33]) {
   HDNode node;
   memcpy(&node, root, sizeof(HDNode));
-  if (!hdnode_private_ckd(&node, HIVE_SLIP48_PURPOSE))     goto fail;
-  if (!hdnode_private_ckd(&node, HIVE_SLIP48_NETWORK))     goto fail;
-  if (!hdnode_private_ckd(&node, role_hardened))            goto fail;
-  if (!hdnode_private_ckd(&node, account_index_hardened))  goto fail;
-  if (!hdnode_private_ckd(&node, 0x80000000u))              goto fail;
+  if (!hdnode_private_ckd(&node, HIVE_SLIP48_PURPOSE)) goto fail;
+  if (!hdnode_private_ckd(&node, HIVE_SLIP48_NETWORK)) goto fail;
+  if (!hdnode_private_ckd(&node, role_hardened)) goto fail;
+  if (!hdnode_private_ckd(&node, account_index_hardened)) goto fail;
+  if (!hdnode_private_ckd(&node, 0x80000000u)) goto fail;
   hdnode_fill_public_key(&node);
   memcpy(out, node.public_key, 33);
   memzero(&node, sizeof(node));
@@ -54,16 +55,18 @@ fail:
 
 // ── SLIP-0048 multi-role key derivation ───────────────────────────────────
 
-bool hive_getPublicKeys(const HDNode *root, uint32_t account_index,
-                        char *owner_out,   size_t owner_len,
-                        char *active_out,  size_t active_len,
-                        char *memo_out,    size_t memo_len,
-                        char *posting_out, size_t posting_len) {
+bool hive_getPublicKeys(const HDNode* root, uint32_t account_index,
+                        char* owner_out, size_t owner_len, char* active_out,
+                        size_t active_len, char* memo_out, size_t memo_len,
+                        char* posting_out, size_t posting_len) {
   const uint32_t roles[4] = {
-    HIVE_ROLE_OWNER, HIVE_ROLE_ACTIVE, HIVE_ROLE_MEMO, HIVE_ROLE_POSTING,
+      HIVE_ROLE_OWNER,
+      HIVE_ROLE_ACTIVE,
+      HIVE_ROLE_MEMO,
+      HIVE_ROLE_POSTING,
   };
-  char *outs[4] = { owner_out, active_out, memo_out, posting_out };
-  size_t lens[4] = { owner_len, active_len, memo_len, posting_len };
+  char* outs[4] = {owner_out, active_out, memo_out, posting_out};
+  size_t lens[4] = {owner_len, active_len, memo_len, posting_len};
 
   uint32_t account_hardened = account_index | 0x80000000u;
 
@@ -81,27 +84,33 @@ bool hive_getPublicKeys(const HDNode *root, uint32_t account_index,
 
 // ── Graphene binary serialization helpers ─────────────────────────────────
 
-static void append_u8(uint8_t **buf, const uint8_t *end, uint8_t v) {
-  if (*buf < end) { **buf = v; (*buf)++; }
+static void append_u8(uint8_t** buf, const uint8_t* end, uint8_t v) {
+  if (*buf < end) {
+    **buf = v;
+    (*buf)++;
+  }
 }
 
-static void append_u16_le(uint8_t **buf, const uint8_t *end, uint16_t v) {
+static void append_u16_le(uint8_t** buf, const uint8_t* end, uint16_t v) {
   append_u8(buf, end, v & 0xFF);
   append_u8(buf, end, (v >> 8) & 0xFF);
 }
 
-static void append_u32_le(uint8_t **buf, const uint8_t *end, uint32_t v) {
+static void append_u32_le(uint8_t** buf, const uint8_t* end, uint32_t v) {
   append_u8(buf, end, v & 0xFF);
   append_u8(buf, end, (v >> 8) & 0xFF);
   append_u8(buf, end, (v >> 16) & 0xFF);
   append_u8(buf, end, (v >> 24) & 0xFF);
 }
 
-static void append_u64_le(uint8_t **buf, const uint8_t *end, uint64_t v) {
-  for (int i = 0; i < 8; i++) { append_u8(buf, end, v & 0xFF); v >>= 8; }
+static void append_u64_le(uint8_t** buf, const uint8_t* end, uint64_t v) {
+  for (int i = 0; i < 8; i++) {
+    append_u8(buf, end, v & 0xFF);
+    v >>= 8;
+  }
 }
 
-static void append_varint(uint8_t **buf, const uint8_t *end, uint64_t v) {
+static void append_varint(uint8_t** buf, const uint8_t* end, uint64_t v) {
   do {
     uint8_t b = v & 0x7F;
     v >>= 7;
@@ -110,7 +119,7 @@ static void append_varint(uint8_t **buf, const uint8_t *end, uint64_t v) {
   } while (v);
 }
 
-static void append_string(uint8_t **buf, const uint8_t *end, const char *s) {
+static void append_string(uint8_t** buf, const uint8_t* end, const char* s) {
   size_t len = s ? strlen(s) : 0;
   append_varint(buf, end, len);
   for (size_t i = 0; i < len && *buf < end; i++)
@@ -120,8 +129,8 @@ static void append_string(uint8_t **buf, const uint8_t *end, const char *s) {
 /*
  * Graphene asset encoding: int64 LE amount + uint8 precision + 7-byte symbol
  */
-static void append_asset(uint8_t **buf, const uint8_t *end,
-                         uint64_t amount, uint8_t precision, const char *symbol) {
+static void append_asset(uint8_t** buf, const uint8_t* end, uint64_t amount,
+                         uint8_t precision, const char* symbol) {
   append_u64_le(buf, end, amount);
   append_u8(buf, end, precision);
   char sym[7] = {0};
@@ -140,13 +149,12 @@ static void append_asset(uint8_t **buf, const uint8_t *end,
  *
  * Note: Hive does NOT use a key-type prefix byte before the 33 raw bytes.
  */
-static void append_authority(uint8_t **buf, const uint8_t *end,
+static void append_authority(uint8_t** buf, const uint8_t* end,
                              const uint8_t pubkey[33]) {
   append_u32_le(buf, end, 1);  // weight_threshold = 1
   append_varint(buf, end, 0);  // 0 account auths
   append_varint(buf, end, 1);  // 1 key auth
-  for (int i = 0; i < 33 && *buf < end; i++)
-    append_u8(buf, end, pubkey[i]);
+  for (int i = 0; i < 33 && *buf < end; i++) append_u8(buf, end, pubkey[i]);
   append_u16_le(buf, end, 1);  // weight = 1
 }
 
@@ -154,26 +162,26 @@ static void append_authority(uint8_t **buf, const uint8_t *end,
  * Common transaction header: ref_block_num, ref_block_prefix, expiration,
  * then a varint op count = 1, then the op type varint.
  */
-static void append_tx_header(uint8_t **buf, const uint8_t *end,
+static void append_tx_header(uint8_t** buf, const uint8_t* end,
                              uint16_t ref_block_num, uint32_t ref_block_prefix,
                              uint32_t expiration, uint32_t op_type) {
   append_u16_le(buf, end, ref_block_num);
   append_u32_le(buf, end, ref_block_prefix);
   append_u32_le(buf, end, expiration);
-  append_varint(buf, end, 1);         // 1 operation
+  append_varint(buf, end, 1);  // 1 operation
   append_varint(buf, end, op_type);
 }
 
-static void append_tx_footer(uint8_t **buf, const uint8_t *end) {
-  append_varint(buf, end, 0);         // 0 extensions
+static void append_tx_footer(uint8_t** buf, const uint8_t* end) {
+  append_varint(buf, end, 0);  // 0 extensions
 }
 
 /*
  * Sign helper: SHA256(chain_id || serialized_tx) → secp256k1 recoverable sig.
  * Writes 65 bytes into sig[]. Returns true on success.
  */
-static bool hive_sign_digest(const HDNode *node, const uint8_t *chain_id,
-                             const uint8_t *tx_buf, size_t tx_len,
+static bool hive_sign_digest(const HDNode* node, const uint8_t* chain_id,
+                             const uint8_t* tx_buf, size_t tx_len,
                              uint8_t sig[65]) {
   SHA256_CTX sha;
   sha256_Init(&sha);
@@ -183,8 +191,8 @@ static bool hive_sign_digest(const HDNode *node, const uint8_t *chain_id,
   sha256_Final(&sha, digest);
 
   uint8_t pby;
-  if (ecdsa_sign_digest(&secp256k1, node->private_key, digest,
-                        sig + 1, &pby, NULL) != 0) {
+  if (ecdsa_sign_digest(&secp256k1, node->private_key, digest, sig + 1, &pby,
+                        NULL) != 0) {
     memzero(digest, sizeof(digest));
     return false;
   }
@@ -197,25 +205,22 @@ static bool hive_sign_digest(const HDNode *node, const uint8_t *chain_id,
 // ── Transfer (op type 2) ──────────────────────────────────────────────────
 
 // Maximum memo length that fits safely in tx_buf[512] with all other fields.
-// Non-memo overhead: header(12) + from(17) + to(17) + asset(16) + footer(1) = ~63 bytes.
-// 512 - 63 - 3 (varint) = 446; use 440 as the conservative limit.
+// Non-memo overhead: header(12) + from(17) + to(17) + asset(16) + footer(1) =
+// ~63 bytes. 512 - 63 - 3 (varint) = 446; use 440 as the conservative limit.
 #define HIVE_MAX_MEMO_LEN 440
 
-static size_t hive_serialize_transfer(const HiveSignTx *msg,
-                                      uint8_t *buf, size_t buf_len) {
-  uint8_t *p = buf;
-  const uint8_t *end = buf + buf_len;
+static size_t hive_serialize_transfer(const HiveSignTx* msg, uint8_t* buf,
+                                      size_t buf_len) {
+  uint8_t* p = buf;
+  const uint8_t* end = buf + buf_len;
 
-  append_tx_header(&p, end,
-                   (uint16_t)(msg->ref_block_num & 0xFFFF),
-                   msg->ref_block_prefix,
-                   msg->expiration,
-                   HIVE_OP_TRANSFER);
+  append_tx_header(&p, end, (uint16_t)(msg->ref_block_num & 0xFFFF),
+                   msg->ref_block_prefix, msg->expiration, HIVE_OP_TRANSFER);
 
   append_string(&p, end, msg->has_from ? msg->from : "");
-  append_string(&p, end, msg->has_to   ? msg->to   : "");
+  append_string(&p, end, msg->has_to ? msg->to : "");
 
-  const char *sym = msg->has_asset_symbol ? msg->asset_symbol : "HIVE";
+  const char* sym = msg->has_asset_symbol ? msg->asset_symbol : "HIVE";
   uint8_t prec = (uint8_t)(msg->has_decimals ? msg->decimals : HIVE_DECIMALS);
   append_asset(&p, end, msg->amount, prec, sym);
 
@@ -224,7 +229,8 @@ static size_t hive_serialize_transfer(const HiveSignTx *msg,
   return (size_t)(p - buf);
 }
 
-void hive_signTx(const HDNode *node, const HiveSignTx *msg, HiveSignedTx *resp) {
+void hive_signTx(const HDNode* node, const HiveSignTx* msg,
+                 HiveSignedTx* resp) {
   // Reject memos that would overflow the fixed-size tx_buf.
   if (msg->has_memo && strlen(msg->memo) > HIVE_MAX_MEMO_LEN) return;
 
@@ -232,10 +238,10 @@ void hive_signTx(const HDNode *node, const HiveSignTx *msg, HiveSignedTx *resp) 
   size_t tx_len = hive_serialize_transfer(msg, tx_buf, sizeof(tx_buf));
 
   const uint8_t default_chain_id[32] = HIVE_CHAIN_ID;
-  const uint8_t *chain_id = (msg->has_chain_id &&
-                              msg->chain_id.size == HIVE_CHAIN_ID_LEN)
-                             ? msg->chain_id.bytes
-                             : default_chain_id;
+  const uint8_t* chain_id =
+      (msg->has_chain_id && msg->chain_id.size == HIVE_CHAIN_ID_LEN)
+          ? msg->chain_id.bytes
+          : default_chain_id;
 
   uint8_t sig[65];
   if (!hive_sign_digest(node, chain_id, tx_buf, tx_len, sig)) {
@@ -261,19 +267,17 @@ void hive_signTx(const HDNode *node, const HiveSignTx *msg, HiveSignedTx *resp) 
 // passed as raw 33-byte compressed public keys. The firmware never uses
 // host-supplied key strings for the actual transaction.
 
-static size_t hive_serialize_account_create(const HiveSignAccountCreate *msg,
-                                             const uint8_t owner_raw[33],
-                                             const uint8_t active_raw[33],
-                                             const uint8_t posting_raw[33],
-                                             const uint8_t memo_raw[33],
-                                             uint8_t *buf, size_t buf_len) {
-  uint8_t *p = buf;
-  const uint8_t *end = buf + buf_len;
+static size_t hive_serialize_account_create(const HiveSignAccountCreate* msg,
+                                            const uint8_t owner_raw[33],
+                                            const uint8_t active_raw[33],
+                                            const uint8_t posting_raw[33],
+                                            const uint8_t memo_raw[33],
+                                            uint8_t* buf, size_t buf_len) {
+  uint8_t* p = buf;
+  const uint8_t* end = buf + buf_len;
 
-  append_tx_header(&p, end,
-                   (uint16_t)(msg->ref_block_num & 0xFFFF),
-                   msg->ref_block_prefix,
-                   msg->expiration,
+  append_tx_header(&p, end, (uint16_t)(msg->ref_block_num & 0xFFFF),
+                   msg->ref_block_prefix, msg->expiration,
                    HIVE_OP_ACCOUNT_CREATE);
 
   // fee (asset)
@@ -284,9 +288,11 @@ static size_t hive_serialize_account_create(const HiveSignAccountCreate *msg,
   append_string(&p, end, msg->has_creator ? msg->creator : "");
 
   // new_account_name
-  append_string(&p, end, msg->has_new_account_name ? msg->new_account_name : "");
+  append_string(&p, end,
+                msg->has_new_account_name ? msg->new_account_name : "");
 
-  // authority fields use device-derived raw bytes (no host trust, no type prefix)
+  // authority fields use device-derived raw bytes (no host trust, no type
+  // prefix)
   append_authority(&p, end, owner_raw);
   append_authority(&p, end, active_raw);
   append_authority(&p, end, posting_raw);
@@ -301,24 +307,23 @@ static size_t hive_serialize_account_create(const HiveSignAccountCreate *msg,
   return (size_t)(p - buf);
 }
 
-void hive_signAccountCreate(const HDNode *signing_node,
-                            const HiveSignAccountCreate *msg,
+void hive_signAccountCreate(const HDNode* signing_node,
+                            const HiveSignAccountCreate* msg,
                             const uint8_t owner_raw[33],
                             const uint8_t active_raw[33],
                             const uint8_t posting_raw[33],
                             const uint8_t memo_raw[33],
-                            HiveSignedAccountCreate *resp) {
+                            HiveSignedAccountCreate* resp) {
   uint8_t tx_buf[512];
-  size_t tx_len = hive_serialize_account_create(msg,
-                                                 owner_raw, active_raw,
-                                                 posting_raw, memo_raw,
-                                                 tx_buf, sizeof(tx_buf));
+  size_t tx_len =
+      hive_serialize_account_create(msg, owner_raw, active_raw, posting_raw,
+                                    memo_raw, tx_buf, sizeof(tx_buf));
 
   const uint8_t default_chain_id[32] = HIVE_CHAIN_ID;
-  const uint8_t *chain_id = (msg->has_chain_id &&
-                              msg->chain_id.size == HIVE_CHAIN_ID_LEN)
-                             ? msg->chain_id.bytes
-                             : default_chain_id;
+  const uint8_t* chain_id =
+      (msg->has_chain_id && msg->chain_id.size == HIVE_CHAIN_ID_LEN)
+          ? msg->chain_id.bytes
+          : default_chain_id;
 
   uint8_t sig[65];
   if (!hive_sign_digest(signing_node, chain_id, tx_buf, tx_len, sig)) {
@@ -344,19 +349,17 @@ void hive_signAccountCreate(const HDNode *signing_node,
 // All four new role keys are device-derived by the caller (FSM handler).
 // The host-supplied new_*_key fields in the message are not used for signing.
 
-static size_t hive_serialize_account_update(const HiveSignAccountUpdate *msg,
-                                             const uint8_t owner_raw[33],
-                                             const uint8_t active_raw[33],
-                                             const uint8_t posting_raw[33],
-                                             const uint8_t memo_raw[33],
-                                             uint8_t *buf, size_t buf_len) {
-  uint8_t *p = buf;
-  const uint8_t *end = buf + buf_len;
+static size_t hive_serialize_account_update(const HiveSignAccountUpdate* msg,
+                                            const uint8_t owner_raw[33],
+                                            const uint8_t active_raw[33],
+                                            const uint8_t posting_raw[33],
+                                            const uint8_t memo_raw[33],
+                                            uint8_t* buf, size_t buf_len) {
+  uint8_t* p = buf;
+  const uint8_t* end = buf + buf_len;
 
-  append_tx_header(&p, end,
-                   (uint16_t)(msg->ref_block_num & 0xFFFF),
-                   msg->ref_block_prefix,
-                   msg->expiration,
+  append_tx_header(&p, end, (uint16_t)(msg->ref_block_num & 0xFFFF),
+                   msg->ref_block_prefix, msg->expiration,
                    HIVE_OP_ACCOUNT_UPDATE);
 
   // account name
@@ -385,24 +388,23 @@ static size_t hive_serialize_account_update(const HiveSignAccountUpdate *msg,
   return (size_t)(p - buf);
 }
 
-void hive_signAccountUpdate(const HDNode *signing_node,
-                            const HiveSignAccountUpdate *msg,
+void hive_signAccountUpdate(const HDNode* signing_node,
+                            const HiveSignAccountUpdate* msg,
                             const uint8_t owner_raw[33],
                             const uint8_t active_raw[33],
                             const uint8_t posting_raw[33],
                             const uint8_t memo_raw[33],
-                            HiveSignedAccountUpdate *resp) {
+                            HiveSignedAccountUpdate* resp) {
   uint8_t tx_buf[512];
-  size_t tx_len = hive_serialize_account_update(msg,
-                                                 owner_raw, active_raw,
-                                                 posting_raw, memo_raw,
-                                                 tx_buf, sizeof(tx_buf));
+  size_t tx_len =
+      hive_serialize_account_update(msg, owner_raw, active_raw, posting_raw,
+                                    memo_raw, tx_buf, sizeof(tx_buf));
 
   const uint8_t default_chain_id[32] = HIVE_CHAIN_ID;
-  const uint8_t *chain_id = (msg->has_chain_id &&
-                              msg->chain_id.size == HIVE_CHAIN_ID_LEN)
-                             ? msg->chain_id.bytes
-                             : default_chain_id;
+  const uint8_t* chain_id =
+      (msg->has_chain_id && msg->chain_id.size == HIVE_CHAIN_ID_LEN)
+          ? msg->chain_id.bytes
+          : default_chain_id;
 
   uint8_t sig[65];
   if (!hive_sign_digest(signing_node, chain_id, tx_buf, tx_len, sig)) {

--- a/lib/firmware/messagemap.def
+++ b/lib/firmware/messagemap.def
@@ -179,10 +179,16 @@
 
     /* Hive */
     MSG_IN(MessageType_MessageType_HiveGetPublicKey,               HiveGetPublicKey,            fsm_msgHiveGetPublicKey)
+    MSG_IN(MessageType_MessageType_HiveGetPublicKeys,              HiveGetPublicKeys,           fsm_msgHiveGetPublicKeys)
     MSG_IN(MessageType_MessageType_HiveSignTx,                     HiveSignTx,                  fsm_msgHiveSignTx)
+    MSG_IN(MessageType_MessageType_HiveSignAccountCreate,          HiveSignAccountCreate,       fsm_msgHiveSignAccountCreate)
+    MSG_IN(MessageType_MessageType_HiveSignAccountUpdate,          HiveSignAccountUpdate,       fsm_msgHiveSignAccountUpdate)
 
     MSG_OUT(MessageType_MessageType_HivePublicKey,                 HivePublicKey,               NO_PROCESS_FUNC)
+    MSG_OUT(MessageType_MessageType_HivePublicKeys,                HivePublicKeys,              NO_PROCESS_FUNC)
     MSG_OUT(MessageType_MessageType_HiveSignedTx,                  HiveSignedTx,                NO_PROCESS_FUNC)
+    MSG_OUT(MessageType_MessageType_HiveSignedAccountCreate,       HiveSignedAccountCreate,     NO_PROCESS_FUNC)
+    MSG_OUT(MessageType_MessageType_HiveSignedAccountUpdate,       HiveSignedAccountUpdate,     NO_PROCESS_FUNC)
 
 #if DEBUG_LINK
     /* Debug Messages */

--- a/lib/firmware/ripple.c
+++ b/lib/firmware/ripple.c
@@ -223,6 +223,25 @@ bool ripple_serialize(uint8_t** buf, const uint8_t* end, const RippleSignTx* tx,
   if (tx->payment.has_destination)
     ripple_serializeAddress(&ok, buf, end, &RFM_destination,
                             tx->payment.destination);
+  // Memos array (ARRAY type=15 key=9) comes last per XRPL canonical ordering.
+  // Layout: 0xF9 [Memos start] 0xEA [Memo object start]
+  //         0x7D [MemoData VL] <varint len> <bytes>
+  //         0xE1 [object end] 0xF1 [array end]
+  if (tx->has_memo && tx->memo[0] != '\0') {
+    size_t memo_len = strlen(tx->memo);
+    append_u8(&ok, buf, end, 0xF9);  // STArray[9] = Memos
+    append_u8(&ok, buf, end, 0xEA);  // STObject[10] = Memo
+    append_u8(&ok, buf, end, 0x7D);  // VL[13] = MemoData
+    ripple_serializeVarint(&ok, buf, end, (int)memo_len);
+    if (ok && *buf + memo_len <= end) {
+      memcpy(*buf, tx->memo, memo_len);
+      *buf += memo_len;
+    } else {
+      ok = false;
+    }
+    append_u8(&ok, buf, end, 0xE1);  // end STObject
+    append_u8(&ok, buf, end, 0xF1);  // end STArray
+  }
   return ok;
 }
 

--- a/lib/transport/CMakeLists.txt
+++ b/lib/transport/CMakeLists.txt
@@ -189,8 +189,6 @@ add_custom_command(
     ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/lib/transport/*.pb.h
        ${CMAKE_BINARY_DIR}/include
   COMMAND
-    sh -c "! grep -r pb_callback_t ${CMAKE_BINARY_DIR}/include/*.pb.h" || (echo "pb_callback_t forbidden. missing .options entry?" && false)
-  COMMAND
     ${CMAKE_COMMAND} -E touch ${CMAKE_BINARY_DIR}/lib/transport/kktransport.pb.stamp
   DEPENDS
     ${protoc_pb_sources} ${protoc_pb_options})

--- a/lib/transport/CMakeLists.txt
+++ b/lib/transport/CMakeLists.txt
@@ -19,6 +19,7 @@ set(protoc_pb_sources
     ${DEVICE_PROTOCOL}/messages-tron.proto
     ${DEVICE_PROTOCOL}/messages-ton.proto
     ${DEVICE_PROTOCOL}/messages-zcash.proto
+    ${DEVICE_PROTOCOL}/messages-hive.proto
     ${DEVICE_PROTOCOL}/messages.proto)
 
 set(protoc_pb_options
@@ -37,6 +38,7 @@ set(protoc_pb_options
     ${CMAKE_SOURCE_DIR}/include/keepkey/transport/messages-tron.options
     ${CMAKE_SOURCE_DIR}/include/keepkey/transport/messages-ton.options
     ${CMAKE_SOURCE_DIR}/include/keepkey/transport/messages-zcash.options
+    ${CMAKE_SOURCE_DIR}/include/keepkey/transport/messages-hive.options
     ${CMAKE_SOURCE_DIR}/include/keepkey/transport/messages.options)
 
 set(protoc_c_sources
@@ -55,6 +57,7 @@ set(protoc_c_sources
     ${CMAKE_BINARY_DIR}/lib/transport/messages-tron.pb.c
     ${CMAKE_BINARY_DIR}/lib/transport/messages-ton.pb.c
     ${CMAKE_BINARY_DIR}/lib/transport/messages-zcash.pb.c
+    ${CMAKE_BINARY_DIR}/lib/transport/messages-hive.pb.c
     ${CMAKE_BINARY_DIR}/lib/transport/messages.pb.c)
 
 set(protoc_c_headers
@@ -73,6 +76,7 @@ set(protoc_c_headers
     ${CMAKE_BINARY_DIR}/include/messages-tron.pb.h
     ${CMAKE_BINARY_DIR}/include/messages-ton.pb.h
     ${CMAKE_BINARY_DIR}/include/messages-zcash.pb.h
+    ${CMAKE_BINARY_DIR}/include/messages-hive.pb.h
     ${CMAKE_BINARY_DIR}/include/messages.pb.h)
 
 set(protoc_pb_sources_moved
@@ -91,6 +95,7 @@ set(protoc_pb_sources_moved
     ${CMAKE_BINARY_DIR}/lib/transport/messages-tron.proto
     ${CMAKE_BINARY_DIR}/lib/transport/messages-ton.proto
     ${CMAKE_BINARY_DIR}/lib/transport/messages-zcash.proto
+    ${CMAKE_BINARY_DIR}/lib/transport/messages-hive.proto
     ${CMAKE_BINARY_DIR}/lib/transport/messages.proto)
 
 add_custom_command(
@@ -172,6 +177,10 @@ add_custom_command(
     ${PROTOC_BINARY} -I. -I/usr/include
       --plugin=nanopb=${NANOPB_DIR}/generator/protoc-gen-nanopb
       "--nanopb_out=-f messages-zcash.options:." messages-zcash.proto
+  COMMAND
+    ${PROTOC_BINARY} -I. -I/usr/include
+      --plugin=nanopb=${NANOPB_DIR}/generator/protoc-gen-nanopb
+      "--nanopb_out=-f messages-hive.options:." messages-hive.proto
   COMMAND
     ${PROTOC_BINARY} -I. -I/usr/include
       --plugin=nanopb=${NANOPB_DIR}/generator/protoc-gen-nanopb


### PR DESCRIPTION
## Summary

- Fixes Hive key derivation from BIP-44 → SLIP-0048 (`m/48'/13'/role'/account'/0'`)
- Adds `HiveGetPublicKeys`: derive all 4 role keys (owner/active/memo/posting) in one interaction
- Adds `HiveSignAccountCreate`: sign Graphene `account_create` op — device is sole root of trust from genesis
- Adds `HiveSignAccountUpdate`: sign `account_update` op — replace existing account authorities with device keys
- Adds `parse_stm_pubkey()` helper for Graphene authority struct serialization (RIPEMD base58check)
- Removes incorrect `pb_callback_t forbidden` check from CMakeLists.txt
- Proto generation via Docker (`kktech/firmware:v15`, nanopb 0.3.9.8, protoc 3.5.1)

## Wire IDs

| Message | ID |
|---|---|
| HiveGetPublicKeys | 1604 |
| HivePublicKeys | 1605 |
| HiveSignAccountCreate | 1606 |
| HiveSignedAccountCreate | 1607 |
| HiveSignAccountUpdate | 1608 |
| HiveSignedAccountUpdate | 1609 |

## Test plan

- [ ] `make build-emulator` from vault repo — emulator builds clean
- [ ] HiveGetPublicKey returns STM-prefixed key at SLIP-0048 path
- [ ] HiveGetPublicKeys returns all 4 role keys for account 0
- [ ] HiveSignTx signs a transfer and emits valid recoverable secp256k1 signature
- [ ] HiveSignAccountCreate signs account_create, device shows username confirmation
- [ ] HiveSignAccountUpdate signs account_update, device shows warning + new owner key