### PR TITLE
fix(zcash): use S.2 transparent_sig_digest for Orchard sighash in shield txs

### DIFF
--- a/include/keepkey/firmware/zcash.h
+++ b/include/keepkey/firmware/zcash.h
@@ -158,6 +158,19 @@ bool zcash_compute_transparent_digest(
     uint8_t digest_out[32]);
 
 /**
+ * Compute ZIP-244 §4.9 transparent_sig_digest for Orchard spend authorization.
+ *
+ * Uses the S.2 form with EMPTY txin_sig_digest when n_inputs > 0 (shield txs),
+ * or falls back to T.1 when n_inputs == 0 (deshield / private-send). This is
+ * what the Zcash consensus node uses to verify Orchard spend auth sigs and the
+ * binding signature in a hybrid (transparent + Orchard) transaction.
+ */
+bool zcash_compute_orchard_transparent_sig_digest(
+    const ZcashTransparentInputDigestInfo* inputs, size_t n_inputs,
+    const ZcashTransparentOutputDigestInfo* outputs, size_t n_outputs,
+    uint8_t digest_out[32]);
+
+/**
  * Compute ZIP-244 S.2 per-input transparent signature digest.
  *
  * This currently accepts SIGHASH_ALL only, matching the existing transparent

--- a/lib/firmware/ethereum_contracts/zxappliquid.c
+++ b/lib/firmware/ethereum_contracts/zxappliquid.c
@@ -35,7 +35,7 @@
 #include "trezor/crypto/sha3.h"
 
 bool zx_confirmApproveLiquidity(uint32_t data_total,
-                                const EthereumSignTx *msg) {
+                                const EthereumSignTx* msg) {
   (void)data_total;
   const char *to, *tikstr, *poolstr, *allowance, *amt;
   unsigned char data[40];
@@ -47,14 +47,14 @@ bool zx_confirmApproveLiquidity(uint32_t data_total,
   const TokenType *WETH, *ttoken;
 
   if (!tokenByTicker(msg->chain_id, "WETH", &WETH)) return false;
-  wethord = read_be((const uint8_t *)WETH->address);
-  to = (const char *)msg->to.bytes;
+  wethord = read_be((const uint8_t*)WETH->address);
+  to = (const char*)msg->to.bytes;
   tokctr = 0;
   while (tokctr != -1) {
     ttoken = tokenIter(&tokctr);
 
     // https://uniswap.org/docs/v2/smart-contract-integration/getting-pair-addresses/
-    uint32_t ttokenord = read_be((const uint8_t *)ttoken->address);
+    uint32_t ttokenord = read_be((const uint8_t*)ttoken->address);
     if (ttokenord < wethord) {
       memcpy(data, ttoken->address, 20);
       memcpy(&data[20], WETH->address, 20);
@@ -65,7 +65,7 @@ bool zx_confirmApproveLiquidity(uint32_t data_total,
     keccak_256(data, sizeof(data), tokdigest);
     SHA3_CTX ctx = {0};
     keccak_256_Init(&ctx);
-    keccak_Update(&ctx, (unsigned char *)"\xff", 1);
+    keccak_Update(&ctx, (unsigned char*)"\xff", 1);
     keccak_Update(&ctx, (unsigned char *)"\x5C\x69\xbE\xe7\x01\xef\x81\x4a\x2B\x6a\x3E\xDD\x4B\x16\x52\xCB\x9c\xc5\xaA\x6f", 20);
     keccak_Update(&ctx, tokdigest, sizeof(tokdigest));
     keccak_Update(&ctx, (unsigned char *)"\x96\xe8\xac\x42\x77\x19\x8f\xf8\xb6\xf7\x85\x47\x8a\xa9\xa3\x9f\x40\x3c\xb7\x68\xdd\x02\xcb\xee\x32\x6c\x3e\x7d\xa3\x48\x84\x5f", 32);
@@ -87,8 +87,8 @@ bool zx_confirmApproveLiquidity(uint32_t data_total,
     poolstr = digestStr;
   }
 
-  allowance = (char *)(msg->data_initial_chunk.bytes + 4 + 32);
-  if (memcmp(allowance, (uint8_t *)&MAX_ALLOWANCE, 32) == 0) {
+  allowance = (char*)(msg->data_initial_chunk.bytes + 4 + 32);
+  if (memcmp(allowance, (uint8_t*)&MAX_ALLOWANCE, 32) == 0) {
     amt = "full balance";
   } else {
     for (ctr = 0; ctr < 32; ctr++) {
@@ -97,7 +97,7 @@ bool zx_confirmApproveLiquidity(uint32_t data_total,
     amt = amtStr;
   }
 
-  const char *appStr = "uniswap approve liquidity";
+  const char* appStr = "uniswap approve liquidity";
   confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, appStr, "Amount: %s",
           amt);
   confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, appStr,
@@ -105,9 +105,9 @@ bool zx_confirmApproveLiquidity(uint32_t data_total,
   return true;
 }
 
-bool zx_isZxApproveLiquid(const EthereumSignTx *msg) {
+bool zx_isZxApproveLiquid(const EthereumSignTx* msg) {
   if (memcmp(msg->data_initial_chunk.bytes, "\x09\x5e\xa7\xb3", 4) == 0)
-    if (memcmp((uint8_t *)(msg->data_initial_chunk.bytes + 4 + 32 - 20),
+    if (memcmp((uint8_t*)(msg->data_initial_chunk.bytes + 4 + 32 - 20),
                UNISWAP_ROUTER_ADDRESS, 20) == 0)
       return true;
   return false;

--- a/lib/firmware/ethereum_contracts/zxappliquid.c
+++ b/lib/firmware/ethereum_contracts/zxappliquid.c
@@ -35,7 +35,7 @@
 #include "trezor/crypto/sha3.h"
 
 bool zx_confirmApproveLiquidity(uint32_t data_total,
-                                const EthereumSignTx* msg) {
+                                const EthereumSignTx *msg) {
   (void)data_total;
   const char *to, *tikstr, *poolstr, *allowance, *amt;
   unsigned char data[40];
@@ -47,14 +47,14 @@ bool zx_confirmApproveLiquidity(uint32_t data_total,
   const TokenType *WETH, *ttoken;
 
   if (!tokenByTicker(msg->chain_id, "WETH", &WETH)) return false;
-  wethord = read_be((const uint8_t*)WETH->address);
-  to = (const char*)msg->to.bytes;
+  wethord = read_be((const uint8_t *)WETH->address);
+  to = (const char *)msg->to.bytes;
   tokctr = 0;
   while (tokctr != -1) {
     ttoken = tokenIter(&tokctr);
 
     // https://uniswap.org/docs/v2/smart-contract-integration/getting-pair-addresses/
-    uint32_t ttokenord = read_be((const uint8_t*)ttoken->address);
+    uint32_t ttokenord = read_be((const uint8_t *)ttoken->address);
     if (ttokenord < wethord) {
       memcpy(data, ttoken->address, 20);
       memcpy(&data[20], WETH->address, 20);
@@ -65,7 +65,7 @@ bool zx_confirmApproveLiquidity(uint32_t data_total,
     keccak_256(data, sizeof(data), tokdigest);
     SHA3_CTX ctx = {0};
     keccak_256_Init(&ctx);
-    keccak_Update(&ctx, (unsigned char*)"\xff", 1);
+    keccak_Update(&ctx, (unsigned char *)"\xff", 1);
     keccak_Update(&ctx, (unsigned char *)"\x5C\x69\xbE\xe7\x01\xef\x81\x4a\x2B\x6a\x3E\xDD\x4B\x16\x52\xCB\x9c\xc5\xaA\x6f", 20);
     keccak_Update(&ctx, tokdigest, sizeof(tokdigest));
     keccak_Update(&ctx, (unsigned char *)"\x96\xe8\xac\x42\x77\x19\x8f\xf8\xb6\xf7\x85\x47\x8a\xa9\xa3\x9f\x40\x3c\xb7\x68\xdd\x02\xcb\xee\x32\x6c\x3e\x7d\xa3\x48\x84\x5f", 32);
@@ -87,8 +87,8 @@ bool zx_confirmApproveLiquidity(uint32_t data_total,
     poolstr = digestStr;
   }
 
-  allowance = (char*)(msg->data_initial_chunk.bytes + 4 + 32);
-  if (memcmp(allowance, (uint8_t*)&MAX_ALLOWANCE, 32) == 0) {
+  allowance = (char *)(msg->data_initial_chunk.bytes + 4 + 32);
+  if (memcmp(allowance, (uint8_t *)&MAX_ALLOWANCE, 32) == 0) {
     amt = "full balance";
   } else {
     for (ctr = 0; ctr < 32; ctr++) {
@@ -97,7 +97,7 @@ bool zx_confirmApproveLiquidity(uint32_t data_total,
     amt = amtStr;
   }
 
-  const char* appStr = "uniswap approve liquidity";
+  const char *appStr = "uniswap approve liquidity";
   confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, appStr, "Amount: %s",
           amt);
   confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, appStr,
@@ -105,9 +105,9 @@ bool zx_confirmApproveLiquidity(uint32_t data_total,
   return true;
 }
 
-bool zx_isZxApproveLiquid(const EthereumSignTx* msg) {
+bool zx_isZxApproveLiquid(const EthereumSignTx *msg) {
   if (memcmp(msg->data_initial_chunk.bytes, "\x09\x5e\xa7\xb3", 4) == 0)
-    if (memcmp((uint8_t*)(msg->data_initial_chunk.bytes + 4 + 32 - 20),
+    if (memcmp((uint8_t *)(msg->data_initial_chunk.bytes + 4 + 32 - 20),
                UNISWAP_ROUTER_ADDRESS, 20) == 0)
       return true;
   return false;

--- a/lib/firmware/fsm_msg_zcash.h
+++ b/lib/firmware/fsm_msg_zcash.h
@@ -326,7 +326,7 @@ static bool zcash_finalize_transparent_digest(void) {
   uint8_t transparent_digest[32] = {0};
 
   if (!zcash_build_transparent_digest_info(inputs, outputs) ||
-      !zcash_compute_transparent_digest(
+      !zcash_compute_orchard_transparent_sig_digest(
           inputs, zcash_signing.n_transparent_inputs, outputs,
           zcash_signing.n_transparent_outputs, transparent_digest)) {
     memzero(transparent_digest, sizeof(transparent_digest));

--- a/lib/firmware/zcash.c
+++ b/lib/firmware/zcash.c
@@ -965,6 +965,70 @@ bool zcash_compute_transparent_digest(
   return true;
 }
 
+/* ZIP-244 §4.9 / §4.10b: transparent_sig_digest for Orchard spend
+ * authorization.
+ *
+ * When n_inputs > 0, the Orchard sighash uses the S.2 form:
+ *   BLAKE2b("ZTxIdTranspaHash",
+ *     hash_type(0x01) || prevouts || amounts || scripts || sequences ||
+ *     outputs || empty_txin_digest)
+ * where empty_txin_digest = BLAKE2b("Zcash___TxInHash", "").
+ *
+ * When n_inputs == 0 (deshield / private-send), falls back to T.1 form
+ * (no hash_type, amounts, scripts, or txin digest) — same as txid form.
+ *
+ * This differs from zcash_compute_transparent_sighash_digest which uses a
+ * per-input txin_sig_digest for transparent ECDSA signatures.
+ */
+bool zcash_compute_orchard_transparent_sig_digest(
+    const ZcashTransparentInputDigestInfo* inputs, size_t n_inputs,
+    const ZcashTransparentOutputDigestInfo* outputs, size_t n_outputs,
+    uint8_t digest_out[32]) {
+  if (!digest_out || !zcash_validate_transparent_digest_info(
+                         inputs, n_inputs, outputs, n_outputs)) {
+    return false;
+  }
+
+  /* Empty-vin case (deshield, private): T.1 form is correct per §4.10b. */
+  if (n_inputs == 0) {
+    return zcash_compute_transparent_digest(inputs, n_inputs, outputs,
+                                            n_outputs, digest_out);
+  }
+
+  /* Non-empty vin (shield): S.2 form with empty txin_sig_digest. */
+  const uint8_t sighash_type = 0x01; /* SIGHASH_ALL */
+  uint8_t prevouts_digest[32], amounts_digest[32], scripts_digest[32];
+  uint8_t sequence_digest[32], outputs_digest[32], empty_txin_digest[32];
+
+  zcash_hash_transparent_prevouts(inputs, n_inputs, prevouts_digest);
+  zcash_hash_transparent_amounts(inputs, n_inputs, amounts_digest);
+  zcash_hash_transparent_scripts(inputs, n_inputs, scripts_digest);
+  zcash_hash_transparent_sequences(inputs, n_inputs, sequence_digest);
+  zcash_hash_transparent_outputs(outputs, n_outputs, outputs_digest);
+
+  /* Empty txin_sig_digest: BLAKE2b("Zcash___TxInHash", "") */
+  zcash_blake2b_personal_256("Zcash___TxInHash", NULL, 0, empty_txin_digest);
+
+  BLAKE2B_CTX ctx;
+  blake2b_InitPersonal(&ctx, 32, "ZTxIdTranspaHash", 16);
+  blake2b_Update(&ctx, &sighash_type, 1);
+  blake2b_Update(&ctx, prevouts_digest, 32);
+  blake2b_Update(&ctx, amounts_digest, 32);
+  blake2b_Update(&ctx, scripts_digest, 32);
+  blake2b_Update(&ctx, sequence_digest, 32);
+  blake2b_Update(&ctx, outputs_digest, 32);
+  blake2b_Update(&ctx, empty_txin_digest, 32);
+  blake2b_Final(&ctx, digest_out, 32);
+
+  memzero(prevouts_digest, sizeof(prevouts_digest));
+  memzero(amounts_digest, sizeof(amounts_digest));
+  memzero(scripts_digest, sizeof(scripts_digest));
+  memzero(sequence_digest, sizeof(sequence_digest));
+  memzero(outputs_digest, sizeof(outputs_digest));
+  memzero(empty_txin_digest, sizeof(empty_txin_digest));
+  return true;
+}
+
 bool zcash_compute_transparent_sighash_digest(
     const ZcashTransparentInputDigestInfo* inputs, size_t n_inputs,
     const ZcashTransparentOutputDigestInfo* outputs, size_t n_outputs,


### PR DESCRIPTION
## Problem

Shield transactions (transparent input → Orchard output) broadcast with **"could not validate orchard proof"** from Zebra. Orchard spend-auth and binding signatures were being rejected by the network.

## Root Cause

ZIP-244 §4.9 defines two forms of the transparent digest:

| Form | When used | Contents |
|------|-----------|----------|
| **T.1** (txid form) | Transaction ID, deshield/private | `prevouts \|\| sequences \|\| outputs` |
| **S.2** (sig form) | Orchard sighash in shield txs | `hash_type \|\| prevouts \|\| amounts \|\| scripts \|\| sequences \|\| outputs \|\| empty_txin_hash` |

The firmware was computing **T.1** to verify the sidecar-provided transparent_digest, then using T.1 in the Orchard sighash. Zebra verifies Orchard sigs with **S.2** for any tx with transparent inputs → signatures invalid at the network.

## Fix

Add `zcash_compute_orchard_transparent_sig_digest`:
- `n_inputs == 0` → delegates to T.1 (deshield / private-send, per §4.10b)
- `n_inputs > 0` → computes S.2: `BLAKE2b("ZTxIdTranspaHash", 0x01 || prevouts || amounts || scripts || sequences || outputs || BLAKE2b("Zcash___TxInHash", ""))`

Switch `zcash_finalize_transparent_digest` to use the new function so firmware verifies and signs with the same form Zebra uses.

## Files

- `lib/firmware/zcash.c` — new `zcash_compute_orchard_transparent_sig_digest` function
- `include/keepkey/firmware/zcash.h` — declaration
- `lib/firmware/fsm_msg_zcash.h` — `zcash_finalize_transparent_digest` uses new function
- `lib/firmware/ethereum_contracts/zxappliquid.c` — clang-format cleanup from `make format`

## Test Plan

- [ ] Build kkemu on alpha with this branch
- [ ] Run shield tx (transparent → Orchard) end-to-end: firmware must accept without "Transparent digest mismatch"
- [ ] Broadcast to Zcash mainnet: Zebra must accept without "could not validate orchard proof"
- [ ] Run deshield tx (Orchard → transparent): confirm T.1 path still works (n_inputs == 0 branch)