### PR TITLE
feat(emulator): cross-compile libkkemu.dll for Windows (MinGW-w64)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,13 @@ endif()
 if(${KK_EMULATOR})
   add_definitions(-DEMULATOR)
   add_definitions(-DCONFIDENTIAL=)
+  # macOS/BSD declare strlcpy/strlcat in <string.h>; glibc (Linux) and MinGW
+  # (Windows) do not. Force-include the prototypes so the ~20 call sites build
+  # without -Werror=implicit-function-declaration (definitions come from
+  # lib/board/strlcpy.c + strlcat.c). Apple already has them in <string.h>.
+  if(NOT APPLE)
+    add_compile_options(-include ${CMAKE_SOURCE_DIR}/include/keepkey/board/bsd_compat.h)
+  endif()
 else()
   add_definitions(-DCONFIDENTIAL=__attribute__\(\(section\("confidential"\)\)\))
 endif()

--- a/cmake/toolchains/mingw-w64-x86_64.cmake
+++ b/cmake/toolchains/mingw-w64-x86_64.cmake
@@ -1,0 +1,40 @@
+# MinGW-w64 cross-compile toolchain for the Windows emulator DLL (libkkemu.dll,
+# x86_64). Lets us cross-build the Windows DLL from the existing macOS/Linux
+# emulator build host — no Windows runner required.
+#
+# Usage:
+#   cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/mingw-w64-x86_64.cmake \
+#         -DKK_EMULATOR=ON -DKK_BUILD_DYLIB=ON -DKK_DEBUG_LINK=ON ...
+#   cmake --build <dir> --target kkemulator_dylib
+#
+# Install MinGW: `brew install mingw-w64` (macOS) / `apt-get install mingw-w64`.
+#
+# Only the kkemulator_dylib target is meant to cross-compile. The standalone
+# UDP `kkemu` binary is gated out on Windows (tools/emulator/CMakeLists.txt).
+
+set(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_SYSTEM_PROCESSOR x86_64)
+
+set(TOOLCHAIN_PREFIX x86_64-w64-mingw32)
+find_program(CMAKE_C_COMPILER   NAMES ${TOOLCHAIN_PREFIX}-gcc)
+find_program(CMAKE_CXX_COMPILER NAMES ${TOOLCHAIN_PREFIX}-g++)
+find_program(CMAKE_RC_COMPILER  NAMES ${TOOLCHAIN_PREFIX}-windres)
+
+if(NOT CMAKE_C_COMPILER)
+  message(FATAL_ERROR
+    "${TOOLCHAIN_PREFIX}-gcc not found. Install MinGW-w64 "
+    "(brew install mingw-w64 / apt-get install mingw-w64).")
+endif()
+
+# Derive the target sysroot from the compiler location so this works across
+# Homebrew versions and Linux package layouts.
+get_filename_component(_kk_cc   "${CMAKE_C_COMPILER}" REALPATH)
+get_filename_component(_kk_bin  "${_kk_cc}" DIRECTORY)
+get_filename_component(_kk_root "${_kk_bin}/.." ABSOLUTE)
+set(CMAKE_FIND_ROOT_PATH "${_kk_root}/${TOOLCHAIN_PREFIX}")
+
+# Find host programs on the host; libraries/headers in the target sysroot.
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)

--- a/include/keepkey/board/bsd_compat.h
+++ b/include/keepkey/board/bsd_compat.h
@@ -1,0 +1,28 @@
+#ifndef KEEPKEY_BOARD_BSD_COMPAT_H
+#define KEEPKEY_BOARD_BSD_COMPAT_H
+
+/*
+ * Declarations for BSD libc extensions that macOS/BSD expose via <string.h>
+ * but glibc (Linux) and MinGW (Windows) do not. The emulator build compiles
+ * lib/board/strlcpy.c + strlcat.c when the libc lacks the definitions
+ * (KK_HAVE_STRLCPY / KK_HAVE_STRLCAT), so only the prototypes are missing.
+ *
+ * Force-included for non-Apple emulator builds (see CMakeLists.txt) so every
+ * translation unit sees the prototypes without us having to chase down ~20
+ * call sites — and without touching the real hardware (ARM) build at all.
+ */
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+size_t strlcpy(char *dst, const char *src, size_t siz);
+size_t strlcat(char *dst, const char *src, size_t siz);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* KEEPKEY_BOARD_BSD_COMPAT_H */

--- a/lib/board/timer.c
+++ b/lib/board/timer.c
@@ -26,8 +26,9 @@
 #include <signal.h>
 #include <unistd.h>
 #ifdef _WIN32
-#define WIN32_LEAN_AND_MEAN  /* exclude winsock.h — it declares shutdown(SOCKET,int) */
-#include <windows.h>         /* Sleep() */
+#define WIN32_LEAN_AND_MEAN /* exclude winsock.h — it declares \
+                               shutdown(SOCKET,int) */
+#include <windows.h>        /* Sleep() */
 #endif
 #endif
 
@@ -238,7 +239,8 @@ void timer_init(void) {
   signal(SIGALRM, tim4_sighandler);
   ualarm(1000, 1000);
 #endif
-  /* _WIN32: no SIGALRM/ualarm — libkkemu's kkemu_poll() drives timerisr_usr(). */
+  /* _WIN32: no SIGALRM/ualarm — libkkemu's kkemu_poll() drives timerisr_usr().
+   */
 }
 
 uint32_t fi_defense_delay(volatile uint32_t value) {

--- a/lib/board/timer.c
+++ b/lib/board/timer.c
@@ -25,6 +25,10 @@
 #else
 #include <signal.h>
 #include <unistd.h>
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN  /* exclude winsock.h — it declares shutdown(SOCKET,int) */
+#include <windows.h>         /* Sleep() */
+#endif
 #endif
 
 #include "keepkey/board/keepkey_board.h"
@@ -288,8 +292,21 @@ void delay_us(uint32_t us) {
 void delay_ms(uint32_t ms) {
   remaining_delay = ms;
 
+#ifdef _WIN32
+  /* No async SIGALRM timer on Windows, and kkemu_poll() drives timerisr_usr()
+   * only once per poll — so a plain spin here would never make progress when
+   * delay_ms() is reached from inside usbPoll() (e.g. PIN/U2F/authenticator
+   * flows). Advance the tick ourselves from wall-clock Sleep instead. Keeps
+   * timeSinceWakeup + the runnable queue moving exactly like the SIGALRM path,
+   * and stays single-threaded (no data races). */
+  while (remaining_delay > 0) {
+    Sleep(1);
+    timerisr_usr();
+  }
+#else
   while (remaining_delay > 0) {
   }
+#endif
 }
 
 /*
@@ -311,6 +328,12 @@ void delay_ms_with_callback(uint32_t ms, callback_func_t callback_func,
     if (remaining_delay % frequency_ms == 0) {
       (*callback_func)();
     }
+#ifdef _WIN32
+    /* See delay_ms(): drive the tick from wall-clock Sleep on Windows so this
+     * loop terminates when reached from inside usbPoll(). */
+    Sleep(1);
+    timerisr_usr();
+#endif
   }
 }
 

--- a/lib/board/timer.c
+++ b/lib/board/timer.c
@@ -229,11 +229,12 @@ void timer_init(void) {
   nvic_set_priority(NVIC_TIM4_IRQ, 16 * 2);
 
   timer_enable_counter(TIM4);
-#else
+#elif !defined(_WIN32)
   void tim4_sighandler(int sig);
   signal(SIGALRM, tim4_sighandler);
   ualarm(1000, 1000);
 #endif
+  /* _WIN32: no SIGALRM/ualarm — libkkemu's kkemu_poll() drives timerisr_usr(). */
 }
 
 uint32_t fi_defense_delay(volatile uint32_t value) {
@@ -348,7 +349,7 @@ void timerisr_usr(void) {
 #endif
 }
 
-#ifdef EMULATOR
+#if defined(EMULATOR) && !defined(_WIN32)
 void tim4_sighandler(int sig) { timerisr_usr(); }
 #endif
 

--- a/lib/emulator/libkkemu.c
+++ b/lib/emulator/libkkemu.c
@@ -25,7 +25,8 @@
 #include <string.h>
 #include <errno.h>
 #ifdef _WIN32
-#define WIN32_LEAN_AND_MEAN  /* exclude winsock.h — it declares shutdown(SOCKET,int) */
+#define WIN32_LEAN_AND_MEAN /* exclude winsock.h — it declares \
+                               shutdown(SOCKET,int) */
 #include <windows.h>
 #else
 #include <sys/mman.h>

--- a/lib/emulator/libkkemu.c
+++ b/lib/emulator/libkkemu.c
@@ -24,10 +24,21 @@
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN  /* exclude winsock.h — it declares shutdown(SOCKET,int) */
+#include <windows.h>
+#else
 #include <sys/mman.h>
+#endif
 
 /* Defined in firmware — we just need the declaration */
 extern void fsm_init(void);
+#ifdef _WIN32
+/* On macOS/Linux the firmware's 1ms tick is delivered by a SIGALRM/ualarm
+ * timer (lib/board/timer.c). Windows has neither signal, so we advance the
+ * timer from the host poll loop instead — see kkemu_poll(). */
+extern void timerisr_usr(void);
+#endif
 
 /* ── Ring buffers (replace UDP sockets) ─────────────────────────────── */
 
@@ -151,12 +162,21 @@ int kkemu_init(uint8_t* flash_buf, size_t flash_len) {
    * Production hosts of libkkemu should treat a logged failure as a
    * security warning and refuse to load secrets.
    */
+#ifdef _WIN32
+  if (!VirtualLock(flash_buf, flash_len)) {
+    fprintf(stderr,
+            "[libkkemu] VirtualLock(%zu bytes) failed (err %lu) — flash buffer "
+            "may be paged to disk; do not load production secrets\n",
+            flash_len, (unsigned long)GetLastError());
+  }
+#else
   if (mlock(flash_buf, flash_len) != 0) {
     fprintf(stderr,
             "[libkkemu] mlock(%zu bytes) failed: %s — flash buffer may be "
             "swapped to disk; do not load production secrets\n",
             flash_len, strerror(errno));
   }
+#endif
 
   /* Initialize ring buffers (replaces UDP socket init) */
   libkkemu_socketInit();
@@ -231,7 +251,11 @@ void kkemu_shutdown(void) {
    * want to inspect / persist post-mortem state. Documented contract.
    */
   if (emulator_flash_base) {
+#ifdef _WIN32
+    VirtualUnlock(emulator_flash_base, KKEMU_FLASH_SIZE);
+#else
     munlock(emulator_flash_base, KKEMU_FLASH_SIZE);
+#endif
     emulator_flash_base = NULL;
   }
 
@@ -266,6 +290,13 @@ int kkemu_poll(void) {
    * usbPoll() internally calls emulatorSocketRead() which we've
    * replaced with libkkemu_socketRead() via the ring buffers.
    */
+#ifdef _WIN32
+  /* Advance the firmware millisecond timer (SIGALRM-driven elsewhere). One
+   * tick per poll is coarse — the host polls ~every 16ms — but keeps
+   * delay_ms()/animations progressing. TODO: drive from a wall-clock delta
+   * or a Windows multimedia timer for accurate timing. */
+  timerisr_usr();
+#endif
   usbPoll();
   animate();
   display_refresh();

--- a/lib/emulator/setup.c
+++ b/lib/emulator/setup.c
@@ -22,46 +22,71 @@
 #include "keepkey/rand/rng.h"
 
 #include <errno.h>
-#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN  /* exclude winsock.h — it declares shutdown(SOCKET,int) */
+#include <windows.h>
+#include <bcrypt.h>
+#else
+#include <fcntl.h>
 #include <sys/mman.h>
 #include <unistd.h>
+#endif
 
 #define EMULATOR_FLASH_FILE "emulator.img"
 
-uint32_t __stack_chk_guard;
+/* __stack_chk_guard is defined once in lib/board/keepkey_board.c (as uintptr_t).
+ * It used to be redefined here as uint32_t, which is (a) the wrong size on
+ * 64-bit hosts and (b) a duplicate strong symbol. Apple's ld silently merged
+ * the two; GNU/MinGW ld rejects it ("multiple definition"), which blocked the
+ * Linux .so and Windows .dll builds. Removed — the board copy is canonical. */
 
 static int urandom = -1;
 
 static void setup_urandom(void);
+
+#ifndef _WIN32
 static void setup_flash(void);
 
 void setup(void) {
   setup_urandom();
   setup_flash();
 }
+#endif
 
 /* For libkkemu: init RNG only (flash buffer provided by host) */
 void setup_urandom_only(void) { setup_urandom(); }
 
 void emulatorRandom(void* buffer, size_t size) {
+#ifdef _WIN32
+  /* Windows has no /dev/urandom — use the system CSPRNG. */
+  if (BCryptGenRandom(NULL, (PUCHAR)buffer, (ULONG)size,
+                      BCRYPT_USE_SYSTEM_PREFERRED_RNG) != 0) {
+    fprintf(stderr, "BCryptGenRandom failed\n");
+    exit(1);
+  }
+#else
   ssize_t n = read(urandom, buffer, size);
   if (n < 0 || ((size_t)n) != size) {
     perror("Failed to read /dev/urandom");
     exit(1);
   }
+#endif
 }
 
 static void setup_urandom(void) {
+#ifndef _WIN32
   urandom = open("/dev/urandom", O_RDONLY);
   if (urandom < 0) {
     perror("Failed to open /dev/urandom");
     exit(1);
   }
+#endif
 }
 
+#ifndef _WIN32
 static void setup_flash(void) {
   int fd = open(EMULATOR_FLASH_FILE, O_RDWR | O_SYNC | O_CREAT, 0644);
   if (fd < 0) {
@@ -92,3 +117,4 @@ static void setup_flash(void) {
     memset(emulator_flash_base, 0xff, FLASH_TOTAL_SIZE);
   }
 }
+#endif /* !_WIN32 — setup_flash is standalone-UDP only; the dylib/DLL host owns flash */

--- a/lib/emulator/setup.c
+++ b/lib/emulator/setup.c
@@ -26,7 +26,8 @@
 #include <stdlib.h>
 #include <string.h>
 #ifdef _WIN32
-#define WIN32_LEAN_AND_MEAN  /* exclude winsock.h — it declares shutdown(SOCKET,int) */
+#define WIN32_LEAN_AND_MEAN /* exclude winsock.h — it declares \
+                               shutdown(SOCKET,int) */
 #include <windows.h>
 #include <bcrypt.h>
 #else
@@ -37,11 +38,12 @@
 
 #define EMULATOR_FLASH_FILE "emulator.img"
 
-/* __stack_chk_guard is defined once in lib/board/keepkey_board.c (as uintptr_t).
- * It used to be redefined here as uint32_t, which is (a) the wrong size on
- * 64-bit hosts and (b) a duplicate strong symbol. Apple's ld silently merged
- * the two; GNU/MinGW ld rejects it ("multiple definition"), which blocked the
- * Linux .so and Windows .dll builds. Removed — the board copy is canonical. */
+/* __stack_chk_guard is defined once in lib/board/keepkey_board.c (as
+ * uintptr_t). It used to be redefined here as uint32_t, which is (a) the wrong
+ * size on 64-bit hosts and (b) a duplicate strong symbol. Apple's ld silently
+ * merged the two; GNU/MinGW ld rejects it ("multiple definition"), which
+ * blocked the Linux .so and Windows .dll builds. Removed — the board copy is
+ * canonical. */
 
 static int urandom = -1;
 
@@ -117,4 +119,5 @@ static void setup_flash(void) {
     memset(emulator_flash_base, 0xff, FLASH_TOTAL_SIZE);
   }
 }
-#endif /* !_WIN32 — setup_flash is standalone-UDP only; the dylib/DLL host owns flash */
+#endif /* !_WIN32 — setup_flash is standalone-UDP only; the dylib/DLL host \
+          owns flash */

--- a/lib/emulator/udp.c
+++ b/lib/emulator/udp.c
@@ -17,16 +17,21 @@
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <arpa/inet.h>
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/socket.h>
 
 #ifndef KEEPKEY_UDP_PORT
 #define KEEPKEY_UDP_PORT 11044
 #endif
+
+#ifndef KKEMU_DYLIB
+/* Sockets are only used by the standalone UDP binary. In dylib/DLL mode all
+ * I/O goes through ring buffers (below), so skip the BSD socket headers and
+ * helpers entirely — they don't exist on MinGW/Windows. */
+#include <arpa/inet.h>
+#include <sys/socket.h>
 
 struct usb_socket {
   int fd;
@@ -95,6 +100,7 @@ static size_t socket_read(struct usb_socket* sock, void* buffer, size_t size) {
 
   return n;
 }
+#endif /* !KKEMU_DYLIB — socket helpers are standalone-UDP only */
 
 #ifdef KKEMU_DYLIB
 /*

--- a/lib/firmware/eos.c
+++ b/lib/firmware/eos.c
@@ -534,7 +534,11 @@ bool eos_signTx(EosSignedTx* tx) {
 
   time_t expiry = header.expiration;
   char expiry_str[26];
+#ifdef _WIN32
+  asctime_s(expiry_str, sizeof(expiry_str), gmtime(&expiry));
+#else
   asctime_r(gmtime(&expiry), expiry_str);
+#endif
   expiry_str[24] = 0;  // cut off the '\n'
   uint32_t delay = header.delay_sec;
   if (!confirm(ButtonRequestType_ButtonRequest_SignTx, "Sign Transaction",

--- a/lib/firmware/eos.c
+++ b/lib/firmware/eos.c
@@ -535,6 +535,8 @@ bool eos_signTx(EosSignedTx* tx) {
   time_t expiry = header.expiration;
   char expiry_str[26];
 #ifdef _WIN32
+  // asctime_s is the bounds-checked Windows variant; output truncated below.
+  // cppcheck-suppress asctime_sCalled
   asctime_s(expiry_str, sizeof(expiry_str), gmtime(&expiry));
 #else
   asctime_r(gmtime(&expiry), expiry_str);

--- a/lib/firmware/tiny-json.c
+++ b/lib/firmware/tiny-json.c
@@ -33,7 +33,9 @@
 
 // #include <stdio.h>
 
-int errno = 0;
+/* Renamed from `errno` to avoid colliding with the libc <errno.h> macro on
+ * glibc/MinGW (where errno expands to (*_errno())). Write-only, never read. */
+int json_errno = 0;
 
 /** Structure to handle a heap of JSON properties. */
 typedef struct jsonStaticPool_s {
@@ -73,7 +75,7 @@ static bool isEndOfPrimitive(char ch);
 json_t const* json_createWithPool(char* str, jsonPool_t* pool) {
   char* ptr = goBlank(str);
   if (!ptr || (*ptr != '{' && *ptr != '[')) {
-    errno = -1;
+    json_errno = -1;
     return 0;
   }
   json_t* obj = pool->init(pool);
@@ -82,7 +84,7 @@ json_t const* json_createWithPool(char* str, jsonPool_t* pool) {
   obj->u.c.child = 0;
   ptr = objValue(ptr, obj, pool);
   if (!ptr) {
-    errno = -2;
+    json_errno = -2;
     return 0;
   }
   return obj;

--- a/lib/rand/rng.c
+++ b/lib/rand/rng.c
@@ -28,7 +28,8 @@
 #endif
 
 #ifdef _WIN32
-#define WIN32_LEAN_AND_MEAN  /* exclude winsock.h — it declares shutdown(SOCKET,int) */
+#define WIN32_LEAN_AND_MEAN /* exclude winsock.h — it declares \
+                               shutdown(SOCKET,int) */
 #include <stdlib.h>
 #include <windows.h>
 #include <bcrypt.h>
@@ -88,7 +89,7 @@ uint32_t random32(void) {
   /* Windows has no POSIX random(); use the system CSPRNG (stronger than the
    * macOS/Linux emulator's random() PRNG anyway). Resolves via the bcrypt link
    * on kkemulator_dylib (tools/emulator/CMakeLists.txt). */
-  uint32_t v;
+  uint32_t v = 0;
   if (BCryptGenRandom(NULL, (PUCHAR)&v, (ULONG)sizeof(v),
                       BCRYPT_USE_SYSTEM_PREFERRED_RNG) != 0) {
     abort();
@@ -116,14 +117,14 @@ void random_buffer(uint8_t *buf, size_t len) {
 #endif
 
 // I miss C++ templates sooo bad.
-#define RANDOM_PERMUTE(BUFF, COUNT)           \
-  do {                                        \
-    for (size_t i = (COUNT)-1; i >= 1; i--) { \
-      size_t j = random_uniform(i + 1);       \
-      typeof(*(BUFF)) t = (BUFF)[j];          \
-      (BUFF)[j] = (BUFF)[i];                  \
-      (BUFF)[i] = t;                          \
-    }                                         \
+#define RANDOM_PERMUTE(BUFF, COUNT)             \
+  do {                                          \
+    for (size_t i = (COUNT) - 1; i >= 1; i--) { \
+      size_t j = random_uniform(i + 1);         \
+      typeof(*(BUFF)) t = (BUFF)[j];            \
+      (BUFF)[j] = (BUFF)[i];                    \
+      (BUFF)[i] = t;                            \
+    }                                           \
   } while (0)
 
 void random_permute_char(char *str, size_t len) { RANDOM_PERMUTE(str, len); }

--- a/lib/rand/rng.c
+++ b/lib/rand/rng.c
@@ -27,6 +27,13 @@
 #include <libopencm3/stm32/f2/rng.h>
 #endif
 
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN  /* exclude winsock.h — it declares shutdown(SOCKET,int) */
+#include <stdlib.h>
+#include <windows.h>
+#include <bcrypt.h>
+#endif
+
 void reset_rng(void) {
 #ifndef EMULATOR
   /* disable RNG */
@@ -77,10 +84,36 @@ uint32_t random32(void) {
   }
   last = new;
   return new;
+#elif defined(_WIN32)
+  /* Windows has no POSIX random(); use the system CSPRNG (stronger than the
+   * macOS/Linux emulator's random() PRNG anyway). Resolves via the bcrypt link
+   * on kkemulator_dylib (tools/emulator/CMakeLists.txt). */
+  uint32_t v;
+  if (BCryptGenRandom(NULL, (PUCHAR)&v, (ULONG)sizeof(v),
+                      BCRYPT_USE_SYSTEM_PREFERRED_RNG) != 0) {
+    abort();
+  }
+  return v;
 #else
   return random();
 #endif
 }
+
+#if defined(EMULATOR) && !defined(__APPLE__)
+/* trezor-crypto declares random_buffer() as a weak symbol so platforms can
+ * supply their own. GNU/MinGW ld will NOT extract a weak definition from a
+ * static archive to satisfy a strong reference (fsm.c/reset.c/storage.c),
+ * which breaks the Linux .so and Windows .dll links. Provide a strong
+ * definition here — identical to trezor-crypto's, built on our random32().
+ * macOS ld64 resolves the weak one fine, so it's left untouched there. */
+void random_buffer(uint8_t *buf, size_t len) {
+  uint32_t r = 0;
+  for (size_t i = 0; i < len; i++) {
+    if (i % 4 == 0) r = random32();
+    buf[i] = (r >> ((i % 4) * 8)) & 0xff;
+  }
+}
+#endif
 
 // I miss C++ templates sooo bad.
 #define RANDOM_PERMUTE(BUFF, COUNT)           \

--- a/tools/emulator/CMakeLists.txt
+++ b/tools/emulator/CMakeLists.txt
@@ -42,14 +42,16 @@ if(${KK_EMULATOR})
   if(KK_BUILD_DYLIB)
     if(WIN32)
       # kkrand and trezorcrypto cross-reference each other (random32 /
-      # random_uniform). GNU/MinGW ld resolves archives left-to-right in a
-      # single pass, so wrap FIRMWARE_LIBS in a RESCAN group. macOS ld64 does
-      # multi-pass resolution and needs no group.
+      # random_uniform). GNU/MinGW ld resolves static archives left-to-right in
+      # a single pass, so wrap FIRMWARE_LIBS in a linker group. Use the raw
+      # --start-group/--end-group flags rather than the LINK_GROUP genex: the
+      # genex needs CMake >= 3.24, but this repo's cmake_minimum_required is
+      # 3.7.2. macOS ld64 is multi-pass and needs neither.
       # Also: MinGW exports nothing from a DLL by default (unlike Mach-O/ELF),
       # so export the kkemu_* FFI entry points; and link the Windows CSPRNG
       # (bcrypt, BCryptGenRandom) used by setup.c / rng.c on _WIN32.
-      list(JOIN FIRMWARE_LIBS "," _kk_fw_group)
-      target_link_libraries(kkemulator_dylib "$<LINK_GROUP:RESCAN,${_kk_fw_group}>" bcrypt)
+      target_link_libraries(kkemulator_dylib
+          -Wl,--start-group ${FIRMWARE_LIBS} -Wl,--end-group bcrypt)
       target_link_options(kkemulator_dylib PRIVATE "-Wl,--export-all-symbols")
     else()
       target_link_libraries(kkemulator_dylib ${FIRMWARE_LIBS})

--- a/tools/emulator/CMakeLists.txt
+++ b/tools/emulator/CMakeLists.txt
@@ -21,21 +21,41 @@ if(${KK_EMULATOR})
       SecAESSTM32
       kkrand)
 
-  # Standalone emulator binary (uses UDP sockets)
-  add_executable(kkemu ${sources})
+  # Standalone emulator binary — UDP sockets on :11044/:11045 (used by firmware
+  # CI: python-keepkey UDP tests + OLED screenshots). NOT built on Windows: it
+  # depends on BSD sockets + signal(); the vault never uses it — the vault loads
+  # the dylib/DLL below instead.
+  if(NOT WIN32)
+    add_executable(kkemu ${sources})
 
-  # Add linker flags for ARM64 Mac compatibility
-  if(APPLE AND CMAKE_SYSTEM_PROCESSOR MATCHES "arm64")
-    target_link_options(kkemu PRIVATE "-Wl,-no_fixup_chains")
+    # Add linker flags for ARM64 Mac compatibility
+    if(APPLE AND CMAKE_SYSTEM_PROCESSOR MATCHES "arm64")
+      target_link_options(kkemu PRIVATE "-Wl,-no_fixup_chains")
+    endif()
+
+    target_link_libraries(kkemu ${FIRMWARE_LIBS} kkemulator)
   endif()
 
-  target_link_libraries(kkemu ${FIRMWARE_LIBS} kkemulator)
-
-  # Shared library (ring buffers, no sockets) for in-process FFI (vault)
+  # Shared library (ring buffers, no sockets) for in-process FFI — this is what
+  # the vault loads via bun:ffi (libkkemu.dylib on macOS, .so on Linux, .dll on
+  # Windows).
   if(KK_BUILD_DYLIB)
-    target_link_libraries(kkemulator_dylib ${FIRMWARE_LIBS})
-    if(APPLE AND CMAKE_SYSTEM_PROCESSOR MATCHES "arm64")
-      target_link_options(kkemulator_dylib PRIVATE "-Wl,-no_fixup_chains")
+    if(WIN32)
+      # kkrand and trezorcrypto cross-reference each other (random32 /
+      # random_uniform). GNU/MinGW ld resolves archives left-to-right in a
+      # single pass, so wrap FIRMWARE_LIBS in a RESCAN group. macOS ld64 does
+      # multi-pass resolution and needs no group.
+      # Also: MinGW exports nothing from a DLL by default (unlike Mach-O/ELF),
+      # so export the kkemu_* FFI entry points; and link the Windows CSPRNG
+      # (bcrypt, BCryptGenRandom) used by setup.c / rng.c on _WIN32.
+      list(JOIN FIRMWARE_LIBS "," _kk_fw_group)
+      target_link_libraries(kkemulator_dylib "$<LINK_GROUP:RESCAN,${_kk_fw_group}>" bcrypt)
+      target_link_options(kkemulator_dylib PRIVATE "-Wl,--export-all-symbols")
+    else()
+      target_link_libraries(kkemulator_dylib ${FIRMWARE_LIBS})
+      if(APPLE AND CMAKE_SYSTEM_PROCESSOR MATCHES "arm64")
+        target_link_options(kkemulator_dylib PRIVATE "-Wl,-no_fixup_chains")
+      endif()
     endif()
   endif()
 endif()


### PR DESCRIPTION
## Summary

Builds the in-process FFI emulator library as a **Windows DLL** (`libkkemu.dll`) so the vault can load the emulator on Windows — today it's macOS-only. Cross-compiled from macOS/Linux via **MinGW-w64** (no Windows runner needed); exports the same 8 `kkemu_*` FFI entry points as the dylib.

The standalone **UDP `kkemu` binary** used by firmware CI (python-keepkey UDP tests + OLED screenshots) is untouched and explicitly gated out of the Windows build. Same firmware source, two transports.

## Why these changes

The DLL links the whole firmware core (`kkfirmware`/`kkboard`/`kktransport`/`trezorcrypto`/`SecAESSTM32`), which was written in the GCC dialect for ARM + native clang. Targeting **MinGW-w64 (not MSVC)** keeps the dialect; the remaining gaps are POSIX/BSD libc functions and GNU-ld linkage rules. Every change is guarded (`_WIN32` / `!__APPLE__` / `KKEMU_DYLIB`) so the proven macOS/ARM paths are behavior-neutral. Several fixes also benefit the (currently failing) Linux `.so` build — notably the `__stack_chk_guard` dedup.

### Portability fixes
- **setup.c** — drop the duplicate `__stack_chk_guard` (`keepkey_board.c` owns it; the `uint32_t` copy was wrong-sized on 64-bit and a duplicate strong symbol GNU/MinGW ld rejects); `/dev/urandom`→`BCryptGenRandom`; guard the `mmap` flash-file path (standalone-only, dead in dylib/DLL mode).
- **libkkemu.c** — `mlock/munlock`→`VirtualLock/VirtualUnlock`; drive the 1 ms timer from `kkemu_poll()` (Windows has no `SIGALRM`).
- **timer.c** — guard the `SIGALRM`/`ualarm` emulator timer for `_WIN32`.
- **rng.c** — `random32()` via `BCryptGenRandom` on Windows; provide a **strong** `random_buffer()` (trezor-crypto's is `weak` and GNU/MinGW ld won't extract a weak def for a strong ref).
- **udp.c** — move the BSD-socket helpers under `#ifndef KKEMU_DYLIB` (they sat above the guard; absent on MinGW).
- **eos.c** — `asctime_r`→`asctime_s` on Windows.
- **tiny-json.c** — rename the global `errno` (collided with the libc `errno` macro on glibc/MinGW; write-only, never read).
- **bsd_compat.h** (new) — force-included on non-Apple emulator builds to declare `strlcpy`/`strlcat` (BSD-only prototypes; definitions already compiled in).

### Build wiring
- **cmake/toolchains/mingw-w64-x86_64.cmake** (new) — MinGW-w64 cross toolchain.
- **tools/emulator/CMakeLists.txt** — gate the standalone UDP `kkemu` binary out on Windows; export DLL symbols + link `bcrypt`; `LINK_GROUP RESCAN` around `FIRMWARE_LIBS` (`kkrand`↔`trezorcrypto` are circular; GNU ld is single-pass).

## Test plan
- ✅ `cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/mingw-w64-x86_64.cmake -DKK_EMULATOR=ON -DKK_BUILD_DYLIB=ON -DKK_DEBUG_LINK=ON …` + `cmake --build … --target kkemulator_dylib` → `libkkemu.dll` (**PE32+ x86-64**, ~1.4 MB), all 8 `kkemu_*` exports, deps only UCRT + `bcrypt.dll` + `KERNEL32.dll`.
- ✅ macOS arm64 dylib build re-verified clean (no regression).
- ⬜ Load the DLL from the vault on a Windows machine (vault-side integration is a separate change).

Requires submodules at their pinned SHAs (`deps/crypto/trezor-firmware`, `deps/device-protocol`) — `git submodule update --init --recursive`.