### PR TITLE
fix(emulator): drive firmware ms-timer from kkemu_poll (fix blank OLED at rest)

### DIFF
--- a/lib/emulator/libkkemu.c
+++ b/lib/emulator/libkkemu.c
@@ -34,12 +34,6 @@
 
 /* Defined in firmware — we just need the declaration */
 extern void fsm_init(void);
-#ifdef _WIN32
-/* On macOS/Linux the firmware's 1ms tick is delivered by a SIGALRM/ualarm
- * timer (lib/board/timer.c). Windows has neither signal, so we advance the
- * timer from the host poll loop instead — see kkemu_poll(). */
-extern void timerisr_usr(void);
-#endif
 
 /* ── Ring buffers (replace UDP sockets) ─────────────────────────────── */
 
@@ -62,6 +56,11 @@ static int libkkemu_initialized = 0;
  */
 #define FRAME_PACKED_SIZE 2048
 #define FRAME_RING_SIZE 64
+
+/* Host poll cadence (the vault's setInterval is ~16ms). kkemu_poll() ticks the
+ * firmware ms-timer this many times per call so animations advance at ~real
+ * speed without relying on the (host-runtime-unreliable) SIGALRM timer. */
+#define KKEMU_POLL_INTERVAL_MS 16
 
 static uint8_t frame_ring[FRAME_RING_SIZE][FRAME_PACKED_SIZE];
 static uint8_t last_packed[FRAME_PACKED_SIZE];
@@ -291,13 +290,16 @@ int kkemu_poll(void) {
    * usbPoll() internally calls emulatorSocketRead() which we've
    * replaced with libkkemu_socketRead() via the ring buffers.
    */
-#ifdef _WIN32
-  /* Advance the firmware millisecond timer (SIGALRM-driven elsewhere). One
-   * tick per poll is coarse — the host polls ~every 16ms — but keeps
-   * delay_ms()/animations progressing. TODO: drive from a wall-clock delta
-   * or a Windows multimedia timer for accurate timing. */
-  timerisr_usr();
-#endif
+  /* Drive the firmware millisecond timer from the host poll on EVERY platform.
+   * The dylib is caller-driven; relying on the SIGALRM/ualarm timer (which the
+   * standalone kkemu binary uses) is unreliable inside the host runtime — Bun
+   * does not deliver the firmware's SIGALRM, so animate_flag never flips and
+   * every animation (boot logo, screensaver) stays frozen → a blank OLED at
+   * rest. Tick ~one poll-interval of milliseconds so the periodic animation
+   * runnable fires and animations + delay_ms() advance at roughly real speed.
+   */
+  for (int t = 0; t < KKEMU_POLL_INTERVAL_MS; t++) timerisr_usr();
+
   usbPoll();
   animate();
   display_refresh();


### PR DESCRIPTION
## Summary

The emulator dylib showed a **blank OLED at rest** — only the lock icon + `DEBUG_LINK` watermark, never the KeepKey home logo (and confirm/screensaver animations never rendered either).

**Root cause:** the firmware's animations (boot logo, screensaver) advance only when `animate_flag` is set, which is driven by a 20ms runnable fired off the `SIGALRM`/`ualarm` timer (`lib/board/timer.c`). The standalone `kkemu` binary receives that signal, but **inside the Bun host runtime the dylib's `SIGALRM` is not delivered**, so `animate_flag` never flips and every animation stays frozen on the cleared canvas (just the directly-drawn lock icon + watermark survive).

**Fix:** the dylib is caller-driven, so drive the firmware millisecond timer directly from `kkemu_poll()` on every platform (~one poll-interval of `timerisr_usr()` ticks per call) instead of relying on `SIGALRM`. The periodic animation runnable now fires and `delay_ms()`/animations advance at ~real speed.

This also **supersedes the Windows-only single `timerisr_usr()` tick** added in #249 — all platforms now tick per poll, which fixes frozen animations on Windows too (and the prior 1-tick/poll would have made animations crawl).

## Test plan
- ✅ FFI framebuffer dump (`kkemu_init` + poll + `kkemu_get_display`): center lit pixels went **0 → ~937**, rendering the KeepKey logo, and it persists at rest. Lock icon + watermark intact.
- ✅ `clang-format-20` clean, `cppcheck` (zero-warning) clean.
- ⬜ Live in the vault: rebuild dylib (`make build-emulator`) + restart — home logo shows at rest.

One file: `lib/emulator/libkkemu.c`.