### PR TITLE
fix(emulator): thread-safety of the dylib poll thread

### DIFF
--- a/include/keepkey/emulator/libkkemu.h
+++ b/include/keepkey/emulator/libkkemu.h
@@ -86,20 +86,16 @@ int kkemu_read(uint8_t* buf, size_t len, int iface);
 int kkemu_poll(void);
 
 /**
- * Get the OLED framebuffer (256x64, 1-bit per pixel = 2048 bytes).
+ * Snapshot the current OLED framebuffer (256x64, 1-bit, 2048 bytes) into
+ * internal scratch and return a pointer to it (valid until the next call).
  *
- * This returns a pointer to internal scratch storage containing a snapshot
- * of the current display in packed SSD1306 page format.
+ * WARNING: host-driven mode ONLY. Reads the live canvas with no synchronization
+ * against the poll thread — do NOT call it once kkemu_start() is running. In
+ * thread-driven mode use kkemu_pop_frame() (the lock-free SPSC ring) instead.
+ * Returns NULL if the emulator is not initialized.
  *
  * @param width   Receives 256.
  * @param height  Receives 64.
- * @return Pointer to framebuffer data. The pointer remains valid only until
- *         the next call to kkemu_get_display(), which overwrites the same
- *         scratch buffer. Calling kkemu_poll() may update the emulator's
- *         display state, but it does not refresh previously returned data
- *         in place; call kkemu_get_display() again after kkemu_poll() to
- *         obtain an updated framebuffer snapshot. Returns NULL if emulator
- *         is not initialized.
  */
 const uint8_t* kkemu_get_display(int* width, int* height);
 
@@ -107,14 +103,15 @@ const uint8_t* kkemu_get_display(int* width, int* height);
  * Pop the next captured framebuffer from the display capture ring.
  *
  * Every display_refresh() inside the firmware (including those that fire
- * inside confirm_helper's busy loop within a single kkemu_poll() call)
- * snapshots the canvas into a ring buffer. Adjacent identical frames
- * are deduplicated. This lets the host see intermediate screen states
- * (confirm dialogs, cipher prompts, recovery screens) that would
- * otherwise be invisible — they exist only inside synchronous C calls.
+ * inside confirm_helper's busy loop) snapshots the canvas into a lock-free
+ * SPSC ring. Adjacent identical frames are deduplicated. This is the canonical
+ * way to observe intermediate screen states (confirm dialogs, cipher prompts,
+ * recovery screens) — and the only display path that is safe to call while the
+ * poll thread runs.
  *
  * @param out_packed  Buffer of at least 2048 bytes (256x64, 1-bit packed
- *                    SSD1306 page format — same as kkemu_get_display).
+ *                    SSD1306 page format: byte index = x + (y/8)*256,
+ *                    bit within byte = y%8).
  * @return 1 if a frame was popped, 0 if the ring is empty.
  */
 int kkemu_pop_frame(uint8_t* out_packed);
@@ -147,9 +144,20 @@ void kkemu_stop(void);
  * Bracket a host-side read of the flash buffer (e.g. before encrypting and
  * persisting it) so it can't tear a concurrent storage_commit() on the poll
  * thread. No-op in host-driven mode. Must be balanced with kkemu_unlock().
+ *
+ * kkemu_lock() BLOCKS and must not be used from a host loop that also has to
+ * stay alive to deliver a confirm decision — use kkemu_trylock() there.
  */
 void kkemu_lock(void);
 void kkemu_unlock(void);
+
+/**
+ * Non-blocking acquire of the firmware lock. Returns 1 if acquired (balance
+ * with kkemu_unlock()), 0 if currently held by the poll thread (e.g. during a
+ * pending confirm) — yield the host event loop and retry. Returns 1 as a no-op
+ * when the poll thread isn't running.
+ */
+int kkemu_trylock(void);
 
 #ifdef __cplusplus
 }

--- a/lib/emulator/libkkemu.c
+++ b/lib/emulator/libkkemu.c
@@ -66,7 +66,15 @@ static pthread_t g_poll_thread;
 #define FW_LOCK() pthread_mutex_lock(&g_fw_lock)
 #define FW_UNLOCK() pthread_mutex_unlock(&g_fw_lock)
 #endif
-static volatile int g_poll_running = 0;
+
+/* Cross-thread poll-running flag. _Atomic (not volatile — volatile is not a
+ * synchronization primitive in C): the poll thread reads it each loop while
+ * start/stop write it from the host thread. acquire/release publishes the
+ * surrounding firmware/ring state alongside the flag. */
+#include <stdatomic.h>
+static _Atomic int g_poll_running = 0;
+#define POLL_RUNNING() atomic_load_explicit(&g_poll_running, memory_order_acquire)
+#define POLL_SET(v) atomic_store_explicit(&g_poll_running, (v), memory_order_release)
 
 /* ── Ring buffers (replace UDP sockets) ─────────────────────────────── */
 
@@ -84,8 +92,12 @@ static int libkkemu_initialized = 0;
  * The host drains via kkemu_pop_frame(). Adjacent identical frames are
  * skipped so an idle firmware doesn't spam the ring.
  *
- * Sized for ~4 seconds at 16ms refresh; if the host falls behind the
- * oldest frames are dropped (write advances past read).
+ * Sized for ~4 seconds at 16ms refresh. Cross-thread in thread-driven mode:
+ * the poll thread is the sole producer, the host (kkemu_pop_frame) the sole
+ * consumer — a lock-free SPSC ring with the same atomic discipline as the HID
+ * rings (ringbuf.c). When the ring is full the producer drops the NEW frame
+ * (it must NOT overwrite a slot the consumer may be mid-copy on, and it must
+ * NOT write the consumer-owned read index).
  */
 #define FRAME_PACKED_SIZE 2048
 #define FRAME_RING_SIZE 64
@@ -96,11 +108,11 @@ static int libkkemu_initialized = 0;
 #define KKEMU_POLL_INTERVAL_MS 16
 
 static uint8_t frame_ring[FRAME_RING_SIZE][FRAME_PACKED_SIZE];
-static uint8_t last_packed[FRAME_PACKED_SIZE];
-static int last_packed_valid = 0;
-static uint32_t frame_write_idx =
-    0; /* monotonic, mod FRAME_RING_SIZE for slot */
-static uint32_t frame_read_idx = 0; /* monotonic */
+static uint8_t last_packed[FRAME_PACKED_SIZE];   /* producer-only (poll thread) */
+static int last_packed_valid = 0;                /* producer-only */
+static uint8_t capture_scratch[FRAME_PACKED_SIZE]; /* producer-only pack buffer */
+static _Atomic uint32_t frame_write_idx = 0; /* written by producer ONLY */
+static _Atomic uint32_t frame_read_idx = 0;  /* written by consumer ONLY */
 
 /*
  * Scratch returned by kkemu_get_display(). File-scope (not function-static)
@@ -151,28 +163,38 @@ size_t libkkemu_socketWrite(int iface, const void* buffer, size_t size) {
 static void libkkemu_capture_frame(const uint8_t* canvas_buf) {
   if (!canvas_buf) return;
 
-  uint8_t* slot = frame_ring[frame_write_idx % FRAME_RING_SIZE];
-  memset(slot, 0, FRAME_PACKED_SIZE);
+  /* Pack into a producer-private scratch — NOT a ring slot. When the ring is
+   * full the next write slot still holds an unread frame the consumer may be
+   * copying, so we must decide to publish/drop before touching it. */
+  memset(capture_scratch, 0, FRAME_PACKED_SIZE);
   for (int x = 0; x < 256; x++) {
     for (int y = 0; y < 64; y++) {
       if (canvas_buf[y * 256 + x] > 0) {
-        slot[x + (y / 8) * 256] |= (uint8_t)(1u << (y % 8));
+        capture_scratch[x + (y / 8) * 256] |= (uint8_t)(1u << (y % 8));
       }
     }
   }
 
-  /* Dedup: skip if identical to last captured */
-  if (last_packed_valid && memcmp(slot, last_packed, FRAME_PACKED_SIZE) == 0) {
+  /* Dedup against the last captured frame (producer-only state). */
+  if (last_packed_valid &&
+      memcmp(capture_scratch, last_packed, FRAME_PACKED_SIZE) == 0) {
     return;
   }
-  memcpy(last_packed, slot, FRAME_PACKED_SIZE);
-  last_packed_valid = 1;
 
-  frame_write_idx++;
-  /* Drop oldest if host fell behind */
-  if (frame_write_idx - frame_read_idx > FRAME_RING_SIZE) {
-    frame_read_idx = frame_write_idx - FRAME_RING_SIZE;
-  }
+  /* SPSC publish, drop-on-full (same discipline as ringbuf.c). The producer
+   * writes only frame_write_idx; the consumer writes only frame_read_idx. When
+   * not full, write%SIZE != read%SIZE (their distance is in [1, SIZE-1]), so
+   * producer and consumer never touch the same slot. last_packed is updated
+   * ONLY on a real publish, so a frame dropped while full can still be captured
+   * on a later tick. */
+  uint32_t w = atomic_load_explicit(&frame_write_idx, memory_order_relaxed);
+  uint32_t r = atomic_load_explicit(&frame_read_idx, memory_order_acquire);
+  if (w - r >= FRAME_RING_SIZE) return; /* full → drop the new frame */
+
+  memcpy(frame_ring[w % FRAME_RING_SIZE], capture_scratch, FRAME_PACKED_SIZE);
+  memcpy(last_packed, capture_scratch, FRAME_PACKED_SIZE);
+  last_packed_valid = 1;
+  atomic_store_explicit(&frame_write_idx, w + 1, memory_order_release);
 }
 
 /* ── Public API ─────────────────────────────────────────────────────── */
@@ -278,6 +300,7 @@ void kkemu_shutdown(void) {
   memzero(&rb_debug_out, sizeof(rb_debug_out));
   memzero(frame_ring, sizeof(frame_ring));
   memzero(last_packed, sizeof(last_packed));
+  memzero(capture_scratch, sizeof(capture_scratch));
   memzero(display_packed_scratch, sizeof(display_packed_scratch));
   last_packed_valid = 0;
   frame_write_idx = 0;
@@ -346,7 +369,7 @@ int kkemu_poll(void) {
   /* When the poll thread owns execution, the host must not also poll —
    * that would be two threads driving the single-threaded firmware core.
    * Treat a stray host poll as a no-op rather than a data race. */
-  if (g_poll_running) return 0;
+  if (POLL_RUNNING()) return 0;
   kkemu_poll_body();
   return 0;
 }
@@ -360,15 +383,18 @@ static void kkemu_sleep_ms(int ms) {
 #endif
 }
 
-/* The poll thread holds g_fw_lock across each body call. While confirm_helper
- * busy-waits for a decision the body does not return, so the lock is held for
- * the whole confirm — that is fine: the host delivers the decision through the
- * lock-free rings (no lock needed), and host flash snapshots only happen
- * BETWEEN operations, never during a pending confirm. */
+/* The poll thread holds g_fw_lock across each body call, releasing it during
+ * the inter-poll sleep. While confirm_helper busy-waits for a decision the body
+ * does not return, so the lock stays held for the whole confirm — but that must
+ * NOT block the host: the decision is delivered through the lock-free rings, and
+ * the host acquires the lock for flash snapshots via kkemu_trylock() (which
+ * never blocks the host event loop). The host must never take g_fw_lock with a
+ * blocking call while a confirm may be pending, or it would deadlock against the
+ * very loop that needs the host alive to deliver the decision. */
 static void kkemu_poll_loop(void) {
-  while (g_poll_running) {
+  while (POLL_RUNNING()) {
     FW_LOCK();
-    if (g_poll_running) kkemu_poll_body();
+    if (POLL_RUNNING()) kkemu_poll_body();
     FW_UNLOCK();
     kkemu_sleep_ms(KKEMU_POLL_INTERVAL_MS);
   }
@@ -391,7 +417,15 @@ static void* kkemu_poll_thread_fn(void* arg) {
 /* Push a Cancel (MessageType 20) into the main input ring so a confirm_helper
  * blocked on the poll thread reads it, returns false, and lets the thread exit
  * its loop — otherwise kkemu_stop() would join a thread parked forever waiting
- * for a button decision that will never arrive. */
+ * for a button decision that will never arrive.
+ *
+ * This injected Cancel is the ONLY firmware-side wakeup for a parked confirm
+ * (confirm_helper has no idle timeout in EMULATOR builds), and kkemu_stop()
+ * then joins the thread with no deadline — so a SILENTLY dropped Cancel would
+ * freeze the (single-threaded) host forever, beyond any watchdog's reach. The
+ * push can only fail if rb_main_in is full; the parked confirm drains one input
+ * frame per spin, so a slot frees within ~a poll tick. Retry briefly, and shout
+ * loudly if it somehow never takes rather than dropping it. */
 static void kkemu_inject_cancel(void) {
   uint8_t frame[KKEMU_PACKET_SIZE];
   memset(frame, 0, sizeof(frame));
@@ -401,25 +435,33 @@ static void kkemu_inject_cancel(void) {
   frame[3] = 0x00; /* MessageType_Cancel high */
   frame[4] = 0x14; /* MessageType_Cancel low (20) */
   /* payload length 0 (bytes 5-8 already zero) */
-  ringbuf_push(&rb_main_in, frame, sizeof(frame));
+  for (int i = 0; i < 200; i++) {
+    if (ringbuf_push(&rb_main_in, frame, sizeof(frame))) return;
+    kkemu_sleep_ms(1);
+  }
+  fprintf(stderr,
+          "[libkkemu] FATAL: could not inject Cancel to wake a parked confirm "
+          "before join — rb_main_in stayed full for ~200ms; the poll thread may "
+          "not exit\n");
 }
 
 int kkemu_start(void) {
   if (!libkkemu_initialized) return -1;
-  if (g_poll_running) return 0; /* idempotent */
+  if (POLL_RUNNING()) return 0; /* idempotent */
 
-  g_poll_running = 1;
 #ifdef _WIN32
   InitializeCriticalSection(&g_fw_lock);
+  POLL_SET(1);
   g_poll_thread = CreateThread(NULL, 0, kkemu_poll_thread_fn, NULL, 0, NULL);
   if (!g_poll_thread) {
-    g_poll_running = 0;
+    POLL_SET(0);
     DeleteCriticalSection(&g_fw_lock);
     return -1;
   }
 #else
+  POLL_SET(1);
   if (pthread_create(&g_poll_thread, NULL, kkemu_poll_thread_fn, NULL) != 0) {
-    g_poll_running = 0;
+    POLL_SET(0);
     return -1;
   }
 #endif
@@ -427,9 +469,9 @@ int kkemu_start(void) {
 }
 
 void kkemu_stop(void) {
-  if (!g_poll_running) return;
+  if (!POLL_RUNNING()) return;
 
-  g_poll_running = 0;
+  POLL_SET(0);
   /* Unblock any confirm_helper currently parked on the thread, then join. */
   kkemu_inject_cancel();
 #ifdef _WIN32
@@ -447,25 +489,48 @@ void kkemu_stop(void) {
 /* Host-side guard for reading the shared flash buffer (saveFlash) without
  * tearing a concurrent storage_commit on the poll thread. No-op when the
  * thread isn't running (single-threaded test path needs no lock, and on
- * Windows the CRITICAL_SECTION only exists between start and stop). */
+ * Windows the CRITICAL_SECTION only exists between start and stop).
+ *
+ * WARNING: kkemu_lock() BLOCKS, and the poll thread can hold g_fw_lock for the
+ * whole duration of a pending confirm. The host must therefore NOT call
+ * kkemu_lock() from a thread/loop that also has to stay alive to deliver the
+ * confirm decision (it would deadlock). Use kkemu_trylock() + an event-loop
+ * yield there instead. kkemu_lock() is retained for paths with no pending
+ * confirm. */
 void kkemu_lock(void) {
-  if (g_poll_running) FW_LOCK();
+  if (POLL_RUNNING()) FW_LOCK();
 }
 
 void kkemu_unlock(void) {
-  if (g_poll_running) FW_UNLOCK();
+  if (POLL_RUNNING()) FW_UNLOCK();
 }
 
+/* Non-blocking acquire. Returns 1 if the firmware lock is now held by the
+ * caller (balance with kkemu_unlock()), 0 if it is currently held by the poll
+ * thread (e.g. mid-confirm) — the caller should yield its event loop and retry,
+ * which keeps the loop alive to deliver the decision that releases the lock.
+ * No-op success (returns 1, nothing to unlock) when the thread isn't running. */
+int kkemu_trylock(void) {
+  if (!POLL_RUNNING()) return 1;
+#ifdef _WIN32
+  return TryEnterCriticalSection(&g_fw_lock) ? 1 : 0;
+#else
+  return pthread_mutex_trylock(&g_fw_lock) == 0 ? 1 : 0;
+#endif
+}
+
+/*
+ * Snapshot the current OLED canvas into packed SSD1306 format (byte index =
+ * x + (y/8)*256, bit = y%8). Host-driven convenience used by the python
+ * screenshot harness, which drives the firmware single-threaded via kkemu_poll.
+ *
+ * WARNING: NOT thread-safe. It reads the live firmware canvas directly with no
+ * synchronization against the poll thread, so it is only safe in HOST-DRIVEN
+ * mode (no kkemu_start). In thread-driven mode the canonical, race-free way to
+ * observe the display is the SPSC capture ring via kkemu_pop_frame(); do not
+ * wire kkemu_get_display into a threaded host.
+ */
 const uint8_t* kkemu_get_display(int* width, int* height) {
-  /*
-   * Pack the firmware's 8-bpp grayscale canvas (256×64 = 16384 bytes) into
-   * the 1-bit packed layout vault expects (2048 bytes). Same format
-   * DebugLinkGetState.layout uses: byte index = x + (y/8)*256,
-   * bit within byte = y%8 (LSB = top row of the 8-pixel column).
-   *
-   * Output goes into the file-scope `display_packed_scratch` so
-   * kkemu_shutdown() can zero it on teardown alongside the frame ring.
-   */
   if (!libkkemu_initialized) {
     if (width) *width = 0;
     if (height) *height = 0;
@@ -495,10 +560,13 @@ const uint8_t* kkemu_get_display(int* width, int* height) {
 
 int kkemu_pop_frame(uint8_t* out_packed) {
   if (!libkkemu_initialized || !out_packed) return 0;
-  if (frame_read_idx == frame_write_idx) return 0;
-  const uint8_t* slot = frame_ring[frame_read_idx % FRAME_RING_SIZE];
-  memcpy(out_packed, slot, FRAME_PACKED_SIZE);
-  frame_read_idx++;
+  /* SPSC consume: read frame_read_idx (we own it) and frame_write_idx (acquire,
+   * to see the producer's slot write). Empty when the indices are equal. */
+  uint32_t r = atomic_load_explicit(&frame_read_idx, memory_order_relaxed);
+  uint32_t w = atomic_load_explicit(&frame_write_idx, memory_order_acquire);
+  if (r == w) return 0;
+  memcpy(out_packed, frame_ring[r % FRAME_RING_SIZE], FRAME_PACKED_SIZE);
+  atomic_store_explicit(&frame_read_idx, r + 1, memory_order_release);
   return 1;
 }
 


### PR DESCRIPTION
## Thread-safety follow-up to #251 (poll-thread / screen-first confirm gating)

A concurrency review of #251 found three real races introduced when the dylib gained the poll thread. This fixes all three, plus a robustness gap and a dead-code race trap.

### Fixes
- **Frame ring (data race).** The display capture ring (`frame_ring`/`frame_write_idx`/`frame_read_idx`/`last_packed`) was cross-thread but plain, and `frame_read_idx` was written by **both** threads. Now a true lock-free SPSC like the HID rings (`ringbuf.c`): `_Atomic` indices, producer writes `write_idx` only / consumer writes `read_idx` only, **drop-on-full**, producer packs into a private scratch. When not full, producer/consumer slots are provably disjoint (distance in `[1, SIZE-1]`).
- **`g_poll_running` (data race).** `volatile int` → `_Atomic int` with acquire/release at every read (poll loop, `kkemu_poll`, lock/unlock) and write (start/stop). `volatile` is not C thread synchronization.
- **Save deadlock.** Added non-blocking `kkemu_trylock()`. The poll thread holds the flash lock across a pending confirm, so a *blocking* host lock would deadlock against the loop that must stay alive to deliver the decision. The host (vault) now uses `trylock` + an event-loop yield. (See the vault PR.)
- **`kkemu_inject_cancel` robustness.** It ignored `ringbuf_push`'s return on the **only** path that wakes a confirm parked on the poll thread before `kkemu_stop`'s `pthread_join(INFINITE)`. A dropped Cancel → the join freezes the host forever. Now bounded-retries the push and logs loudly on failure.
- **Retire `kkemu_get_display`.** Zero callers anywhere; it reads the canvas buffer unsynchronized w.r.t. the poll thread — a latent race trap. Removed (the SPSC frame ring via `kkemu_pop_frame` is the canonical, race-free display path).

### Safety
`confirm_sm.c` and the shared firmware core are untouched; `libkkemu.c` compiles only into the dylib. Real-hardware signing is byte-identical.

### Test
- `make test-emu` (vault) → **30/30**, incl. a new `08-thread-safety.test.ts`: proves the save-during-confirm path does **not** deadlock (the save waited ~400ms through a held confirm, then acquired) and drains the frame ring cross-thread under load with 0 malformed frames.