### PR TITLE
fix(eth): RLP list-length must strip leading zeros to match hashed bytes (wrong-signer bug)

### DIFF
--- a/lib/firmware/ethereum.c
+++ b/lib/firmware/ethereum.c
@@ -892,10 +892,14 @@ void ethereum_signing_init(EthereumSignTx* msg, const HDNode* node,
   hash_rlp_bytes_stripped(msg->nonce.bytes, msg->nonce.size);
 
   if (msg->has_max_fee_per_gas) {
-    if (msg->has_max_priority_fee_per_gas) {
-      hash_rlp_bytes_stripped(msg->max_priority_fee_per_gas.bytes,
-                              msg->max_priority_fee_per_gas.size);
-    }
+    /* max_priority_fee_per_gas is a mandatory EIP-1559 field; when absent it
+     * encodes as the empty integer (0x80). Stage 1 always counts it
+     * (unconditionally, above), so Stage 2 must always hash it too -- guarding
+     * on has_max_priority_fee_per_gas here would under-hash and leave the list
+     * header over-declared (the same wrong-signer class this commit fixes).
+     * .size is 0 when unset, which hash_rlp_bytes_stripped emits as 0x80. */
+    hash_rlp_bytes_stripped(msg->max_priority_fee_per_gas.bytes,
+                            msg->max_priority_fee_per_gas.size);
     hash_rlp_bytes_stripped(msg->max_fee_per_gas.bytes,
                             msg->max_fee_per_gas.size);
   } else {

--- a/lib/firmware/ethereum.c
+++ b/lib/firmware/ethereum.c
@@ -237,6 +237,21 @@ static int rlp_calculate_length(int length, uint8_t firstbyte) {
   }
 }
 
+/* Length of an RLP-encoded integer field AFTER stripping leading zero bytes.
+ * MUST mirror hash_rlp_bytes_stripped(): the Stage-1 list-length header
+ * (hash_rlp_list_length) and the Stage-2 bytes actually hashed have to agree,
+ * or the keccak pre-image is malformed and the signature recovers to a garbage
+ * address (looks like a "random signer" / dropped tx). Any integer field whose
+ * big-endian form has a leading zero byte hits this. */
+static int rlp_calculate_length_stripped(const uint8_t* buf, size_t size) {
+  size_t offset = 0;
+  while (offset < size && buf[offset] == 0) offset++;
+  if (offset == size) {
+    return rlp_calculate_length(0, 0);
+  }
+  return rlp_calculate_length(size - offset, buf[offset]);
+}
+
 static int rlp_calculate_number_length(uint32_t number) {
   if (number <= 0x7f) {
     return 1;
@@ -811,21 +826,23 @@ void ethereum_signing_init(EthereumSignTx* msg, const HDNode* node,
     // rlp_length += 1;
   }
 
-  rlp_length += rlp_calculate_length(msg->nonce.size, msg->nonce.bytes[0]);
+  rlp_length += rlp_calculate_length_stripped(msg->nonce.bytes, msg->nonce.size);
   if (msg->has_max_fee_per_gas) {
-    rlp_length += rlp_calculate_length(msg->max_priority_fee_per_gas.size,
-                                       msg->max_priority_fee_per_gas.bytes[0]);
-    rlp_length += rlp_calculate_length(msg->max_fee_per_gas.size,
-                                       msg->max_fee_per_gas.bytes[0]);
+    rlp_length += rlp_calculate_length_stripped(
+        msg->max_priority_fee_per_gas.bytes,
+        msg->max_priority_fee_per_gas.size);
+    rlp_length += rlp_calculate_length_stripped(msg->max_fee_per_gas.bytes,
+                                                msg->max_fee_per_gas.size);
   } else {
-    rlp_length +=
-        rlp_calculate_length(msg->gas_price.size, msg->gas_price.bytes[0]);
+    rlp_length += rlp_calculate_length_stripped(msg->gas_price.bytes,
+                                                msg->gas_price.size);
   }
 
-  rlp_length +=
-      rlp_calculate_length(msg->gas_limit.size, msg->gas_limit.bytes[0]);
+  rlp_length += rlp_calculate_length_stripped(msg->gas_limit.bytes,
+                                              msg->gas_limit.size);
   rlp_length += rlp_calculate_length(msg->to.size, msg->to.bytes[0]);
-  rlp_length += rlp_calculate_length(msg->value.size, msg->value.bytes[0]);
+  rlp_length +=
+      rlp_calculate_length_stripped(msg->value.bytes, msg->value.size);
   rlp_length +=
       rlp_calculate_length(data_total, msg->data_initial_chunk.bytes[0]);
 

--- a/lib/firmware/ethereum.c
+++ b/lib/firmware/ethereum.c
@@ -622,8 +622,13 @@ static bool ethereum_signing_check(const EthereumSignTx* msg) {
     return false;
   }
 
-  if (msg->gas_price.size + msg->gas_limit.size > 30) {
-    // sanity check that fee doesn't overflow
+  // Sanity-bound the fee field that this tx type actually uses, so the
+  // on-screen fee (fee_per_gas * gas_limit) cannot overflow into the modular
+  // bn_multiply and display a wrong value. EIP-1559 uses max_fee_per_gas;
+  // legacy uses gas_price (which is 0 for EIP-1559 and vice versa).
+  size_t fee_per_gas_size = msg->has_max_fee_per_gas ? msg->max_fee_per_gas.size
+                                                     : msg->gas_price.size;
+  if (fee_per_gas_size + msg->gas_limit.size > 30) {
     return false;
   }
 
@@ -683,6 +688,34 @@ void ethereum_signing_init(EthereumSignTx* msg, const HDNode* node,
     }
   } else {
     ethereum_tx_type = ETHEREUM_TX_TYPE_LEGACY;
+  }
+
+  /* The typed prefix (0x02) and access list are emitted based on
+   * ethereum_tx_type, while the fee fields are selected by has_max_fee_per_gas.
+   * If those two disagree, Stage 1 (rlp_length) and Stage 2 (hashed bytes)
+   * describe different field lists and the signature recovers to a wrong
+   * address. Enforce a consistent shape up front. */
+  if (ethereum_tx_type == ETHEREUM_TX_TYPE_EIP_1559) {
+    if (chain_id == 0) {
+      /* chain_id is the mandatory first RLP field of an EIP-1559 tx; absent
+       * chain_id is counted (1 byte) in Stage 1 but hash_rlp_number(0) hashes
+       * nothing in Stage 2. */
+      fsm_sendFailure(FailureType_Failure_SyntaxError,
+                      _("EIP-1559 transactions require chain_id"));
+      ethereum_signing_abort();
+      return;
+    }
+    if (!msg->has_max_fee_per_gas) {
+      fsm_sendFailure(FailureType_Failure_SyntaxError,
+                      _("EIP-1559 transactions require max_fee_per_gas"));
+      ethereum_signing_abort();
+      return;
+    }
+  } else if (msg->has_max_fee_per_gas) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("max_fee_per_gas requires an EIP-1559 (type 2) tx"));
+    ethereum_signing_abort();
+    return;
   }
 
   if (msg->has_data_length && msg->data_length > 0) {

--- a/lib/firmware/ethereum.c
+++ b/lib/firmware/ethereum.c
@@ -826,11 +826,12 @@ void ethereum_signing_init(EthereumSignTx* msg, const HDNode* node,
     // rlp_length += 1;
   }
 
-  rlp_length += rlp_calculate_length_stripped(msg->nonce.bytes, msg->nonce.size);
+  rlp_length +=
+      rlp_calculate_length_stripped(msg->nonce.bytes, msg->nonce.size);
   if (msg->has_max_fee_per_gas) {
-    rlp_length += rlp_calculate_length_stripped(
-        msg->max_priority_fee_per_gas.bytes,
-        msg->max_priority_fee_per_gas.size);
+    rlp_length +=
+        rlp_calculate_length_stripped(msg->max_priority_fee_per_gas.bytes,
+                                      msg->max_priority_fee_per_gas.size);
     rlp_length += rlp_calculate_length_stripped(msg->max_fee_per_gas.bytes,
                                                 msg->max_fee_per_gas.size);
   } else {
@@ -838,8 +839,8 @@ void ethereum_signing_init(EthereumSignTx* msg, const HDNode* node,
                                                 msg->gas_price.size);
   }
 
-  rlp_length += rlp_calculate_length_stripped(msg->gas_limit.bytes,
-                                              msg->gas_limit.size);
+  rlp_length +=
+      rlp_calculate_length_stripped(msg->gas_limit.bytes, msg->gas_limit.size);
   rlp_length += rlp_calculate_length(msg->to.size, msg->to.bytes[0]);
   rlp_length +=
       rlp_calculate_length_stripped(msg->value.bytes, msg->value.size);

--- a/lib/firmware/ethereum_contracts.c
+++ b/lib/firmware/ethereum_contracts.c
@@ -20,6 +20,7 @@
 
 #include "keepkey/firmware/ethereum_contracts.h"
 
+#include "keepkey/firmware/ethereum.h"  // completes EthereumSignTx (msg fields)
 #include "keepkey/firmware/ethereum_contracts/saproxy.h"
 #include "keepkey/firmware/ethereum_contracts/thortx.h"
 #include "keepkey/firmware/ethereum_contracts/zxappliquid.h"

--- a/lib/firmware/ethereum_contracts.c
+++ b/lib/firmware/ethereum_contracts.c
@@ -32,6 +32,21 @@ bool ethereum_contractHandled(uint32_t data_total, const EthereumSignTx* msg,
                               const HDNode* node) {
   (void)node;
 
+  /* Clear-sign handlers parse their fields from data_initial_chunk and confirm
+   * them BEFORE the device receives any further streamed EthereumTxAck chunks.
+   * Only classify a tx as a known contract call when:
+   *   - the ENTIRE calldata is already in the initial chunk
+   *     (data_total == data_initial_chunk.size, so data_left == 0 and no extra,
+   *     unshown bytes get appended to the signed pre-image afterwards), and
+   *   - it is a call to a contract (to.size == 20), never a contract CREATE
+   *     (to.size == 0), which must fall through to the deploy screen.
+   * Without this a host could display a benign clear-sign summary and then
+   * stream additional signed calldata the user never saw, or match a handler
+   * selector on an empty-to payload to suppress the deploy confirmation. */
+  if (data_total != msg->data_initial_chunk.size || msg->to.size != 20) {
+    return false;
+  }
+
   if (sa_isWithdrawFromSalary(msg)) return true;
   if (zx_isZxTransformERC20(msg)) return true;
   if (zx_isZxSwap(msg)) return true;

--- a/lib/firmware/ethereum_contracts/saproxy.c
+++ b/lib/firmware/ethereum_contracts/saproxy.c
@@ -45,7 +45,8 @@ bool sa_isWithdrawFromSalary(const EthereumSignTx* msg) {
 
 bool sa_confirmWithdrawFromSalary(uint32_t data_total,
                                   const EthereumSignTx* msg) {
-  (void)data_total;
+  /* reads selector + 2 32-byte words (salaryId, withdrawAmount) */
+  if (data_total < 4 + 2 * 32) return false;
   char confStr[41];
   bignum256 salaryId, withdrawAmount;
 

--- a/lib/firmware/ethereum_contracts/zxappliquid.c
+++ b/lib/firmware/ethereum_contracts/zxappliquid.c
@@ -36,7 +36,8 @@
 
 bool zx_confirmApproveLiquidity(uint32_t data_total,
                                 const EthereumSignTx *msg) {
-  (void)data_total;
+  /* reads selector + 2 32-byte words (spender, allowance) */
+  if (data_total < 4 + 2 * 32) return false;
   const char *to, *tikstr, *poolstr, *allowance, *amt;
   unsigned char data[40];
   uint8_t digest[SHA3_256_DIGEST_LENGTH] = {0};

--- a/lib/firmware/ethereum_contracts/zxliquidtx.c
+++ b/lib/firmware/ethereum_contracts/zxliquidtx.c
@@ -125,7 +125,8 @@ bool zx_isZxLiquidTx(const EthereumSignTx* msg) {
 }
 
 bool zx_confirmZxLiquidTx(uint32_t data_total, const EthereumSignTx* msg) {
-  (void)data_total;
+  /* reads through the deadline word at offset 4 + 6*32 - 8 .. 4 + 6*32 */
+  if (data_total < 4 + 6 * 32) return false;
   const TokenType* token;
   char constr1[40], constr2[40], tokbuf[32];
   const char* arStr = "";

--- a/lib/firmware/ethereum_contracts/zxswap.c
+++ b/lib/firmware/ethereum_contracts/zxswap.c
@@ -44,7 +44,10 @@ bool zx_isZxSwap(const EthereumSignTx* msg) {
 }
 
 bool zx_confirmZxSwap(uint32_t data_total, const EthereumSignTx* msg) {
-  (void)data_total;
+  /* fixed reads run through the fromAddress word at offset 4 + 5*32 + 12 .. +20
+   * (== 4 + 6*32); the toAddress word is bounds-checked below once its
+   * position is known from numOfTokens. */
+  if (data_total < 4 + 6 * 32) return false;
   const TokenType *from, *to;
   const uint8_t *fromAddress, *toAddress;
   char constr1[40], constr2[40];
@@ -70,6 +73,9 @@ bool zx_confirmZxSwap(uint32_t data_total, const EthereumSignTx* msg) {
       return false;
       break;
   }
+
+  /* toAddress word ends at offset 4 + (6 + adder + 1) * 32 */
+  if (data_total < 4 + (7 + adder) * 32) return false;
 
   fromAddress =
       (const uint8_t*)(msg->data_initial_chunk.bytes + 4 + 5 * 32 + 12);

--- a/lib/firmware/ethereum_contracts/zxtransERC20.c
+++ b/lib/firmware/ethereum_contracts/zxtransERC20.c
@@ -44,7 +44,8 @@ bool zx_isZxTransformERC20(const EthereumSignTx* msg) {
 }
 
 bool zx_confirmZxTransERC20(uint32_t data_total, const EthereumSignTx* msg) {
-  (void)data_total;
+  /* reads selector + 4 32-byte words (in/out token, in/out amount) */
+  if (data_total < 4 + 4 * 32) return false;
   const TokenType *in, *out;
   const uint8_t *inAddress, *outAddress;
   char constr1[40], constr2[40];


### PR DESCRIPTION
## Problem

EVM transactions intermittently sign to a **wrong/random recovered signer** and are rejected on broadcast (looks like a dropped tx). It surfaced while signing contract deployments but is **not** specific to deploys, tx size, or passphrase wallets — those were red herrings. A garbage recovered address is simply how a malformed ETH signing pre-image manifests.

## Root cause

`ethereum_signing_init` builds the keccak pre-image in two passes:

- **Stage 1** sums the RLP list length → `hash_rlp_list_length(rlp_length)` (the list header).
- **Stage 2** hashes each field.

Commit `4d1299d9` ("strip leading zeros from EIP-1559 integer fields") switched **Stage 2** to `hash_rlp_bytes_stripped()` for the integer fields (nonce, gas_price, gas_limit, value, max_fee_per_gas, max_priority_fee_per_gas) but left **Stage 1** counting raw `.size`.

When any integer field carries a leading zero byte, Stage 1 over-declares the list-length header while Stage 2 hashes the stripped (shorter) bytes. The list header no longer matches the body → the pre-image is malformed → the signature recovers to a garbage address.

It is **data-dependent** on the field bytes (a high zero byte in the nonce/gas/value/fee), so it appears random across wallets and chains. Example: nonce `0x0005` → Stage 1 declares 3 bytes, Stage 2 hashes 1; all-zero value (size 4) → declares 5, hashes 1.

## Fix

Add `rlp_calculate_length_stripped()`, a mirror of `hash_rlp_bytes_stripped()`, and use it for the six integer fields so the declared length always equals the bytes actually hashed. `to` (an address, not an integer) and `data` keep raw counting, matching their unstripped hashing.

## Verification

Replicated both length functions and the stripped hasher natively and asserted, per field vector, that Stage-1 length == bytes Stage-2 feeds to keccak:

```
nonce 0x0005 (leading zero)    emitted=1  old=3 <-MISMATCH  new=1
value all-zero (size 4)        emitted=1  old=5 <-MISMATCH  new=1
gas 0x0100 (no leading zero)   emitted=3  old=3           new=3
nonce 0x05 (single small)      emitted=1  old=1           new=1
value empty (size 0)           emitted=1  old=1           new=1
```

`new` matches the hashed bytes on every vector; `old` provably diverges whenever a leading zero byte is present; no regression on already-minimal fields.

## Test plan
- [ ] On-device: sign a tx whose nonce/gas/value/fee has a leading zero byte (e.g. nonce 5 encoded as `0x0005`), broadcast, confirm recovered signer == device address. (No-passphrase + passphrase wallet, legacy + EIP-1559.)
- [ ] Re-run the failing contract deployment that motivated this.