### PR TITLE
feat(eth): clear-signing screen for contract deployments

### DIFF
--- a/lib/firmware/ethereum.c
+++ b/lib/firmware/ethereum.c
@@ -497,6 +497,85 @@ static void layoutEthereumConfirmTx(const uint8_t* to, uint32_t to_len,
   }
 }
 
+/* Compute the address a CREATE (contract-deployment) tx will deploy to:
+ * keccak256(rlp([sender, nonce]))[12:32]. Depends only on sender + nonce, both
+ * known at confirm time, so it works even when the init code is streamed in
+ * later chunks. The nonce is RLP-encoded as an integer (leading zeros
+ * stripped); payload is at most 1 + 20 + 1 + 32 = 54 bytes, so the list always
+ * fits a single-byte 0xc0+len header. */
+static bool ethereum_creation_address(const HDNode* node, const uint8_t* nonce,
+                                      size_t nonce_size, uint8_t out_addr[20]) {
+  uint8_t sender[20];
+  if (!hdnode_get_ethereum_pubkeyhash(node, sender)) {
+    return false;
+  }
+
+  size_t off = 0;
+  while (off < nonce_size && nonce[off] == 0) off++;  // strip leading zeros
+
+  /* rlp([sender, nonce]): reserve rlp[0] for the list header, fill the payload
+   * from index 1, then back-fill the header from the bytes actually written
+   * (payload is at most 1 + 20 + 1 + 32 = 54, so a single-byte 0xc0+len). */
+  uint8_t rlp[1 + 1 + 20 + 1 + 32];
+  size_t p = 1;
+  rlp[p++] = 0x80 + 20; /* 0x94 address header */
+  memcpy(rlp + p, sender, 20);
+  p += 20;
+  if (off == nonce_size) {
+    rlp[p++] = 0x80; /* empty integer (nonce 0) */
+  } else if (nonce_size - off == 1 && nonce[off] <= 0x7f) {
+    rlp[p++] = nonce[off]; /* single small byte, no header */
+  } else {
+    size_t len = nonce_size - off;
+    if (len > 32) len = 32; /* a uint256 nonce never exceeds this */
+    rlp[p++] = 0x80 + (uint8_t)len;
+    memcpy(rlp + p, nonce + off, len);
+    p += len;
+  }
+  rlp[0] = 0xc0 + (uint8_t)(p - 1); /* list header = payload length */
+
+  uint8_t hash[32];
+  struct SHA3_CTX ctx;
+  sha3_256_Init(&ctx);
+  sha3_Update(&ctx, rlp, p);
+  keccak_Final(&ctx, hash);
+  memcpy(out_addr, hash + 12, 20);
+  return true;
+}
+
+/* Dedicated clear-signing screen for contract deployments (empty `to`):
+ * shows the deterministic deployment address and the init-code size instead of
+ * the generic "Send <amount> to new contract?". */
+static void layoutEthereumDeploy(const uint8_t* contract_addr,
+                                 const uint8_t* value, uint32_t value_len,
+                                 uint32_t code_len, char* out_str,
+                                 size_t out_str_len) {
+  char addr[43] = "0x";
+  ethereum_address_checksum(contract_addr, addr + 2, false, chain_id);
+
+  bignum256 val;
+  uint8_t pad_val[32];
+  memset(pad_val, 0, sizeof(pad_val));
+  memcpy(pad_val + (32 - value_len), value, value_len);
+  bn_read_be(pad_val, &val);
+
+  int cx;
+  if (bn_is_zero(&val)) {
+    cx = snprintf(out_str, out_str_len, "Deploy %lu-byte contract to %s?",
+                  (unsigned long)code_len, addr);
+  } else {
+    char amount[32];
+    ethereumFormatAmount(&val, NULL, chain_id, amount, sizeof(amount));
+    cx = snprintf(out_str, out_str_len,
+                  "Deploy %lu-byte contract (sending %s) to %s?",
+                  (unsigned long)code_len, amount, addr);
+  }
+  if (out_str_len <= (size_t)cx) {
+    /*error detected. Clear the buffer */
+    memset(out_str, 0, out_str_len);
+  }
+}
+
 static void layoutEthereumData(const uint8_t* data, uint32_t len,
                                uint32_t total_len, char* out_str,
                                size_t out_str_len) {
@@ -816,34 +895,58 @@ void ethereum_signing_init(EthereumSignTx* msg, const HDNode* node,
   }
 
   if (needs_confirm) {
-    if (token != NULL) {
-      layoutEthereumConfirmTx(
-          msg->data_initial_chunk.bytes + 16, 20,
-          msg->data_initial_chunk.bytes + 36, 32, token, confirm_body_message,
-          sizeof(confirm_body_message), /*approve=*/is_approve);
+    if (msg->to.size == 0) {
+      /* contract deployment: dedicated clear-signing screen showing the
+       * deterministic deployment address (sender + nonce) and code size. */
+      uint8_t contract_addr[20];
+      if (!ethereum_creation_address(node, msg->nonce.bytes, msg->nonce.size,
+                                     contract_addr)) {
+        fsm_sendFailure(FailureType_Failure_Other,
+                        _("Failed to derive contract address"));
+        ethereum_signing_abort();
+        return;
+      }
+      layoutEthereumDeploy(contract_addr, msg->value.bytes, msg->value.size,
+                           data_total, confirm_body_message,
+                           sizeof(confirm_body_message));
+      if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
+                   "Deploy Contract", "%s", confirm_body_message)) {
+        fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                        "Signing cancelled by user");
+        ethereum_signing_abort();
+        return;
+      }
     } else {
-      layoutEthereumConfirmTx(msg->to.bytes, msg->to.size, msg->value.bytes,
-                              msg->value.size, NULL, confirm_body_message,
-                              sizeof(confirm_body_message), /*approve=*/false);
-    }
-    bool is_transfer = msg->address_type == OutputAddressType_TRANSFER;
-    const char* title;
-    ButtonRequestType BRT;
-    if (is_approve) {
-      title = "Approve";
-      BRT = ButtonRequestType_ButtonRequest_ConfirmOutput;
-    } else if (is_transfer) {
-      title = "Transfer";
-      BRT = ButtonRequestType_ButtonRequest_ConfirmTransferToAccount;
-    } else {
-      title = "Send";
-      BRT = ButtonRequestType_ButtonRequest_ConfirmOutput;
-    }
-    if (!confirm(BRT, title, "%s", confirm_body_message)) {
-      fsm_sendFailure(FailureType_Failure_ActionCancelled,
-                      "Signing cancelled by user");
-      ethereum_signing_abort();
-      return;
+      if (token != NULL) {
+        layoutEthereumConfirmTx(
+            msg->data_initial_chunk.bytes + 16, 20,
+            msg->data_initial_chunk.bytes + 36, 32, token, confirm_body_message,
+            sizeof(confirm_body_message), /*approve=*/is_approve);
+      } else {
+        layoutEthereumConfirmTx(msg->to.bytes, msg->to.size, msg->value.bytes,
+                                msg->value.size, NULL, confirm_body_message,
+                                sizeof(confirm_body_message),
+                                /*approve=*/false);
+      }
+      bool is_transfer = msg->address_type == OutputAddressType_TRANSFER;
+      const char* title;
+      ButtonRequestType BRT;
+      if (is_approve) {
+        title = "Approve";
+        BRT = ButtonRequestType_ButtonRequest_ConfirmOutput;
+      } else if (is_transfer) {
+        title = "Transfer";
+        BRT = ButtonRequestType_ButtonRequest_ConfirmTransferToAccount;
+      } else {
+        title = "Send";
+        BRT = ButtonRequestType_ButtonRequest_ConfirmOutput;
+      }
+      if (!confirm(BRT, title, "%s", confirm_body_message)) {
+        fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                        "Signing cancelled by user");
+        ethereum_signing_abort();
+        return;
+      }
     }
   }
 


### PR DESCRIPTION
## What

Contract-deployment txs (empty `to`) currently fall through to the generic confirm string **"Send <amount> to new contract?"** — which tells the user nothing about *what* they're deploying or *where*.

This adds a dedicated **"Deploy Contract"** confirmation that shows:
- the **deterministic deployment address** — `keccak256(rlp([sender, nonce]))[12:32]`,
- the **init-code size** in bytes,
- the **value** sent to the constructor, if non-zero.

## Why the address works at confirm time

The CREATE address depends only on **sender + nonce**, both known when we render the confirm screen. It does **not** depend on the init code, so it's correct even for large contracts whose code is streamed in later chunks (the device confirms before all chunks arrive). A full-init-code hash is *not* available at confirm time without buffering every chunk first, so the address is the right, attainable verification primitive.

## How

- `ethereum_creation_address()` builds the RLP pre-image `rlp([sender(20), nonce])` (nonce stripped to a minimal integer; payload ≤ 54 bytes, so the list always fits a single-byte `0xc0+len` header) and keccaks it.
- `layoutEthereumDeploy()` formats the screen.
- Wired as the first branch of the `needs_confirm` block when `msg->to.size == 0`. The existing arbitrary-data warning + raw-data hex confirm still follow for byte-level inspection.

**Display-only — does not change the bytes that get signed.** Independent of the signing-correctness fix in #255.

## Verification

The only hand-rolled crypto is the RLP pre-image; `keccak256[12:]` is a trusted lib primitive. Asserted the RLP bytes against canonical Ethereum CREATE vectors (sender `0x6ac7ea33f8831ea9dcc53393aaa88b25a785dbf0`):

```
nonce 0      -> d6 94 <addr> 80   (the documented first-deploy pre-image)
nonce 1      -> d6 94 <addr> 01
nonce 0x0005 -> d6 94 <addr> 05   (leading-zero input stripped)
nonce 256    -> d8 94 <addr> 82 01 00
PASS
```

## Test plan
- [ ] On-device: deploy a contract; confirm the displayed address matches the address the tx actually creates after broadcast (sender + nonce).
- [ ] Deploy with non-zero value; confirm the value line renders.
- [ ] Regression: normal sends, ERC-20 transfer/approve, and known-contract flows still show their existing screens.