### PR TITLE
fix(insight): wire clear-signing tests into CI + lint/cppcheck green

### DIFF
--- a/include/keepkey/board/confirm_sm.h
+++ b/include/keepkey/board/confirm_sm.h
@@ -96,8 +96,8 @@ bool confirm(ButtonRequestType type, const char* request_title,
     __attribute__((format(printf, 3, 4)));
 
 bool confirm_with_icon(ButtonRequestType type, IconType iconNum,
-                       const char* request_title, const char* request_body,
-                       ...) __attribute__((format(printf, 4, 5)));
+                       const char* request_title, const char* request_body, ...)
+    __attribute__((format(printf, 4, 5)));
 
 bool confirm_constant_power(ButtonRequestType type, const char* request_title,
                             const char* request_body, ...)

--- a/include/keepkey/firmware/fsm.h
+++ b/include/keepkey/firmware/fsm.h
@@ -155,7 +155,6 @@ void fsm_msgFlashWrite(FlashWrite* msg);
 void fsm_msgFlashHash(FlashHash* msg);
 void fsm_msgSoftReset(SoftReset* msg);
 
-
-void fsm_msgEthereumTxMetadata(const EthereumTxMetadata *msg);
+void fsm_msgEthereumTxMetadata(const EthereumTxMetadata* msg);
 
 #endif

--- a/include/keepkey/firmware/signed_metadata.h
+++ b/include/keepkey/firmware/signed_metadata.h
@@ -52,11 +52,12 @@ typedef struct {
 bool signed_metadata_available(void);
 void signed_metadata_clear(void);
 MetadataClassification signed_metadata_process(const uint8_t *payload,
-                                              size_t payload_len,
-                                              uint8_t key_id);
+                                               size_t payload_len,
+                                               uint8_t key_id);
 /* Display gate: does this metadata plausibly describe `msg`? Binds contract
  * address, selector and chain id so the wrong method is never shown. The
- * authoritative full-tx binding is enforced later by signed_metadata_enforce(). */
+ * authoritative full-tx binding is enforced later by signed_metadata_enforce().
+ */
 bool signed_metadata_matches_tx(const EthereumSignTx *msg);
 bool signed_metadata_confirm(void);
 

--- a/include/keepkey/firmware/storage.h
+++ b/include/keepkey/firmware/storage.h
@@ -73,7 +73,7 @@ bool storage_getRootNode(const char* curve, bool usePassphrase, HDNode* node);
 /// \brief Get the raw 64-byte BIP-39 seed, triggering passphrase if needed.
 /// \param usePassphrase[in]  Whether to use the passphrase.
 /// \returns pointer to 64-byte seed, or NULL on failure.
-const uint8_t *storage_getRawSeed(bool usePassphrase);
+const uint8_t* storage_getRawSeed(bool usePassphrase);
 
 /// \brief Fetch the node used for U2F signing.
 /// \returns true iff retrieval was successful.

--- a/lib/board/confirm_sm.c
+++ b/lib/board/confirm_sm.c
@@ -331,8 +331,9 @@ bool confirm_with_icon(ButtonRequestType type, IconType iconNum,
   resp.code = type;
   msg_write(MessageType_MessageType_ButtonRequest, &resp);
 
-  bool ret = confirm_helper(request_title, strbuf, &layout_standard_notification,
-                            false, iconNum, false);
+  bool ret =
+      confirm_helper(request_title, strbuf, &layout_standard_notification,
+                     false, iconNum, false);
   memzero(strbuf, sizeof(strbuf));
   return ret;
 }

--- a/lib/board/layout.c
+++ b/lib/board/layout.c
@@ -328,7 +328,8 @@ void layout_add_icon(IconType type) {
   switch (type) {
     case ETHEREUM_ICON:
     /* ponytail: reuse the ETH glyph as the "verified" mark — it's an ETH tx.
-     * Swap in a dedicated checkmark bitmap if the trust mark needs to differ. */
+     * Swap in a dedicated checkmark bitmap if the trust mark needs to differ.
+     */
     case VERIFIED_ICON:
       draw_bitmap_mono_rle(canvas, get_ethereum_icon_frame(), false);
       break;

--- a/lib/firmware/fsm_msg_ethereum.h
+++ b/lib/firmware/fsm_msg_ethereum.h
@@ -36,8 +36,7 @@ void fsm_msgEthereumTxMetadata(const EthereumTxMetadata* msg) {
 
   switch (result) {
     case METADATA_VERIFIED:
-      strlcpy(resp->display_summary, "Verified",
-              sizeof(resp->display_summary));
+      strlcpy(resp->display_summary, "Verified", sizeof(resp->display_summary));
       break;
     case METADATA_OPAQUE:
       strlcpy(resp->display_summary, "Unverified",
@@ -45,8 +44,7 @@ void fsm_msgEthereumTxMetadata(const EthereumTxMetadata* msg) {
       break;
     case METADATA_MALFORMED:
     default:
-      strlcpy(resp->display_summary, "Invalid",
-              sizeof(resp->display_summary));
+      strlcpy(resp->display_summary, "Invalid", sizeof(resp->display_summary));
       break;
   }
 

--- a/lib/firmware/signed_metadata.c
+++ b/lib/firmware/signed_metadata.c
@@ -83,8 +83,8 @@ static bool read_be_u32(const uint8_t **cursor, const uint8_t *end,
   return true;
 }
 
-static bool read_bytes(const uint8_t **cursor, const uint8_t *end,
-                       uint8_t *out, size_t size) {
+static bool read_bytes(const uint8_t **cursor, const uint8_t *end, uint8_t *out,
+                       size_t size) {
   if ((size_t)(end - *cursor) < size) {
     return false;
   }
@@ -198,8 +198,8 @@ void signed_metadata_clear(void) {
 }
 
 MetadataClassification signed_metadata_process(const uint8_t *payload,
-                                              size_t payload_len,
-                                              uint8_t key_id) {
+                                               size_t payload_len,
+                                               uint8_t key_id) {
   uint8_t digest[32];
   size_t signed_len;
 
@@ -256,8 +256,9 @@ bool signed_metadata_matches_tx(const EthereumSignTx *msg) {
 
   /* This only gates what we DISPLAY (so a benign-looking method screen can't
    * be shown for the wrong call). The metadata commits to the full tx hash;
-   * that is enforced against the real signed digest in signed_metadata_enforce()
-   * because the digest does not exist until send_signature() finalizes it. */
+   * that is enforced against the real signed digest in
+   * signed_metadata_enforce() because the digest does not exist until
+   * send_signature() finalizes it. */
   return true;
 }
 
@@ -279,7 +280,8 @@ bool signed_metadata_confirm(void) {
   }
 
   /* Screen 2: Contract address — ALWAYS show full address, never truncate.
-   * Truncation is a spoofing vector (attacker crafts matching prefix+suffix). */
+   * Truncation is a spoofing vector (attacker crafts matching prefix+suffix).
+   */
   char contract_addr[43] = "0x";
   ethereum_address_checksum(stored_metadata.contract_address, contract_addr + 2,
                             false, stored_metadata.chain_id);
@@ -308,16 +310,19 @@ bool signed_metadata_confirm(void) {
       }
       case ARG_FORMAT_AMOUNT: {
         bignum256 amount;
-        char formatted[48];
         bn_from_metadata_bytes(arg->value, arg->value_len, &amount);
         /* Check for MAX_UINT256 (unlimited approval) */
         bool is_max = true;
         for (uint16_t j = 0; j < arg->value_len; j++) {
-          if (arg->value[j] != 0xFF) { is_max = false; break; }
+          if (arg->value[j] != 0xFF) {
+            is_max = false;
+            break;
+          }
         }
         if (is_max && arg->value_len == 32) {
           snprintf(body, sizeof(body), "%s:\nUNLIMITED", arg->name);
         } else {
+          char formatted[48];
           bn_format(&amount, NULL, " wei", 0, 0, false, formatted,
                     sizeof(formatted));
           snprintf(body, sizeof(body), "%s:\n%s", arg->name, formatted);
@@ -328,8 +333,7 @@ bool signed_metadata_confirm(void) {
       case ARG_FORMAT_RAW:
       default: {
         char hex[(METADATA_MAX_ARG_VALUE_LEN * 2) + 1];
-        size_t display_len =
-            arg->value_len > 16 ? 16 : (size_t)arg->value_len;
+        size_t display_len = arg->value_len > 16 ? 16 : (size_t)arg->value_len;
         data2hex(arg->value, display_len, hex);
         snprintf(body, sizeof(body), "%s:\n%s%s", arg->name, hex,
                  arg->value_len > 16 ? "..." : "");


### PR DESCRIPTION
Follow-up to #257. Bumps deps/python-keepkey pin → a79ce7bf so firmware CI builds the feature emulator and runs the 28 clear-signing integration tests (instead of skipping). Also fixes the alpha CI redness the #257 merge introduced:
- clang-format-20 on the 8 flagged files (only the new Insight lines reformatted)
- cppcheck zero-warning: reduce scope of `formatted` in signed_metadata.c

CI green on fix/insight-pin-bump: lint-format, static-analysis, build-arm-firmware, build-emulator, unit-tests (44 signed_metadata), python-integration-tests (28 clear-signing + screenshots), python-dylib-tests all pass.