### PR TITLE
fix(eth): clear-sign security fixes + transformERC20 regression + alpha CI repair

### DIFF
--- a/include/keepkey/board/confirm_sm.h
+++ b/include/keepkey/board/confirm_sm.h
@@ -96,8 +96,8 @@ bool confirm(ButtonRequestType type, const char* request_title,
     __attribute__((format(printf, 3, 4)));
 
 bool confirm_with_icon(ButtonRequestType type, IconType iconNum,
-                       const char* request_title, const char* request_body,
-                       ...) __attribute__((format(printf, 4, 5)));
+                       const char* request_title, const char* request_body, ...)
+    __attribute__((format(printf, 4, 5)));
 
 bool confirm_constant_power(ButtonRequestType type, const char* request_title,
                             const char* request_body, ...)

--- a/include/keepkey/firmware/fsm.h
+++ b/include/keepkey/firmware/fsm.h
@@ -155,7 +155,6 @@ void fsm_msgFlashWrite(FlashWrite* msg);
 void fsm_msgFlashHash(FlashHash* msg);
 void fsm_msgSoftReset(SoftReset* msg);
 
-
-void fsm_msgEthereumTxMetadata(const EthereumTxMetadata *msg);
+void fsm_msgEthereumTxMetadata(const EthereumTxMetadata* msg);
 
 #endif

--- a/include/keepkey/firmware/signed_metadata.h
+++ b/include/keepkey/firmware/signed_metadata.h
@@ -51,13 +51,14 @@ typedef struct {
 
 bool signed_metadata_available(void);
 void signed_metadata_clear(void);
-MetadataClassification signed_metadata_process(const uint8_t *payload,
-                                              size_t payload_len,
-                                              uint8_t key_id);
+MetadataClassification signed_metadata_process(const uint8_t* payload,
+                                               size_t payload_len,
+                                               uint8_t key_id);
 /* Display gate: does this metadata plausibly describe `msg`? Binds contract
  * address, selector and chain id so the wrong method is never shown. The
- * authoritative full-tx binding is enforced later by signed_metadata_enforce(). */
-bool signed_metadata_matches_tx(const EthereumSignTx *msg);
+ * authoritative full-tx binding is enforced later by signed_metadata_enforce().
+ */
+bool signed_metadata_matches_tx(const EthereumSignTx* msg);
 bool signed_metadata_confirm(void);
 
 /* True once a verified confirm has suppressed the raw-data confirmation, i.e.
@@ -76,9 +77,9 @@ bool signed_metadata_enforce(const uint8_t hash[32]);
  * feeds the module state into this function. No state, no I/O. */
 bool signed_metadata_enforce_decision(bool relied, bool available,
                                       int classification,
-                                      const uint8_t *stored_hash,
-                                      const uint8_t *hash);
+                                      const uint8_t* stored_hash,
+                                      const uint8_t* hash);
 
-const SignedMetadata *signed_metadata_get(void);
+const SignedMetadata* signed_metadata_get(void);
 
 #endif

--- a/include/keepkey/firmware/storage.h
+++ b/include/keepkey/firmware/storage.h
@@ -73,7 +73,7 @@ bool storage_getRootNode(const char* curve, bool usePassphrase, HDNode* node);
 /// \brief Get the raw 64-byte BIP-39 seed, triggering passphrase if needed.
 /// \param usePassphrase[in]  Whether to use the passphrase.
 /// \returns pointer to 64-byte seed, or NULL on failure.
-const uint8_t *storage_getRawSeed(bool usePassphrase);
+const uint8_t* storage_getRawSeed(bool usePassphrase);
 
 /// \brief Fetch the node used for U2F signing.
 /// \returns true iff retrieval was successful.

--- a/lib/board/confirm_sm.c
+++ b/lib/board/confirm_sm.c
@@ -331,8 +331,9 @@ bool confirm_with_icon(ButtonRequestType type, IconType iconNum,
   resp.code = type;
   msg_write(MessageType_MessageType_ButtonRequest, &resp);
 
-  bool ret = confirm_helper(request_title, strbuf, &layout_standard_notification,
-                            false, iconNum, false);
+  bool ret =
+      confirm_helper(request_title, strbuf, &layout_standard_notification,
+                     false, iconNum, false);
   memzero(strbuf, sizeof(strbuf));
   return ret;
 }

--- a/lib/board/layout.c
+++ b/lib/board/layout.c
@@ -328,7 +328,8 @@ void layout_add_icon(IconType type) {
   switch (type) {
     case ETHEREUM_ICON:
     /* ponytail: reuse the ETH glyph as the "verified" mark — it's an ETH tx.
-     * Swap in a dedicated checkmark bitmap if the trust mark needs to differ. */
+     * Swap in a dedicated checkmark bitmap if the trust mark needs to differ.
+     */
     case VERIFIED_ICON:
       draw_bitmap_mono_rle(canvas, get_ethereum_icon_frame(), false);
       break;

--- a/lib/firmware/ethereum_contracts.c
+++ b/lib/firmware/ethereum_contracts.c
@@ -33,23 +33,27 @@ bool ethereum_contractHandled(uint32_t data_total, const EthereumSignTx* msg,
                               const HDNode* node) {
   (void)node;
 
-  /* Clear-sign handlers parse their fields from data_initial_chunk and confirm
-   * them BEFORE the device receives any further streamed EthereumTxAck chunks.
-   * Only classify a tx as a known contract call when:
-   *   - the ENTIRE calldata is already in the initial chunk
-   *     (data_total == data_initial_chunk.size, so data_left == 0 and no extra,
-   *     unshown bytes get appended to the signed pre-image afterwards), and
-   *   - it is a call to a contract (to.size == 20), never a contract CREATE
-   *     (to.size == 0), which must fall through to the deploy screen.
-   * Without this a host could display a benign clear-sign summary and then
-   * stream additional signed calldata the user never saw, or match a handler
-   * selector on an empty-to payload to suppress the deploy confirmation. */
-  if (data_total != msg->data_initial_chunk.size || msg->to.size != 20) {
+  /* Only a CALL to a contract may be clear-signed, never a CREATE
+   * (to.size == 0 must reach the deploy screen). */
+  if (msg->to.size != 20) {
+    return false;
+  }
+
+  /* 0x transformERC20 is pinned to the ExchangeProxy and bounded by its
+   * displayed input/min-output amounts, so it is safe to clear-sign at ANY
+   * calldata size; its transformations[] tail legitimately exceeds one 1024-
+   * byte chunk. (It guards its own fixed-offset reads against
+   * data_initial_chunk.size.) */
+  if (zx_isZxTransformERC20(msg)) return true;
+
+  /* Every other handler must have the ENTIRE calldata in the first chunk, so
+   * the fields it parses and displays are the whole transaction and nothing
+   * unshown streams in afterwards. */
+  if (data_total != msg->data_initial_chunk.size) {
     return false;
   }
 
   if (sa_isWithdrawFromSalary(msg)) return true;
-  if (zx_isZxTransformERC20(msg)) return true;
   if (zx_isZxSwap(msg)) return true;
   if (zx_isZxLiquidTx(msg)) return true;
   if (zx_isZxApproveLiquid(msg)) return true;

--- a/lib/firmware/ethereum_contracts/zxliquidtx.c
+++ b/lib/firmware/ethereum_contracts/zxliquidtx.c
@@ -91,23 +91,29 @@ static bool confirmFromAccountMatch(const EthereumSignTx* msg,
 
   if (!hdnode_get_ethereum_pubkeyhash(node, addressBytes)) {
     memzero(node, sizeof(*node));
+    return false;
   }
 
   fromAddress =
       (const uint8_t*)(msg->data_initial_chunk.bytes + 4 + 5 * 32 - 20);
 
-  if (memcmp(fromAddress, addressBytes, 20) == 0) {
-    fromSrc = "self";
-  } else {
-    fromSrc = "NOT this wallet";
-  }
+  bool isSelf = (memcmp(fromAddress, addressBytes, 20) == 0);
+  fromSrc = isSelf ? "this wallet" : "NOT this wallet";
 
   for (uint32_t ctr = 0; ctr < 20; ctr++) {
     snprintf(&addressStr[2 + ctr * 2], 3, "%02x", fromAddress[ctr]);
   }
 
   if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, addremStr,
-               "Confirming ETH address is %s: %s", fromSrc, addressStr)) {
+               "Liquidity recipient is %s: %s", fromSrc, addressStr)) {
+    return false;
+  }
+
+  /* Fail closed: the liquidity/LP recipient (the `to` parameter) must be the
+   * signer's own address. Previously a non-self recipient only produced a soft
+   * "NOT this wallet" warning that the user could click through, letting LP
+   * tokens / withdrawn ETH be routed to an attacker. */
+  if (!isSelf) {
     return false;
   }
   return true;

--- a/lib/firmware/ethereum_contracts/zxswap.c
+++ b/lib/firmware/ethereum_contracts/zxswap.c
@@ -48,6 +48,18 @@ bool zx_confirmZxSwap(uint32_t data_total, const EthereumSignTx* msg) {
    * (== 4 + 6*32); the toAddress word is bounds-checked below once its
    * position is known from numOfTokens. */
   if (data_total < 4 + 6 * 32) return false;
+
+  /* The first head word is the ABI offset pointer to the dynamic `tokens[]`
+   * array. We read numOfTokens / tokens[] at FIXED offsets that are only
+   * correct when this pointer is canonical (0x80 = 4 head words). If it is
+   * not, the Solidity decoder follows it elsewhere, so what we display would
+   * differ from what executes (a drain via display/execution mismatch). Reject
+   * the non-canonical encoding -> falls through to the blind-sign path. */
+  static const uint8_t TOKENS_OFFSET_CANON[32] = {[31] = 0x80};
+  if (memcmp(msg->data_initial_chunk.bytes + 4, TOKENS_OFFSET_CANON, 32) != 0) {
+    return false;
+  }
+
   const TokenType *from, *to;
   const uint8_t *fromAddress, *toAddress;
   char constr1[40], constr2[40];

--- a/lib/firmware/ethereum_contracts/zxtransERC20.c
+++ b/lib/firmware/ethereum_contracts/zxtransERC20.c
@@ -44,8 +44,11 @@ bool zx_isZxTransformERC20(const EthereumSignTx* msg) {
 }
 
 bool zx_confirmZxTransERC20(uint32_t data_total, const EthereumSignTx* msg) {
-  /* reads selector + 4 32-byte words (in/out token, in/out amount) */
-  if (data_total < 4 + 4 * 32) return false;
+  (void)data_total;
+  /* Reads selector + 4 static head words (in/out token, in/out amount). This
+   * handler is allowed at any data_total (large transformations[] tail), so
+   * guard the read extent against the RECEIVED chunk, not the total length. */
+  if (msg->data_initial_chunk.size < 4 + 4 * 32) return false;
   const TokenType *in, *out;
   const uint8_t *inAddress, *outAddress;
   char constr1[40], constr2[40];

--- a/lib/firmware/fsm_msg_ethereum.h
+++ b/lib/firmware/fsm_msg_ethereum.h
@@ -36,8 +36,7 @@ void fsm_msgEthereumTxMetadata(const EthereumTxMetadata* msg) {
 
   switch (result) {
     case METADATA_VERIFIED:
-      strlcpy(resp->display_summary, "Verified",
-              sizeof(resp->display_summary));
+      strlcpy(resp->display_summary, "Verified", sizeof(resp->display_summary));
       break;
     case METADATA_OPAQUE:
       strlcpy(resp->display_summary, "Unverified",
@@ -45,8 +44,7 @@ void fsm_msgEthereumTxMetadata(const EthereumTxMetadata* msg) {
       break;
     case METADATA_MALFORMED:
     default:
-      strlcpy(resp->display_summary, "Invalid",
-              sizeof(resp->display_summary));
+      strlcpy(resp->display_summary, "Invalid", sizeof(resp->display_summary));
       break;
   }
 

--- a/lib/firmware/signed_metadata.c
+++ b/lib/firmware/signed_metadata.c
@@ -50,7 +50,7 @@ static const uint8_t METADATA_PUBKEYS[METADATA_MAX_KEYS][33] = {
 #endif
 };
 
-static bool read_u8(const uint8_t **cursor, const uint8_t *end, uint8_t *out) {
+static bool read_u8(const uint8_t** cursor, const uint8_t* end, uint8_t* out) {
   if ((size_t)(end - *cursor) < 1) {
     return false;
   }
@@ -60,8 +60,8 @@ static bool read_u8(const uint8_t **cursor, const uint8_t *end, uint8_t *out) {
   return true;
 }
 
-static bool read_be_u16(const uint8_t **cursor, const uint8_t *end,
-                        uint16_t *out) {
+static bool read_be_u16(const uint8_t** cursor, const uint8_t* end,
+                        uint16_t* out) {
   if ((size_t)(end - *cursor) < 2) {
     return false;
   }
@@ -71,8 +71,8 @@ static bool read_be_u16(const uint8_t **cursor, const uint8_t *end,
   return true;
 }
 
-static bool read_be_u32(const uint8_t **cursor, const uint8_t *end,
-                        uint32_t *out) {
+static bool read_be_u32(const uint8_t** cursor, const uint8_t* end,
+                        uint32_t* out) {
   if ((size_t)(end - *cursor) < 4) {
     return false;
   }
@@ -83,8 +83,8 @@ static bool read_be_u32(const uint8_t **cursor, const uint8_t *end,
   return true;
 }
 
-static bool read_bytes(const uint8_t **cursor, const uint8_t *end,
-                       uint8_t *out, size_t size) {
+static bool read_bytes(const uint8_t** cursor, const uint8_t* end, uint8_t* out,
+                       size_t size) {
   if ((size_t)(end - *cursor) < size) {
     return false;
   }
@@ -94,7 +94,7 @@ static bool read_bytes(const uint8_t **cursor, const uint8_t *end,
   return true;
 }
 
-static bool read_string(const uint8_t **cursor, const uint8_t *end, char *out,
+static bool read_string(const uint8_t** cursor, const uint8_t* end, char* out,
                         size_t max_len) {
   uint16_t value_len = 0;
   if (!read_be_u16(cursor, end, &value_len) || value_len == 0 ||
@@ -108,7 +108,7 @@ static bool read_string(const uint8_t **cursor, const uint8_t *end, char *out,
   return true;
 }
 
-static bool read_arg_name(const uint8_t **cursor, const uint8_t *end, char *out,
+static bool read_arg_name(const uint8_t** cursor, const uint8_t* end, char* out,
                           size_t max_len) {
   uint8_t value_len = 0;
   if (!read_u8(cursor, end, &value_len) || value_len == 0 ||
@@ -122,8 +122,8 @@ static bool read_arg_name(const uint8_t **cursor, const uint8_t *end, char *out,
   return true;
 }
 
-static bool parse_metadata_binary(const uint8_t *payload, size_t payload_len,
-                                  SignedMetadata *out) {
+static bool parse_metadata_binary(const uint8_t* payload, size_t payload_len,
+                                  SignedMetadata* out) {
   /* Minimum: version(1) + chain_id(4) + contract(20) + selector(4) +
    * tx_hash(32) + method_len(2) + method(1) + num_args(1) +
    * classification(1) + timestamp(4) + key_id(1) + sig(64) + recovery(1)
@@ -132,8 +132,8 @@ static bool parse_metadata_binary(const uint8_t *payload, size_t payload_len,
     return false;
   }
 
-  const uint8_t *cursor = payload;
-  const uint8_t *end = payload + payload_len;
+  const uint8_t* cursor = payload;
+  const uint8_t* end = payload + payload_len;
   memset(out, 0, sizeof(*out));
 
   if (!read_u8(&cursor, end, &out->version) || out->version != 0x01 ||
@@ -151,7 +151,7 @@ static bool parse_metadata_binary(const uint8_t *payload, size_t payload_len,
   for (uint8_t i = 0; i < out->num_args; i++) {
     uint8_t format = 0;
     uint16_t value_len = 0;
-    MetadataArg *arg = &out->args[i];
+    MetadataArg* arg = &out->args[i];
 
     if (!read_arg_name(&cursor, end, arg->name, METADATA_MAX_ARG_NAME_LEN) ||
         !read_u8(&cursor, end, &format) || format > ARG_FORMAT_BYTES ||
@@ -178,8 +178,8 @@ static bool parse_metadata_binary(const uint8_t *payload, size_t payload_len,
   return true;
 }
 
-static void bn_from_metadata_bytes(const uint8_t *value, size_t value_len,
-                                   bignum256 *out) {
+static void bn_from_metadata_bytes(const uint8_t* value, size_t value_len,
+                                   bignum256* out) {
   uint8_t padded[32] = {0};
   if (value_len > sizeof(padded)) {
     value_len = sizeof(padded);
@@ -197,9 +197,9 @@ void signed_metadata_clear(void) {
   relied_on_metadata = false;
 }
 
-MetadataClassification signed_metadata_process(const uint8_t *payload,
-                                              size_t payload_len,
-                                              uint8_t key_id) {
+MetadataClassification signed_metadata_process(const uint8_t* payload,
+                                               size_t payload_len,
+                                               uint8_t key_id) {
   uint8_t digest[32];
   size_t signed_len;
 
@@ -229,7 +229,7 @@ MetadataClassification signed_metadata_process(const uint8_t *payload,
   return stored_metadata.classification;
 }
 
-bool signed_metadata_matches_tx(const EthereumSignTx *msg) {
+bool signed_metadata_matches_tx(const EthereumSignTx* msg) {
   if (!metadata_available || !msg ||
       stored_metadata.classification != METADATA_VERIFIED ||
       msg->to.size != sizeof(stored_metadata.contract_address) ||
@@ -256,8 +256,9 @@ bool signed_metadata_matches_tx(const EthereumSignTx *msg) {
 
   /* This only gates what we DISPLAY (so a benign-looking method screen can't
    * be shown for the wrong call). The metadata commits to the full tx hash;
-   * that is enforced against the real signed digest in signed_metadata_enforce()
-   * because the digest does not exist until send_signature() finalizes it. */
+   * that is enforced against the real signed digest in
+   * signed_metadata_enforce() because the digest does not exist until
+   * send_signature() finalizes it. */
   return true;
 }
 
@@ -279,7 +280,8 @@ bool signed_metadata_confirm(void) {
   }
 
   /* Screen 2: Contract address — ALWAYS show full address, never truncate.
-   * Truncation is a spoofing vector (attacker crafts matching prefix+suffix). */
+   * Truncation is a spoofing vector (attacker crafts matching prefix+suffix).
+   */
   char contract_addr[43] = "0x";
   ethereum_address_checksum(stored_metadata.contract_address, contract_addr + 2,
                             false, stored_metadata.chain_id);
@@ -292,7 +294,7 @@ bool signed_metadata_confirm(void) {
 
   /* Screen 3..N: Each decoded argument */
   for (uint8_t i = 0; i < stored_metadata.num_args; i++) {
-    MetadataArg *arg = &stored_metadata.args[i];
+    MetadataArg* arg = &stored_metadata.args[i];
     memset(body, 0, sizeof(body));
 
     switch (arg->format) {
@@ -308,16 +310,19 @@ bool signed_metadata_confirm(void) {
       }
       case ARG_FORMAT_AMOUNT: {
         bignum256 amount;
-        char formatted[48];
         bn_from_metadata_bytes(arg->value, arg->value_len, &amount);
         /* Check for MAX_UINT256 (unlimited approval) */
         bool is_max = true;
         for (uint16_t j = 0; j < arg->value_len; j++) {
-          if (arg->value[j] != 0xFF) { is_max = false; break; }
+          if (arg->value[j] != 0xFF) {
+            is_max = false;
+            break;
+          }
         }
         if (is_max && arg->value_len == 32) {
           snprintf(body, sizeof(body), "%s:\nUNLIMITED", arg->name);
         } else {
+          char formatted[48];
           bn_format(&amount, NULL, " wei", 0, 0, false, formatted,
                     sizeof(formatted));
           snprintf(body, sizeof(body), "%s:\n%s", arg->name, formatted);
@@ -328,8 +333,7 @@ bool signed_metadata_confirm(void) {
       case ARG_FORMAT_RAW:
       default: {
         char hex[(METADATA_MAX_ARG_VALUE_LEN * 2) + 1];
-        size_t display_len =
-            arg->value_len > 16 ? 16 : (size_t)arg->value_len;
+        size_t display_len = arg->value_len > 16 ? 16 : (size_t)arg->value_len;
         data2hex(arg->value, display_len, hex);
         snprintf(body, sizeof(body), "%s:\n%s%s", arg->name, hex,
                  arg->value_len > 16 ? "..." : "");
@@ -353,8 +357,8 @@ bool signed_metadata_relied(void) { return relied_on_metadata; }
 
 bool signed_metadata_enforce_decision(bool relied, bool available,
                                       int classification,
-                                      const uint8_t *stored_hash,
-                                      const uint8_t *hash) {
+                                      const uint8_t* stored_hash,
+                                      const uint8_t* hash) {
   if (!relied) {
     return true; /* signature was not gated by metadata */
   }
@@ -372,6 +376,6 @@ bool signed_metadata_enforce(const uint8_t hash[32]) {
       stored_metadata.tx_hash, hash);
 }
 
-const SignedMetadata *signed_metadata_get(void) {
+const SignedMetadata* signed_metadata_get(void) {
   return metadata_available ? &stored_metadata : NULL;
 }


### PR DESCRIPTION
Lands the verified, CI-green clear-sign correctness/security fixes. The THORChain router pin is held separately (it needs the current router address — see follow-up).

- **transformERC20 clear-signs at any size** — fixes the regression where large 0x swap calldata was forced onto the AdvancedMode blind-sign path. transformERC20 is pinned to the 0x ExchangeProxy and bounded by its displayed input/min-output amounts.
- **sellToUniswap dynamic-array offset validation (HIGH)** — reject non-canonical word0 so the displayed tokens/amounts cannot diverge from what executes (display/execution drain closed).
- **Uniswap liquidity recipient must == signer (MEDIUM)** — fail closed instead of a soft warning, so LP/ETH can't be routed to a third party.
- **#257 lint-format + cppcheck repair** — un-breaks alpha's gating jobs.
- **deps/python-keepkey** bumped to master: new EIP-1559 chain_id/fee-shape guard tests + contract-gate streaming test.

Full CI green (build-arm, build-emulator, unit, python-integration, python-dylib, static-analysis, lint-format).

Follow-up (not in this PR): THORChain router pin — the firmware's `THOR_ROUTER` is the stale v1 address; needs bump to current v4 + migration to the signed-metadata clear-sign protocol so router migrations don't require firmware updates.