### PR TITLE
fix(eth): clear-sign security fixes (sellToUniswap offset, liquidity recipient, transformERC20 clear-sign)

### DIFF
--- a/lib/firmware/ethereum_contracts.c
+++ b/lib/firmware/ethereum_contracts.c
@@ -33,23 +33,27 @@ bool ethereum_contractHandled(uint32_t data_total, const EthereumSignTx* msg,
                               const HDNode* node) {
   (void)node;
 
-  /* Clear-sign handlers parse their fields from data_initial_chunk and confirm
-   * them BEFORE the device receives any further streamed EthereumTxAck chunks.
-   * Only classify a tx as a known contract call when:
-   *   - the ENTIRE calldata is already in the initial chunk
-   *     (data_total == data_initial_chunk.size, so data_left == 0 and no extra,
-   *     unshown bytes get appended to the signed pre-image afterwards), and
-   *   - it is a call to a contract (to.size == 20), never a contract CREATE
-   *     (to.size == 0), which must fall through to the deploy screen.
-   * Without this a host could display a benign clear-sign summary and then
-   * stream additional signed calldata the user never saw, or match a handler
-   * selector on an empty-to payload to suppress the deploy confirmation. */
-  if (data_total != msg->data_initial_chunk.size || msg->to.size != 20) {
+  /* Only a CALL to a contract may be clear-signed, never a CREATE
+   * (to.size == 0 must reach the deploy screen). */
+  if (msg->to.size != 20) {
+    return false;
+  }
+
+  /* 0x transformERC20 is pinned to the ExchangeProxy and bounded by its
+   * displayed input/min-output amounts, so it is safe to clear-sign at ANY
+   * calldata size; its transformations[] tail legitimately exceeds one 1024-
+   * byte chunk. (It guards its own fixed-offset reads against
+   * data_initial_chunk.size.) */
+  if (zx_isZxTransformERC20(msg)) return true;
+
+  /* Every other handler must have the ENTIRE calldata in the first chunk, so
+   * the fields it parses and displays are the whole transaction and nothing
+   * unshown streams in afterwards. */
+  if (data_total != msg->data_initial_chunk.size) {
     return false;
   }
 
   if (sa_isWithdrawFromSalary(msg)) return true;
-  if (zx_isZxTransformERC20(msg)) return true;
   if (zx_isZxSwap(msg)) return true;
   if (zx_isZxLiquidTx(msg)) return true;
   if (zx_isZxApproveLiquid(msg)) return true;

--- a/lib/firmware/ethereum_contracts/zxliquidtx.c
+++ b/lib/firmware/ethereum_contracts/zxliquidtx.c
@@ -91,23 +91,29 @@ static bool confirmFromAccountMatch(const EthereumSignTx* msg,
 
   if (!hdnode_get_ethereum_pubkeyhash(node, addressBytes)) {
     memzero(node, sizeof(*node));
+    return false;
   }
 
   fromAddress =
       (const uint8_t*)(msg->data_initial_chunk.bytes + 4 + 5 * 32 - 20);
 
-  if (memcmp(fromAddress, addressBytes, 20) == 0) {
-    fromSrc = "self";
-  } else {
-    fromSrc = "NOT this wallet";
-  }
+  bool isSelf = (memcmp(fromAddress, addressBytes, 20) == 0);
+  fromSrc = isSelf ? "this wallet" : "NOT this wallet";
 
   for (uint32_t ctr = 0; ctr < 20; ctr++) {
     snprintf(&addressStr[2 + ctr * 2], 3, "%02x", fromAddress[ctr]);
   }
 
   if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, addremStr,
-               "Confirming ETH address is %s: %s", fromSrc, addressStr)) {
+               "Liquidity recipient is %s: %s", fromSrc, addressStr)) {
+    return false;
+  }
+
+  /* Fail closed: the liquidity/LP recipient (the `to` parameter) must be the
+   * signer's own address. Previously a non-self recipient only produced a soft
+   * "NOT this wallet" warning that the user could click through, letting LP
+   * tokens / withdrawn ETH be routed to an attacker. */
+  if (!isSelf) {
     return false;
   }
   return true;

--- a/lib/firmware/ethereum_contracts/zxswap.c
+++ b/lib/firmware/ethereum_contracts/zxswap.c
@@ -48,6 +48,18 @@ bool zx_confirmZxSwap(uint32_t data_total, const EthereumSignTx* msg) {
    * (== 4 + 6*32); the toAddress word is bounds-checked below once its
    * position is known from numOfTokens. */
   if (data_total < 4 + 6 * 32) return false;
+
+  /* The first head word is the ABI offset pointer to the dynamic `tokens[]`
+   * array. We read numOfTokens / tokens[] at FIXED offsets that are only
+   * correct when this pointer is canonical (0x80 = 4 head words). If it is
+   * not, the Solidity decoder follows it elsewhere, so what we display would
+   * differ from what executes (a drain via display/execution mismatch). Reject
+   * the non-canonical encoding -> falls through to the blind-sign path. */
+  static const uint8_t TOKENS_OFFSET_CANON[32] = {[31] = 0x80};
+  if (memcmp(msg->data_initial_chunk.bytes + 4, TOKENS_OFFSET_CANON, 32) != 0) {
+    return false;
+  }
+
   const TokenType *from, *to;
   const uint8_t *fromAddress, *toAddress;
   char constr1[40], constr2[40];

--- a/lib/firmware/ethereum_contracts/zxtransERC20.c
+++ b/lib/firmware/ethereum_contracts/zxtransERC20.c
@@ -44,8 +44,11 @@ bool zx_isZxTransformERC20(const EthereumSignTx* msg) {
 }
 
 bool zx_confirmZxTransERC20(uint32_t data_total, const EthereumSignTx* msg) {
-  /* reads selector + 4 32-byte words (in/out token, in/out amount) */
-  if (data_total < 4 + 4 * 32) return false;
+  (void)data_total;
+  /* Reads selector + 4 static head words (in/out token, in/out amount). This
+   * handler is allowed at any data_total (large transformations[] tail), so
+   * guard the read extent against the RECEIVED chunk, not the total length. */
+  if (msg->data_initial_chunk.size < 4 + 4 * 32) return false;
   const TokenType *in, *out;
   const uint8_t *inAddress, *outAddress;
   char constr1[40], constr2[40];


### PR DESCRIPTION
Clear-sign correctness/security fixes, rebased clean onto current alpha (post #258).

- **sellToUniswap dynamic-array offset validation (HIGH)** — reject non-canonical word0 so displayed tokens/amounts cannot diverge from execution (display/execution drain closed).
- **Uniswap liquidity recipient must == signer (MEDIUM)** — fail closed instead of soft warning, so LP/ETH cannot be routed to a third party.
- **transformERC20 clear-signs at any size** — pinned 0x ExchangeProxy + bounded by displayed input/min-output, so it no longer needs the AdvancedMode blind-sign path. (Supersedes the interim AdvancedMode workaround for transformERC20; #258's AdvancedMode test still passes — clear-sign produces the same signature.)

CI fully green (build-arm, build-emulator, unit, python-integration, python-dylib, static-analysis, lint-format).

Not in this PR (follow-ups): THORChain router pin is on the stale v1 address — needs bump to current v4 + migration to the signed-metadata protocol so router migrations don't require firmware updates.