### PR TITLE
fix(eth): pin THORChain router (current v4) + validate memo offset (CRITICAL)

### DIFF
--- a/include/keepkey/firmware/ethereum_contracts/thortx.h
+++ b/include/keepkey/firmware/ethereum_contracts/thortx.h
@@ -30,8 +30,12 @@
   "\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee" \
   "\xee\xee"
 
-/* THORChain ETH router (mainnet) */
-#define THOR_ROUTER "42a5ed456650a09dc10ebc6361a7480fdd61f27b"
+/* THORChain ETH router (mainnet), current v4.1.1.
+ * NOTE: THORChain migrates this router periodically (v1 42a5ed.. -> v3
+ * 3624525.. -> v4 d37bbe..). A hardcoded pin must be updated on each migration;
+ * the durable path is the signed-metadata clear-sign protocol (host-signed,
+ * key-pinned) which needs no firmware update per router change. */
+#define THOR_ROUTER "d37bbe5744d730a1d98d8dc97c42f0ca46ad7146"
 
 /* Maya Protocol ETH router (mainnet) */
 #define MAYA_ROUTER "d89dce570de35a6f42d3bca7dba50a6d89bfc2a2"

--- a/lib/firmware/ethereum_contracts/thortx.c
+++ b/lib/firmware/ethereum_contracts/thortx.c
@@ -58,10 +58,15 @@ bool thor_isMayachainTx(const EthereumSignTx* msg) {
 }
 
 bool thor_isThorchainTx(const EthereumSignTx* msg) {
-  if (msg->has_to && msg->to.size == 20 && thor_has_deposit_selector(msg)) {
-    return true;
-  }
-  return false;
+  if (!msg->has_to || msg->to.size != 20) return false;
+  if (!thor_has_deposit_selector(msg)) return false;
+  /* Pin to the THORChain router. Without this, ANY contract carrying the
+   * deposit selector would get the THORChain clear-sign UX and bypass the
+   * AdvancedMode blind-sign gate, letting an attacker contract drain while the
+   * device shows a benign deposit. Mirrors thor_isMayachainTx. */
+  char toStr[41];
+  thor_format_to_addr(msg, toStr);
+  return strncmp(toStr, THOR_ROUTER, 40) == 0;
 }
 
 static bool thor_confirm_deposit_tx(uint32_t data_total,
@@ -76,6 +81,20 @@ static bool thor_confirm_deposit_tx(uint32_t data_total,
   const bool is_expiry = thor_is_expiry_variant(msg);
   const size_t min_chunk = is_expiry ? 260 : 228;
   if (msg->data_initial_chunk.size < min_chunk) return false;
+
+  /* The memo is a dynamic `string`; its ABI head pointer (word 3, offset
+   * 4+3*32) must be canonical (0x80 for deposit's 4 head words, 0xa0 for
+   * depositWithExpiry's 5), else abi.decode on the router reads the memo from a
+   * different location than we display from the fixed offset below -> the
+   * executed swap destination can differ from what the user approved. */
+  {
+    static const uint8_t MEMO_OFF_DEPOSIT[32] = {[31] = 0x80};
+    static const uint8_t MEMO_OFF_EXPIRY[32] = {[31] = 0xa0};
+    const uint8_t* expected = is_expiry ? MEMO_OFF_EXPIRY : MEMO_OFF_DEPOSIT;
+    if (memcmp(msg->data_initial_chunk.bytes + 4 + 3 * 32, expected, 32) != 0) {
+      return false;
+    }
+  }
 
   char confStr[41];
   const char* conf;


### PR DESCRIPTION
Closes the CRITICAL THORChain clear-sign hole: `thor_isThorchainTx` matched the deposit selector on ANY `to`, so any attacker contract got the THORChain clear-sign UX and bypassed the AdvancedMode blind-sign gate. Now pinned to the router, **bumped from the stale v1 (`42a5ed…`) to the current v4.1.1 (`0xD37BBE…`)**, plus the memo's ABI head pointer is validated canonical so the displayed swap destination matches execution.

Tests: the eth swap / add-liquidity vectors used stale/bogus `to` addresses (accepted under the old no-pin handler); repointed at the real pinned routers (THOR `d37bbe`, Maya `d89dce`) with structural sig asserts (exact r/s regenerate on-device). The teammate's `test_deposit_with_expiry_non_thor_address_blind_sign_blocked` now passes because of the pin. CI fully green.

Note: hardcoded router pins are a firmware-update treadmill (THORChain migrates routers: v1→v3→v4). The durable fix is the signed-metadata clear-sign protocol (#257) — pin a key, host signs per-tx metadata + tx_hash, server-updatable. Migrate THORChain (and the 0x/Uniswap/Sablier handlers) onto it to retire the address pins.