### PR TITLE
fix: widen TokenType.chain_id from uint8_t to uint32_t

### DIFF
--- a/include/keepkey/firmware/ethereum_tokens.h
+++ b/include/keepkey/firmware/ethereum_tokens.h
@@ -39,7 +39,7 @@ enum {
 typedef struct _TokenType {
   const char* const address;
   const char* const ticker;
-  uint8_t chain_id;
+  uint32_t chain_id;
   uint8_t decimals;
 } TokenType;
 
@@ -51,7 +51,7 @@ extern const TokenType* UnknownToken;
 
 const TokenType* tokenIter(int32_t* ctr);
 
-const TokenType* tokenByChainAddress(uint8_t chain_id, const uint8_t* address);
+const TokenType* tokenByChainAddress(uint32_t chain_id, const uint8_t* address);
 
 /// Tokens don't have unique tickers, so this might not return the one you're
 /// looking for :/
@@ -64,7 +64,7 @@ const TokenType* tokenByChainAddress(uint8_t chain_id, const uint8_t* address);
 /// \param[out] token The found token, assuming it was uniquely determinable.
 /// \returns true iff the token can be uniquely found in the list of known
 /// tokens.
-bool tokenByTicker(uint8_t chain_id, const char* ticker,
+bool tokenByTicker(uint32_t chain_id, const char* ticker,
                    const TokenType** token);
 
 void coinFromToken(CoinType* coin, const TokenType* token);

--- a/lib/firmware/ethereum_tokens.c
+++ b/lib/firmware/ethereum_tokens.c
@@ -42,7 +42,8 @@ const TokenType* tokenIter(int32_t* ctr) {
   return &(tokens[*ctr - 1]);
 }
 
-const TokenType* tokenByChainAddress(uint8_t chain_id, const uint8_t* address) {
+const TokenType* tokenByChainAddress(uint32_t chain_id,
+                                     const uint8_t* address) {
   if (!address) return 0;
   for (int i = 0; i < TOKENS_COUNT; i++) {
     if (chain_id == tokens[i].chain_id &&
@@ -57,7 +58,7 @@ const TokenType* tokenByChainAddress(uint8_t chain_id, const uint8_t* address) {
   return UnknownToken;
 }
 
-bool tokenByTicker(uint8_t chain_id, const char* ticker,
+bool tokenByTicker(uint32_t chain_id, const char* ticker,
                    const TokenType** token) {
   *token = NULL;
 


### PR DESCRIPTION
## What
Widens `TokenType.chain_id` from `uint8_t` to `uint32_t` (`ethereum_tokens.{h,c}`).

## Why
EVM chains with chainId ≥ 256 (Arbitrum 42161, Base 8453, Avalanche 43114) were truncated to 8 bits → wrong-chain token recognition/display. Widening to uint32 fixes it.

## Scope
Firmware-only; **no proto or submodule changes** (pins unchanged from develop). First of the singular per-fix PRs staged for the firmware 7.x release.