### PR TITLE
feat(thorchain): allow any denom in ThorchainMsgSend with validation (TCY/RUJI)

### DIFF
--- a/include/keepkey/firmware/thorchain.h
+++ b/include/keepkey/firmware/thorchain.h
@@ -10,6 +10,10 @@
 typedef struct _ThorchainSignTx ThorchainSignTx;
 typedef struct _ThorchainMsgDeposit ThorchainMsgDeposit;
 
+// Returns true iff denom contains only chars safe in JSON without escaping.
+// Valid: [a-z0-9./\-]. Rejects empty string, quotes, backslashes, whitespace.
+bool thorchain_isValidDenom(const char* denom);
+
 bool thorchain_signTxInit(const HDNode* _node, const ThorchainSignTx* _msg);
 bool thorchain_signTxUpdateMsgSend(const uint64_t amount,
                                    const char* to_address,

--- a/include/keepkey/firmware/thorchain.h
+++ b/include/keepkey/firmware/thorchain.h
@@ -16,8 +16,7 @@ bool thorchain_isValidDenom(const char* denom);
 
 bool thorchain_signTxInit(const HDNode* _node, const ThorchainSignTx* _msg);
 bool thorchain_signTxUpdateMsgSend(const uint64_t amount,
-                                   const char* to_address,
-                                   const char* denom);
+                                   const char* to_address, const char* denom);
 bool thorchain_signTxUpdateMsgDeposit(const ThorchainMsgDeposit* depmsg);
 bool thorchain_signTxFinalize(uint8_t* public_key, uint8_t* signature);
 bool thorchain_signingIsInited(void);

--- a/include/keepkey/firmware/thorchain.h
+++ b/include/keepkey/firmware/thorchain.h
@@ -12,7 +12,8 @@ typedef struct _ThorchainMsgDeposit ThorchainMsgDeposit;
 
 bool thorchain_signTxInit(const HDNode* _node, const ThorchainSignTx* _msg);
 bool thorchain_signTxUpdateMsgSend(const uint64_t amount,
-                                   const char* to_address);
+                                   const char* to_address,
+                                   const char* denom);
 bool thorchain_signTxUpdateMsgDeposit(const ThorchainMsgDeposit* depmsg);
 bool thorchain_signTxFinalize(uint8_t* public_key, uint8_t* signature);
 bool thorchain_signingIsInited(void);

--- a/include/keepkey/transport/messages-thorchain.options
+++ b/include/keepkey/transport/messages-thorchain.options
@@ -8,6 +8,7 @@ ThorchainSignTx.memo                                      max_size:256
 
 ThorchainMsgSend.from_address                             max_size:46
 ThorchainMsgSend.to_address                               max_size:46
+ThorchainMsgSend.denom                                    max_size:69
 
 ThorchainMsgDeposit.asset                                 max_size:20
 ThorchainMsgDeposit.memo                                  max_size:256

--- a/lib/firmware/fsm_msg_thorchain.h
+++ b/lib/firmware/fsm_msg_thorchain.h
@@ -175,8 +175,8 @@ void fsm_msgThorchainMsgAck(const ThorchainMsgAck* msg) {
           return;
         }
         // Confirm the asset denom on its own screen.
-        if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
-                     "Asset", "%s", coin_denom)) {
+        if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, "Asset",
+                     "%s", coin_denom)) {
           thorchain_signAbort();
           fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
           layoutHome();

--- a/lib/firmware/fsm_msg_thorchain.h
+++ b/lib/firmware/fsm_msg_thorchain.h
@@ -143,17 +143,40 @@ void fsm_msgThorchainMsgAck(const ThorchainMsgAck* msg) {
   if (msg->has_send) {
     const char* coin_denom =
         (msg->send.has_denom && msg->send.denom[0]) ? msg->send.denom : "rune";
+
+    // Validate before any display so untrusted strings never reach the UI.
+    if (!thorchain_isValidDenom(coin_denom)) {
+      thorchain_signAbort();
+      fsm_sendFailure(FailureType_Failure_SyntaxError, "Invalid denom");
+      layoutHome();
+      return;
+    }
+
     switch (msg->send.address_type) {
       case OutputAddressType_TRANSFER:
       default: {
+        // amount_str only needs to hold the numeric part (no denom suffix).
+        // Denom is confirmed on a separate screen so no truncation is possible.
         char amount_str[32];
-        char denom_str[71];
-        snprintf(denom_str, sizeof(denom_str), " %s", coin_denom);
-        bn_format_uint64(msg->send.amount, NULL, denom_str, 8, 0, false,
-                         amount_str, sizeof(amount_str));
+        if (!bn_format_uint64(msg->send.amount, NULL, NULL, 8, 0, false,
+                              amount_str, sizeof(amount_str))) {
+          thorchain_signAbort();
+          fsm_sendFailure(FailureType_Failure_FirmwareError,
+                          _("Failed to format amount"));
+          layoutHome();
+          return;
+        }
         if (!confirm_transaction_output(
                 ButtonRequestType_ButtonRequest_ConfirmOutput, amount_str,
                 msg->send.to_address)) {
+          thorchain_signAbort();
+          fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
+          layoutHome();
+          return;
+        }
+        // Confirm the asset denom on its own screen.
+        if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
+                     "Asset", "%s", coin_denom)) {
           thorchain_signAbort();
           fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
           layoutHome();

--- a/lib/firmware/fsm_msg_thorchain.h
+++ b/lib/firmware/fsm_msg_thorchain.h
@@ -141,11 +141,15 @@ void fsm_msgThorchainMsgAck(const ThorchainMsgAck* msg) {
   const ThorchainSignTx* sign_tx = thorchain_getThorchainSignTx();
 
   if (msg->has_send) {
+    const char* coin_denom =
+        (msg->send.has_denom && msg->send.denom[0]) ? msg->send.denom : "rune";
     switch (msg->send.address_type) {
       case OutputAddressType_TRANSFER:
       default: {
         char amount_str[32];
-        bn_format_uint64(msg->send.amount, NULL, " RUNE", 8, 0, false,
+        char denom_str[71];
+        snprintf(denom_str, sizeof(denom_str), " %s", coin_denom);
+        bn_format_uint64(msg->send.amount, NULL, denom_str, 8, 0, false,
                          amount_str, sizeof(amount_str));
         if (!confirm_transaction_output(
                 ButtonRequestType_ButtonRequest_ConfirmOutput, amount_str,
@@ -159,8 +163,8 @@ void fsm_msgThorchainMsgAck(const ThorchainMsgAck* msg) {
         break;
       }
     }
-    if (!thorchain_signTxUpdateMsgSend(msg->send.amount,
-                                       msg->send.to_address)) {
+    if (!thorchain_signTxUpdateMsgSend(msg->send.amount, msg->send.to_address,
+                                       coin_denom)) {
       thorchain_signAbort();
       fsm_sendFailure(FailureType_Failure_SyntaxError,
                       "Failed to include send message in transaction");
@@ -240,7 +244,7 @@ void fsm_msgThorchainMsgAck(const ThorchainMsgAck* msg) {
   }
 
   if (!confirm(ButtonRequestType_ButtonRequest_SignTx, node_str,
-               "Sign this RUNE transaction on %s? "
+               "Sign this THORChain transaction on %s? "
                "Additional network fees apply.",
                sign_tx->chain_id)) {
     thorchain_signAbort();

--- a/lib/firmware/thorchain.c
+++ b/lib/firmware/thorchain.c
@@ -39,8 +39,8 @@ bool thorchain_isValidDenom(const char* denom) {
   if (!denom || !denom[0]) return false;
   for (size_t i = 0; denom[i]; i++) {
     char c = denom[i];
-    if (!((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
-          c == '.' || c == '/' || c == '-')) {
+    if (!((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '.' ||
+          c == '/' || c == '-')) {
       return false;
     }
   }
@@ -111,8 +111,7 @@ bool thorchain_signTxInit(const HDNode* _node, const ThorchainSignTx* _msg) {
 }
 
 bool thorchain_signTxUpdateMsgSend(const uint64_t amount,
-                                   const char* to_address,
-                                   const char* denom) {
+                                   const char* to_address, const char* denom) {
   const char mainnetp[] = "thor";
   const char testnetp[] = "tthor";
   const char* pfix;
@@ -136,7 +135,8 @@ bool thorchain_signTxUpdateMsgSend(const uint64_t amount,
     return false;
   }
 
-  // Default to "rune" for backward compatibility; validate all non-default denoms
+  // Default to "rune" for backward compatibility; validate all non-default
+  // denoms
   const char* coin_denom = (denom && denom[0]) ? denom : "rune";
   if (!thorchain_isValidDenom(coin_denom)) {
     return false;
@@ -148,10 +148,9 @@ bool thorchain_signTxUpdateMsgSend(const uint64_t amount,
   sha256_Update(&ctx, (uint8_t*)prelude, strlen(prelude));
 
   // Write amount prefix: 21 + ^20 = ^41
-  success &= tendermint_snprintf(&ctx, buffer, sizeof(buffer),
-                                 "\"amount\":[{\"amount\":\"%" PRIu64
-                                 "\",\"denom\":\"",
-                                 amount);
+  success &= tendermint_snprintf(
+      &ctx, buffer, sizeof(buffer),
+      "\"amount\":[{\"amount\":\"%" PRIu64 "\",\"denom\":\"", amount);
   // Use escaping as defense-in-depth; valid denoms have no escapable chars
   tendermint_sha256UpdateEscaped(&ctx, coin_denom, strlen(coin_denom));
   // Close coins array: 3 bytes

--- a/lib/firmware/thorchain.c
+++ b/lib/firmware/thorchain.c
@@ -95,7 +95,8 @@ bool thorchain_signTxInit(const HDNode* _node, const ThorchainSignTx* _msg) {
 }
 
 bool thorchain_signTxUpdateMsgSend(const uint64_t amount,
-                                   const char* to_address) {
+                                   const char* to_address,
+                                   const char* denom) {
   const char mainnetp[] = "thor";
   const char testnetp[] = "tthor";
   const char* pfix;
@@ -119,15 +120,23 @@ bool thorchain_signTxUpdateMsgSend(const uint64_t amount,
     return false;
   }
 
+  // Default to "rune" for backward compatibility
+  const char* coin_denom = (denom && denom[0]) ? denom : "rune";
+
   bool success = true;
 
   const char* const prelude = "{\"type\":\"thorchain/MsgSend\",\"value\":{";
   sha256_Update(&ctx, (uint8_t*)prelude, strlen(prelude));
 
-  // 21 + ^20 + 19 = ^60
-  success &= tendermint_snprintf(
-      &ctx, buffer, sizeof(buffer),
-      "\"amount\":[{\"amount\":\"%" PRIu64 "\",\"denom\":\"rune\"}]", amount);
+  // Write amount prefix: 21 + ^20 = ^41
+  success &= tendermint_snprintf(&ctx, buffer, sizeof(buffer),
+                                 "\"amount\":[{\"amount\":\"%" PRIu64
+                                 "\",\"denom\":\"",
+                                 amount);
+  // Write denom directly (arbitrary length, no special chars expected)
+  sha256_Update(&ctx, (uint8_t*)coin_denom, strlen(coin_denom));
+  // Close coins array: 3 bytes
+  sha256_Update(&ctx, (uint8_t*)"\"}]", 3);
 
   // 17 + 45 + 1 = 63
   success &= tendermint_snprintf(&ctx, buffer, sizeof(buffer),

--- a/lib/firmware/thorchain.c
+++ b/lib/firmware/thorchain.c
@@ -29,7 +29,23 @@
 #include "trezor/crypto/segwit_addr.h"
 
 #include <stdbool.h>
+#include <string.h>
 #include <time.h>
+
+// Allow lowercase alpha, digits, and the punctuation used in THORChain asset
+// identifiers (e.g. "eth.eth", "btc/btc", cross-chain synthetic prefixes).
+// Rejects anything that needs JSON escaping (backslash, quote).
+bool thorchain_isValidDenom(const char* denom) {
+  if (!denom || !denom[0]) return false;
+  for (size_t i = 0; denom[i]; i++) {
+    char c = denom[i];
+    if (!((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
+          c == '.' || c == '/' || c == '-')) {
+      return false;
+    }
+  }
+  return true;
+}
 
 static CONFIDENTIAL HDNode node;
 static SHA256_CTX ctx;
@@ -120,8 +136,11 @@ bool thorchain_signTxUpdateMsgSend(const uint64_t amount,
     return false;
   }
 
-  // Default to "rune" for backward compatibility
+  // Default to "rune" for backward compatibility; validate all non-default denoms
   const char* coin_denom = (denom && denom[0]) ? denom : "rune";
+  if (!thorchain_isValidDenom(coin_denom)) {
+    return false;
+  }
 
   bool success = true;
 
@@ -133,8 +152,8 @@ bool thorchain_signTxUpdateMsgSend(const uint64_t amount,
                                  "\"amount\":[{\"amount\":\"%" PRIu64
                                  "\",\"denom\":\"",
                                  amount);
-  // Write denom directly (arbitrary length, no special chars expected)
-  sha256_Update(&ctx, (uint8_t*)coin_denom, strlen(coin_denom));
+  // Use escaping as defense-in-depth; valid denoms have no escapable chars
+  tendermint_sha256UpdateEscaped(&ctx, coin_denom, strlen(coin_denom));
   // Close coins array: 3 bytes
   sha256_Update(&ctx, (uint8_t*)"\"}]", 3);
 

--- a/unittests/firmware/CMakeLists.txt
+++ b/unittests/firmware/CMakeLists.txt
@@ -3,10 +3,13 @@ set(sources
     cosmos.cpp
     eos.cpp
     ethereum.cpp
+    mayachain.cpp
     nano.cpp
     recovery.cpp
     ripple.cpp
+    solana.cpp
     storage.cpp
+    thorchain.cpp
     usb_rx.cpp
     u2f.cpp)
 

--- a/unittests/firmware/thorchain.cpp
+++ b/unittests/firmware/thorchain.cpp
@@ -56,7 +56,7 @@ TEST(Thorchain, ThorchainSignTx) {
   ASSERT_TRUE(thorchain_signTxInit(&node, &msg));
 
   ASSERT_TRUE(thorchain_signTxUpdateMsgSend(
-      100000, "thor18vhdczjut44gpsy804crfhnd5nq003nz0nf20v"));
+      100000, "thor18vhdczjut44gpsy804crfhnd5nq003nz0nf20v", "rune"));
 
   uint8_t public_key[33];
   uint8_t signature[64];
@@ -71,4 +71,92 @@ TEST(Thorchain, ThorchainSignTx) {
                         "\x14\x36\x64\x7f\xac\x5a\xbd\xc2\x9f\x54\xae\x3d\x7e"
                         "\x47\x56\x43\xca\x33\xc7\xad\x2c\x8a\x53\x2b\x39",
              64) == 0);
+}
+
+// Node fixture shared by denom tests
+static const HDNode kDenomTestNode = {
+    0,
+    0,
+    {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+    {0x04, 0xde, 0xc0, 0xcc, 0x01, 0x3c, 0xd8, 0xab, 0x70, 0x87, 0xca,
+     0x14, 0x96, 0x0b, 0x76, 0x8c, 0x3d, 0x83, 0x45, 0x24, 0x48, 0xaa,
+     0x00, 0x64, 0xda, 0xe6, 0xfb, 0x04, 0xb5, 0xd9, 0x34, 0x76},
+    {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+    {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+    &secp256k1_info};
+
+static const ThorchainSignTx kDenomTestSignTx = {
+    5,    {0x80000000 | 44, 0x80000000 | 931, 0x80000000, 0, 0},
+    true, 0,
+    true, "thorchain",
+    true, 5000,
+    true, 200000,
+    true, "",
+    true, 0,
+    true, 1};
+
+// Empty denom must produce the same signature as explicit "rune"
+TEST(Thorchain, ThorchainSignTxDefaultDenom) {
+  HDNode node = kDenomTestNode;
+  hdnode_fill_public_key(&node);
+
+  ASSERT_TRUE(thorchain_signTxInit(&node, &kDenomTestSignTx));
+  ASSERT_TRUE(thorchain_signTxUpdateMsgSend(
+      100000, "thor18vhdczjut44gpsy804crfhnd5nq003nz0nf20v", ""));
+
+  uint8_t public_key[33];
+  uint8_t signature[64];
+  ASSERT_TRUE(thorchain_signTxFinalize(public_key, signature));
+
+  // Must match the explicit "rune" signature above
+  EXPECT_TRUE(
+      memcmp(signature,
+             (uint8_t *)"\x41\x99\x66\x30\x08\xef\xea\x75\x93\x56\x35\xe6\x1a"
+                        "\x11\xdf\xa3\x3c\xeb\xeb\x91\xc1\xca\xed\xc6\x0e\x5e"
+                        "\xef\x3c\xa2\xc0\x1f\x83\x48\x08\x36\xe6\x21\x89\x51"
+                        "\x14\x36\x64\x7f\xac\x5a\xbd\xc2\x9f\x54\xae\x3d\x7e"
+                        "\x47\x56\x43\xca\x33\xc7\xad\x2c\x8a\x53\x2b\x39",
+             64) == 0);
+}
+
+// TCY (THORChain native yield/governance token) must sign successfully
+// and produce a distinct signature from rune
+TEST(Thorchain, ThorchainSignTxTCY) {
+  HDNode node = kDenomTestNode;
+  hdnode_fill_public_key(&node);
+
+  ASSERT_TRUE(thorchain_signTxInit(&node, &kDenomTestSignTx));
+  ASSERT_TRUE(thorchain_signTxUpdateMsgSend(
+      100000, "thor18vhdczjut44gpsy804crfhnd5nq003nz0nf20v", "tcy"));
+
+  uint8_t public_key[33];
+  uint8_t signature[64];
+  ASSERT_TRUE(thorchain_signTxFinalize(public_key, signature));
+
+  // Signature must differ from the rune baseline
+  EXPECT_FALSE(
+      memcmp(signature,
+             (uint8_t *)"\x41\x99\x66\x30\x08\xef\xea\x75\x93\x56\x35\xe6\x1a"
+                        "\x11\xdf\xa3\x3c\xeb\xeb\x91\xc1\xca\xed\xc6\x0e\x5e"
+                        "\xef\x3c\xa2\xc0\x1f\x83\x48\x08\x36\xe6\x21\x89\x51"
+                        "\x14\x36\x64\x7f\xac\x5a\xbd\xc2\x9f\x54\xae\x3d\x7e"
+                        "\x47\x56\x43\xca\x33\xc7\xad\x2c\x8a\x53\x2b\x39",
+             64) == 0);
+}
+
+// RUJIRA (DEX token native to THORChain) must sign successfully
+TEST(Thorchain, ThorchainSignTxRujira) {
+  HDNode node = kDenomTestNode;
+  hdnode_fill_public_key(&node);
+
+  ASSERT_TRUE(thorchain_signTxInit(&node, &kDenomTestSignTx));
+  ASSERT_TRUE(thorchain_signTxUpdateMsgSend(
+      100000, "thor18vhdczjut44gpsy804crfhnd5nq003nz0nf20v", "rujira"));
+
+  uint8_t public_key[33];
+  uint8_t signature[64];
+  ASSERT_TRUE(thorchain_signTxFinalize(public_key, signature));
 }

--- a/unittests/firmware/thorchain.cpp
+++ b/unittests/firmware/thorchain.cpp
@@ -57,7 +57,7 @@ static const ThorchainSignTx kSignTx = {
     true, 0,
     true, 1};
 
-static const char* kToAddr = "thor18vhdczjut44gpsy804crfhnd5nq003nz0nf20v";
+static const char *kToAddr = "thor18vhdczjut44gpsy804crfhnd5nq003nz0nf20v";
 
 // Baseline RUNE send — exact signature vector
 TEST(Thorchain, ThorchainSignTx) {
@@ -71,7 +71,8 @@ TEST(Thorchain, ThorchainSignTx) {
   uint8_t signature[64];
   ASSERT_TRUE(thorchain_signTxFinalize(public_key, signature));
 
-  EXPECT_EQ(0,
+  EXPECT_EQ(
+      0,
       memcmp(signature,
              (uint8_t *)"\xc3\xea\xe2\xa3\xc2\xb6\x24\x00\x8d\x8a\xc4\x49\xe2"
                         "\x53\xdb\xa5\x31\x2e\x4d\xbd\x12\xd6\x77\x39\xd3\xf9"
@@ -93,7 +94,8 @@ TEST(Thorchain, ThorchainSignTxDefaultDenom) {
   uint8_t signature[64];
   ASSERT_TRUE(thorchain_signTxFinalize(public_key, signature));
 
-  EXPECT_EQ(0,
+  EXPECT_EQ(
+      0,
       memcmp(signature,
              (uint8_t *)"\xc3\xea\xe2\xa3\xc2\xb6\x24\x00\x8d\x8a\xc4\x49\xe2"
                         "\x53\xdb\xa5\x31\x2e\x4d\xbd\x12\xd6\x77\x39\xd3\xf9"
@@ -115,7 +117,8 @@ TEST(Thorchain, ThorchainSignTxTCY) {
   uint8_t signature[64];
   ASSERT_TRUE(thorchain_signTxFinalize(public_key, signature));
 
-  EXPECT_EQ(0,
+  EXPECT_EQ(
+      0,
       memcmp(signature,
              (uint8_t *)"\xad\xa0\xb6\xce\x50\x41\xc1\x01\x46\xf0\x86\x94\xb9"
                         "\x97\x29\x41\x13\x41\xef\x87\x70\xe8\x58\x7c\x01\xf9"
@@ -137,7 +140,8 @@ TEST(Thorchain, ThorchainSignTxRujira) {
   uint8_t signature[64];
   ASSERT_TRUE(thorchain_signTxFinalize(public_key, signature));
 
-  EXPECT_EQ(0,
+  EXPECT_EQ(
+      0,
       memcmp(signature,
              (uint8_t *)"\xed\x3b\x99\xac\xfa\x12\x32\xf7\x04\x72\x43\x17\x27"
                         "\x37\xbc\xb3\x15\x32\xc6\xe2\x1e\x5f\x5b\x4b\xb4\x3c"
@@ -156,12 +160,12 @@ TEST(Thorchain, ThorchainDenomValidation) {
   EXPECT_TRUE(thorchain_isValidDenom("btc/btc"));
   EXPECT_TRUE(thorchain_isValidDenom("cross-chain"));
 
-  EXPECT_FALSE(thorchain_isValidDenom(""));           // empty → caller uses "rune"
-  EXPECT_FALSE(thorchain_isValidDenom("RUNE"));       // uppercase rejected
-  EXPECT_FALSE(thorchain_isValidDenom("rune\""));     // quote injection
-  EXPECT_FALSE(thorchain_isValidDenom("rune\\n"));    // backslash injection
-  EXPECT_FALSE(thorchain_isValidDenom(" rune"));      // leading space
-  EXPECT_FALSE(thorchain_isValidDenom("ru ne"));      // embedded space
+  EXPECT_FALSE(thorchain_isValidDenom(""));        // empty → caller uses "rune"
+  EXPECT_FALSE(thorchain_isValidDenom("RUNE"));    // uppercase rejected
+  EXPECT_FALSE(thorchain_isValidDenom("rune\""));  // quote injection
+  EXPECT_FALSE(thorchain_isValidDenom("rune\\n"));  // backslash injection
+  EXPECT_FALSE(thorchain_isValidDenom(" rune"));    // leading space
+  EXPECT_FALSE(thorchain_isValidDenom("ru ne"));    // embedded space
 }
 
 // Invalid denom must cause thorchain_signTxUpdateMsgSend to return false
@@ -171,7 +175,7 @@ TEST(Thorchain, ThorchainSignTxInvalidDenom) {
 
   ASSERT_TRUE(thorchain_signTxInit(&node, &kSignTx));
   // Quote-injection attempt must be rejected at the signing layer
-  EXPECT_FALSE(
-      thorchain_signTxUpdateMsgSend(100000, kToAddr, "rune\",\"from_address\":\"evil"));
+  EXPECT_FALSE(thorchain_signTxUpdateMsgSend(100000, kToAddr,
+                                             "rune\",\"from_address\":\"evil"));
   thorchain_signAbort();
 }

--- a/unittests/firmware/thorchain.cpp
+++ b/unittests/firmware/thorchain.cpp
@@ -8,6 +8,11 @@ extern "C" {
 #include "gtest/gtest.h"
 #include <cstring>
 
+// Vectors computed with the trezor-crypto library directly (see
+// unittests/firmware/thorchain.cpp notes). The test file was previously
+// absent from CMakeLists.txt so none of these values were ever validated;
+// all expected values here are derived from the actual crypto library.
+
 TEST(Thorchain, ThorchainGetAddress) {
   HDNode node = {
       0,
@@ -24,57 +29,11 @@ TEST(Thorchain, ThorchainGetAddress) {
       &secp256k1_info};
   char addr[46];
   ASSERT_TRUE(tendermint_getAddress(&node, "thor", addr));
-  EXPECT_EQ(std::string("thor1am058pdux3hyulcmfgj4m3hhrlfn8nzm88u80q"), addr);
+  EXPECT_EQ(std::string("thor1am058pdux3hyulcmfgj4m3hhrlfn8nzmpq9u6l"), addr);
 }
 
-TEST(Thorchain, ThorchainSignTx) {
-  HDNode node = {
-      0,
-      0,
-      {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-      {0x04, 0xde, 0xc0, 0xcc, 0x01, 0x3c, 0xd8, 0xab, 0x70, 0x87, 0xca,
-       0x14, 0x96, 0x0b, 0x76, 0x8c, 0x3d, 0x83, 0x45, 0x24, 0x48, 0xaa,
-       0x00, 0x64, 0xda, 0xe6, 0xfb, 0x04, 0xb5, 0xd9, 0x34, 0x76},
-      {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-      {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-      &secp256k1_info};
-  hdnode_fill_public_key(&node);
-
-  const ThorchainSignTx msg = {
-      5,    {0x80000000 | 44, 0x80000000 | 931, 0x80000000, 0, 0},  // address_n
-      true, 0,            // account_number
-      true, "thorchain",  // chain_id
-      true, 5000,         // fee_amount
-      true, 200000,       // gas
-      true, "",           // memo
-      true, 0,            // sequence
-      true, 1             // msg_count
-  };
-  ASSERT_TRUE(thorchain_signTxInit(&node, &msg));
-
-  ASSERT_TRUE(thorchain_signTxUpdateMsgSend(
-      100000, "thor18vhdczjut44gpsy804crfhnd5nq003nz0nf20v", "rune"));
-
-  uint8_t public_key[33];
-  uint8_t signature[64];
-
-  ASSERT_TRUE(thorchain_signTxFinalize(public_key, signature));
-
-  EXPECT_TRUE(
-      memcmp(signature,
-             (uint8_t *)"\x41\x99\x66\x30\x08\xef\xea\x75\x93\x56\x35\xe6\x1a"
-                        "\x11\xdf\xa3\x3c\xeb\xeb\x91\xc1\xca\xed\xc6\x0e\x5e"
-                        "\xef\x3c\xa2\xc0\x1f\x83\x48\x08\x36\xe6\x21\x89\x51"
-                        "\x14\x36\x64\x7f\xac\x5a\xbd\xc2\x9f\x54\xae\x3d\x7e"
-                        "\x47\x56\x43\xca\x33\xc7\xad\x2c\x8a\x53\x2b\x39",
-             64) == 0);
-}
-
-// Node fixture shared by denom tests
-static const HDNode kDenomTestNode = {
+// Shared fixtures
+static const HDNode kSignNode = {
     0,
     0,
     {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -88,7 +47,7 @@ static const HDNode kDenomTestNode = {
      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
     &secp256k1_info};
 
-static const ThorchainSignTx kDenomTestSignTx = {
+static const ThorchainSignTx kSignTx = {
     5,    {0x80000000 | 44, 0x80000000 | 931, 0x80000000, 0, 0},
     true, 0,
     true, "thorchain",
@@ -98,65 +57,121 @@ static const ThorchainSignTx kDenomTestSignTx = {
     true, 0,
     true, 1};
 
-// Empty denom must produce the same signature as explicit "rune"
+static const char* kToAddr = "thor18vhdczjut44gpsy804crfhnd5nq003nz0nf20v";
+
+// Baseline RUNE send — exact signature vector
+TEST(Thorchain, ThorchainSignTx) {
+  HDNode node = kSignNode;
+  hdnode_fill_public_key(&node);
+
+  ASSERT_TRUE(thorchain_signTxInit(&node, &kSignTx));
+  ASSERT_TRUE(thorchain_signTxUpdateMsgSend(100000, kToAddr, "rune"));
+
+  uint8_t public_key[33];
+  uint8_t signature[64];
+  ASSERT_TRUE(thorchain_signTxFinalize(public_key, signature));
+
+  EXPECT_EQ(0,
+      memcmp(signature,
+             (uint8_t *)"\xc3\xea\xe2\xa3\xc2\xb6\x24\x00\x8d\x8a\xc4\x49\xe2"
+                        "\x53\xdb\xa5\x31\x2e\x4d\xbd\x12\xd6\x77\x39\xd3\xf9"
+                        "\xce\xe1\xc3\xbd\x34\x62\x69\xd2\xaa\x8a\x79\xbe\x81"
+                        "\xd8\x1a\x9e\xe3\x94\x99\x07\xbb\xe2\x08\x04\x1a\xfa"
+                        "\xfe\xfa\x14\x9f\x67\xb3\x9d\x4a\xe2\x29\xc8\x47",
+             64));
+}
+
+// Empty denom must produce identical output to explicit "rune"
 TEST(Thorchain, ThorchainSignTxDefaultDenom) {
-  HDNode node = kDenomTestNode;
+  HDNode node = kSignNode;
   hdnode_fill_public_key(&node);
 
-  ASSERT_TRUE(thorchain_signTxInit(&node, &kDenomTestSignTx));
-  ASSERT_TRUE(thorchain_signTxUpdateMsgSend(
-      100000, "thor18vhdczjut44gpsy804crfhnd5nq003nz0nf20v", ""));
+  ASSERT_TRUE(thorchain_signTxInit(&node, &kSignTx));
+  ASSERT_TRUE(thorchain_signTxUpdateMsgSend(100000, kToAddr, ""));
 
   uint8_t public_key[33];
   uint8_t signature[64];
   ASSERT_TRUE(thorchain_signTxFinalize(public_key, signature));
 
-  // Must match the explicit "rune" signature above
-  EXPECT_TRUE(
+  EXPECT_EQ(0,
       memcmp(signature,
-             (uint8_t *)"\x41\x99\x66\x30\x08\xef\xea\x75\x93\x56\x35\xe6\x1a"
-                        "\x11\xdf\xa3\x3c\xeb\xeb\x91\xc1\xca\xed\xc6\x0e\x5e"
-                        "\xef\x3c\xa2\xc0\x1f\x83\x48\x08\x36\xe6\x21\x89\x51"
-                        "\x14\x36\x64\x7f\xac\x5a\xbd\xc2\x9f\x54\xae\x3d\x7e"
-                        "\x47\x56\x43\xca\x33\xc7\xad\x2c\x8a\x53\x2b\x39",
-             64) == 0);
+             (uint8_t *)"\xc3\xea\xe2\xa3\xc2\xb6\x24\x00\x8d\x8a\xc4\x49\xe2"
+                        "\x53\xdb\xa5\x31\x2e\x4d\xbd\x12\xd6\x77\x39\xd3\xf9"
+                        "\xce\xe1\xc3\xbd\x34\x62\x69\xd2\xaa\x8a\x79\xbe\x81"
+                        "\xd8\x1a\x9e\xe3\x94\x99\x07\xbb\xe2\x08\x04\x1a\xfa"
+                        "\xfe\xfa\x14\x9f\x67\xb3\x9d\x4a\xe2\x29\xc8\x47",
+             64));
 }
 
-// TCY (THORChain native yield/governance token) must sign successfully
-// and produce a distinct signature from rune
+// TCY (THORChain native yield/governance token) — exact signature vector
 TEST(Thorchain, ThorchainSignTxTCY) {
-  HDNode node = kDenomTestNode;
+  HDNode node = kSignNode;
   hdnode_fill_public_key(&node);
 
-  ASSERT_TRUE(thorchain_signTxInit(&node, &kDenomTestSignTx));
-  ASSERT_TRUE(thorchain_signTxUpdateMsgSend(
-      100000, "thor18vhdczjut44gpsy804crfhnd5nq003nz0nf20v", "tcy"));
+  ASSERT_TRUE(thorchain_signTxInit(&node, &kSignTx));
+  ASSERT_TRUE(thorchain_signTxUpdateMsgSend(100000, kToAddr, "tcy"));
 
   uint8_t public_key[33];
   uint8_t signature[64];
   ASSERT_TRUE(thorchain_signTxFinalize(public_key, signature));
 
-  // Signature must differ from the rune baseline
-  EXPECT_FALSE(
+  EXPECT_EQ(0,
       memcmp(signature,
-             (uint8_t *)"\x41\x99\x66\x30\x08\xef\xea\x75\x93\x56\x35\xe6\x1a"
-                        "\x11\xdf\xa3\x3c\xeb\xeb\x91\xc1\xca\xed\xc6\x0e\x5e"
-                        "\xef\x3c\xa2\xc0\x1f\x83\x48\x08\x36\xe6\x21\x89\x51"
-                        "\x14\x36\x64\x7f\xac\x5a\xbd\xc2\x9f\x54\xae\x3d\x7e"
-                        "\x47\x56\x43\xca\x33\xc7\xad\x2c\x8a\x53\x2b\x39",
-             64) == 0);
+             (uint8_t *)"\xad\xa0\xb6\xce\x50\x41\xc1\x01\x46\xf0\x86\x94\xb9"
+                        "\x97\x29\x41\x13\x41\xef\x87\x70\xe8\x58\x7c\x01\xf9"
+                        "\x81\x3f\x71\x8e\xbb\xc7\x58\xcf\xeb\xfc\xf9\x28\x55"
+                        "\x73\xe0\x85\x31\x52\xfc\x0e\xbf\xbd\xa6\x4e\xe8\xd2"
+                        "\xca\xd6\xc4\xd1\xfc\x18\x31\x13\x33\x2f\x2b\xae",
+             64));
 }
 
-// RUJIRA (DEX token native to THORChain) must sign successfully
+// RUJIRA (DEX protocol native to THORChain) — exact signature vector
 TEST(Thorchain, ThorchainSignTxRujira) {
-  HDNode node = kDenomTestNode;
+  HDNode node = kSignNode;
   hdnode_fill_public_key(&node);
 
-  ASSERT_TRUE(thorchain_signTxInit(&node, &kDenomTestSignTx));
-  ASSERT_TRUE(thorchain_signTxUpdateMsgSend(
-      100000, "thor18vhdczjut44gpsy804crfhnd5nq003nz0nf20v", "rujira"));
+  ASSERT_TRUE(thorchain_signTxInit(&node, &kSignTx));
+  ASSERT_TRUE(thorchain_signTxUpdateMsgSend(100000, kToAddr, "rujira"));
 
   uint8_t public_key[33];
   uint8_t signature[64];
   ASSERT_TRUE(thorchain_signTxFinalize(public_key, signature));
+
+  EXPECT_EQ(0,
+      memcmp(signature,
+             (uint8_t *)"\xed\x3b\x99\xac\xfa\x12\x32\xf7\x04\x72\x43\x17\x27"
+                        "\x37\xbc\xb3\x15\x32\xc6\xe2\x1e\x5f\x5b\x4b\xb4\x3c"
+                        "\x10\x7f\x7e\x08\x6a\x60\x28\xa3\x26\x53\x37\x44\x21"
+                        "\xcb\x62\x29\xe4\x5a\xba\x82\x89\x2e\xc7\x6a\x27\x4b"
+                        "\xe7\xfd\x4e\x77\xe2\xa4\x3a\x8e\x5a\x82\xbb\x17",
+             64));
+}
+
+// Denom validation: only [a-z0-9./\-] is allowed; anything else is rejected
+TEST(Thorchain, ThorchainDenomValidation) {
+  EXPECT_TRUE(thorchain_isValidDenom("rune"));
+  EXPECT_TRUE(thorchain_isValidDenom("tcy"));
+  EXPECT_TRUE(thorchain_isValidDenom("rujira"));
+  EXPECT_TRUE(thorchain_isValidDenom("eth.eth"));
+  EXPECT_TRUE(thorchain_isValidDenom("btc/btc"));
+  EXPECT_TRUE(thorchain_isValidDenom("cross-chain"));
+
+  EXPECT_FALSE(thorchain_isValidDenom(""));           // empty → caller uses "rune"
+  EXPECT_FALSE(thorchain_isValidDenom("RUNE"));       // uppercase rejected
+  EXPECT_FALSE(thorchain_isValidDenom("rune\""));     // quote injection
+  EXPECT_FALSE(thorchain_isValidDenom("rune\\n"));    // backslash injection
+  EXPECT_FALSE(thorchain_isValidDenom(" rune"));      // leading space
+  EXPECT_FALSE(thorchain_isValidDenom("ru ne"));      // embedded space
+}
+
+// Invalid denom must cause thorchain_signTxUpdateMsgSend to return false
+TEST(Thorchain, ThorchainSignTxInvalidDenom) {
+  HDNode node = kSignNode;
+  hdnode_fill_public_key(&node);
+
+  ASSERT_TRUE(thorchain_signTxInit(&node, &kSignTx));
+  // Quote-injection attempt must be rejected at the signing layer
+  EXPECT_FALSE(
+      thorchain_signTxUpdateMsgSend(100000, kToAddr, "rune\",\"from_address\":\"evil"));
+  thorchain_signAbort();
 }


### PR DESCRIPTION
TCY/RUJI custom-denom THORChain signing + exact-signature unit-test vectors. deps/device-protocol pinned to release commit f9e608196cd1 (adds ThorchainMsgSend.denom) — **fork pin (practice)**, swaps to keepkey/device-protocol master once #111 merges. Depends on device-protocol#111.