### PR TITLE
feat(ripple): XRP memo field for THORChain routing

### DIFF
--- a/include/keepkey/transport/messages-ripple.options
+++ b/include/keepkey/transport/messages-ripple.options
@@ -6,5 +6,7 @@ RippleSignTx.address_n max_count:8
 
 RipplePayment.destination max_size:36
 
+RippleSignTx.memo max_size:200
+
 RippleSignedTx.signature max_size:75
 RippleSignedTx.serialized_tx max_size:1024

--- a/lib/firmware/fsm_msg_ripple.h
+++ b/lib/firmware/fsm_msg_ripple.h
@@ -110,8 +110,8 @@ void fsm_msgRippleSignTx(RippleSignTx* msg) {
   }
 
   if (msg->has_memo && msg->memo[0] != '\0') {
-    if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, "Memo",
-                 "%s", msg->memo)) {
+    if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, "Memo", "%s",
+                 msg->memo)) {
       memzero(node, sizeof(*node));
       fsm_sendFailure(FailureType_Failure_ActionCancelled, "Signing cancelled");
       layoutHome();

--- a/lib/firmware/fsm_msg_ripple.h
+++ b/lib/firmware/fsm_msg_ripple.h
@@ -109,6 +109,16 @@ void fsm_msgRippleSignTx(RippleSignTx* msg) {
     }
   }
 
+  if (msg->has_memo && msg->memo[0] != '\0') {
+    if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, "Memo",
+                 "%s", msg->memo)) {
+      memzero(node, sizeof(*node));
+      fsm_sendFailure(FailureType_Failure_ActionCancelled, "Signing cancelled");
+      layoutHome();
+      return;
+    }
+  }
+
   if (!confirm(ButtonRequestType_ButtonRequest_SignTx, "Transaction",
                "Really send %s, with a transaction fee of %s?", amount_string,
                fee_string)) {

--- a/lib/firmware/ripple.c
+++ b/lib/firmware/ripple.c
@@ -223,6 +223,25 @@ bool ripple_serialize(uint8_t** buf, const uint8_t* end, const RippleSignTx* tx,
   if (tx->payment.has_destination)
     ripple_serializeAddress(&ok, buf, end, &RFM_destination,
                             tx->payment.destination);
+  // Memos array (ARRAY type=15 key=9) comes last per XRPL canonical ordering.
+  // Layout: 0xF9 [Memos start] 0xEA [Memo object start]
+  //         0x7D [MemoData VL] <varint len> <bytes>
+  //         0xE1 [object end] 0xF1 [array end]
+  if (tx->has_memo && tx->memo[0] != '\0') {
+    size_t memo_len = strlen(tx->memo);
+    append_u8(&ok, buf, end, 0xF9);  // STArray[9] = Memos
+    append_u8(&ok, buf, end, 0xEA);  // STObject[10] = Memo
+    append_u8(&ok, buf, end, 0x7D);  // VL[13] = MemoData
+    ripple_serializeVarint(&ok, buf, end, (int)memo_len);
+    if (ok && *buf + memo_len <= end) {
+      memcpy(*buf, tx->memo, memo_len);
+      *buf += memo_len;
+    } else {
+      ok = false;
+    }
+    append_u8(&ok, buf, end, 0xE1);  // end STObject
+    append_u8(&ok, buf, end, 0xF1);  // end STArray
+  }
   return ok;
 }
 


### PR DESCRIPTION
XRP Memos for THORChain swap routing. deps/device-protocol pinned to release commit f9e608196cd1 (adds RippleSignTx.memo) — **fork pin (practice)**, swaps to keepkey/device-protocol master once #111 merges. Depends on device-protocol#111.